### PR TITLE
fix: display compact-object radius in km and cover supermassive blackholes

### DIFF
--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -319,9 +319,10 @@ describe('SystemBodyComponent (extended coverage)', () => {
       render(makeBody({ type: 'Star', subType: 'Black Hole', solarMasses: 8, solarRadius: 0.00001 }));
       expect(component.isBlackHoleOrNeutronStar()).toBe(true);
       // 0.00001 solar radii * 695700 km = 6.957 km -> "6.96 km"; without conversion it would render "0.00".
+      expect(component.getCompactObjectRadiusKm()).toBeCloseTo(6.957, 3);
       const text = fixture.nativeElement.textContent as string;
       expect(text).toContain('6.96 km');
-      expect(text).not.toContain('Solar radius0.00');
+      expect(text).not.toContain('Solar radius');
     });
 
     it('treats a supermassive black hole as a compact object', () => {

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -315,6 +315,21 @@ describe('SystemBodyComponent (extended coverage)', () => {
       expect(component.getJetConeAngle()).not.toBeNull();
     });
 
+    it('renders a black hole radius in km rather than a rounded-to-zero solar radius', () => {
+      render(makeBody({ type: 'Star', subType: 'Black Hole', solarMasses: 8, solarRadius: 0.00001 }));
+      expect(component.isBlackHoleOrNeutronStar()).toBe(true);
+      // 0.00001 solar radii * 695700 km = 6.957 km -> "6.96 km"; without conversion it would render "0.00".
+      const text = fixture.nativeElement.textContent as string;
+      expect(text).toContain('6.96 km');
+      expect(text).not.toContain('Solar radius0.00');
+    });
+
+    it('treats a supermassive black hole as a compact object', () => {
+      render(makeBody({ type: 'Star', subType: 'Supermassive Black Hole', solarMasses: 4e6, solarRadius: 0.00002 }));
+      expect(component.isBlackHoleOrNeutronStar()).toBe(true);
+      expect(fixture.nativeElement.textContent as string).toContain('13.91 km');
+    });
+
     it('returns no tangential velocity for non-compact bodies', () => {
       render(makeBody({ type: 'Planet', subType: 'Rocky body', rotationalPeriod: 1 }));
       expect(component.getTangentialVelocity()).toBeNull();

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -445,21 +445,22 @@
             </div>
           </div>
           }
-          @if (body().bodyData.solarRadius) {
+          @if (getCompactObjectRadiusKm(); as compactRadiusKm) {
           <div class="body-data-entry">
             <div>
-              @if (isBlackHoleOrNeutronStar()) {
               Radius
-              } @else {
+            </div>
+            <div [matTooltip]="compactRadiusKm + ' km'">
+              {{ compactRadiusKm | number:'0.2-2' }} km
+            </div>
+          </div>
+          } @else if (body().bodyData.solarRadius) {
+          <div class="body-data-entry">
+            <div>
               Solar radius
-              }
             </div>
             <div [matTooltip]="body().bodyData.solarRadius!.toString()">
-              @if (isBlackHoleOrNeutronStar()) {
-              {{ (body().bodyData.solarRadius! * 695700) | number:'0.2-2' }} km
-              } @else {
               {{ body().bodyData.solarRadius | number:'0.2-2' }}
-              }
             </div>
           </div>
           }

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -448,10 +448,14 @@
           @if (body().bodyData.solarRadius) {
           <div class="body-data-entry">
             <div>
+              @if (isBlackHoleOrNeutronStar()) {
+              Radius
+              } @else {
               Solar radius
+              }
             </div>
             <div [matTooltip]="body().bodyData.solarRadius!.toString()">
-              @if (body().bodyData.subType === 'Neutron Star') {
+              @if (isBlackHoleOrNeutronStar()) {
               {{ (body().bodyData.solarRadius! * 695700) | number:'0.2-2' }} km
               } @else {
               {{ body().bodyData.solarRadius | number:'0.2-2' }}

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -316,7 +316,7 @@ export class SystemBodyComponent implements OnChanges {
         body.bodyData.subType === 'Earth-like world' ||
         body.bodyData.subType === 'Water world' ||
         body.bodyData.subType === 'Ammonia world' ||
-        body.bodyData.subType === 'Black Hole' ||
+        body.bodyData.subType?.includes('Black Hole') ||
         body.bodyData.subType === 'Neutron Star' ||
         body.bodyData.subType?.includes('White Dwarf') ||
         body.bodyData.subType?.includes('Wolf-Rayet') ||
@@ -1159,8 +1159,8 @@ export class SystemBodyComponent implements OnChanges {
   public isBlackHoleOrNeutronStar(): boolean {
     const body = this.body();
     return body.bodyData.type === BODY_TYPE.Star &&
-      (body.bodyData.subType === 'Black Hole' ||
-        body.bodyData.subType === 'Neutron Star');
+      (body.bodyData.subType?.includes('Black Hole') ||
+        body.bodyData.subType === 'Neutron Star') === true;
   }
 
   private formatPeriodDays(days: number): string {

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -1163,6 +1163,13 @@ export class SystemBodyComponent implements OnChanges {
         body.bodyData.subType === 'Neutron Star') === true;
   }
 
+  /** Physical radius in km for compact objects (neutron stars, black holes), whose solar-radius is too small to read; null otherwise. */
+  public getCompactObjectRadiusKm(): number | null {
+    if (!this.isBlackHoleOrNeutronStar()) { return null; }
+    const bd = this.body().bodyData;
+    return this.stellarPhysics.radiusKm(bd.radius, bd.solarRadius);
+  }
+
   private formatPeriodDays(days: number): string {
     const absDays = Math.abs(days);
     const seconds = absDays * 86400;


### PR DESCRIPTION
Black holes carry a tiny solarRadius that rounded to 0.00 in the raw "Solar radius" row. Now neutron stars, black holes and supermassive black holes all render their radius converted to km, labelled "Radius".

- isBlackHoleOrNeutronStar() and the auto-expand check use includes('Black Hole') so supermassive black holes are covered, consistent with the existing Schwarzschild-radius logic
- label the compact-object row "Radius" (km) vs "Solar radius" for stars
- add rendering tests for black hole and supermassive black hole radii

Closes #57