### PR TITLE
feat: add system governance info, permit/region flags, local-time updated

### DIFF
--- a/e2e/system-completeness.spec.ts
+++ b/e2e/system-completeness.spec.ts
@@ -27,6 +27,7 @@ test.describe('System completeness bar', () => {
     const bar = page.locator('.system-completeness');
     await expect(bar).toBeVisible();
     await expect(bar.locator('.system-completeness-value')).toHaveText('100%');
+    await expect(bar.locator('.system-completeness-count')).toHaveText('40 / 40 bodies');
     await expect(bar.locator('.system-completeness-fill')).toHaveCSS('width', /.+/);
     // Full completeness → green (green channel dominates).
     const green = await fillRgb(bar.locator('.system-completeness-fill'));
@@ -44,6 +45,7 @@ test.describe('System completeness bar', () => {
     const bar = page.locator('.system-completeness');
     await expect(bar).toBeVisible();
     await expect(bar.locator('.system-completeness-value')).toHaveText('20%');
+    await expect(bar.locator('.system-completeness-count')).toHaveText('1 / 5 bodies');
     await expect(bar.locator('.system-completeness-unknown')).toHaveCount(0);
     // Low completeness → red (red channel dominates).
     const red = await fillRgb(bar.locator('.system-completeness-fill'));
@@ -62,6 +64,7 @@ test.describe('System completeness bar', () => {
     const bar = page.locator('.system-completeness');
     await expect(bar).toBeVisible();
     await expect(bar.locator('.system-completeness-value')).toHaveText('?%');
+    await expect(bar.locator('.system-completeness-count')).toHaveText('0 / ? bodies');
     await expect(bar.locator('.system-completeness-unknown')).toHaveText('Unknown');
     await expect(bar.locator('.system-completeness-fill')).toHaveCount(0);
     // No bodies in the JSON → the bodies list is omitted entirely.

--- a/e2e/system-content.spec.ts
+++ b/e2e/system-content.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page, type Locator } from '@playwright/test';
+import { expectSystemRow } from './support/system-fixture';
 
 /**
  * Deterministic content tests for the loaded-system view. These run against the
@@ -114,5 +115,15 @@ test.describe('System content (test fixture)', () => {
   test('exposes the raw-JSON control on a body header', async ({ page }) => {
     // Every body header offers a "view JSON" button for the underlying data.
     await expect(page.locator('#body-2 .body-title .json-button')).toBeVisible();
+  });
+
+  test('hides the Society section for an unpopulated system but still shows permit/updated', async ({ page }) => {
+    // The test fixture has population 0, so the populated-only Society block is absent.
+    await expect(page.locator('.system-data-section-header').filter({ hasText: 'Society' })).toHaveCount(0);
+
+    // Permit + info-updated are shown for every system. "Test System" is not permit-locked.
+    await expectSystemRow(page, 'Permit required', 'No');
+    // Rendered in local time; the suite pins timezoneId to UTC, so this is the UTC wall-clock.
+    await expectSystemRow(page, 'Info updated', '2024-11-19 17:15');
   });
 });

--- a/e2e/system-info.spec.ts
+++ b/e2e/system-info.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { loadFixtureSystem, expectSystemRow } from './support/system-fixture';
+
+/**
+ * Deterministic tests for the system info panel's society/governance rows and the
+ * all-systems metadata rows (permit, info updated). Sol is a populated, permit-locked
+ * fixture, so it exercises every populated-only row plus "Permit required: Yes".
+ *
+ * Station counts are intentionally not shown: the biostats API only returns surface
+ * stations, so an orbital/surface split would be misleading (see the project plan).
+ */
+
+test.describe('System info — Society & metadata (Sol)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loadFixtureSystem(page, { fixture: 'sol.json', systemName: 'Sol', id64: 10477373803 });
+  });
+
+  test('shows the Society section for a populated system', async ({ page }) => {
+    await expect(
+      page.locator('.system-data-section-header').filter({ hasText: 'Society' }),
+    ).toBeVisible();
+
+    await expectSystemRow(page, 'Economy', 'Refinery / Service');
+    await expectSystemRow(page, 'Government', 'Democracy');
+    await expectSystemRow(page, 'Allegiance', 'Federation');
+    await expectSystemRow(page, 'Controlling faction', 'Mother Gaia');
+    await expectSystemRow(page, 'Security', 'High');
+  });
+
+  test('flags Sol as permit-locked and shows when its data was updated', async ({ page }) => {
+    await expectSystemRow(page, 'Permit required', 'Yes');
+    // Shown in the viewer's local zone; the suite pins timezoneId to UTC, so this is the UTC wall-clock.
+    await expectSystemRow(page, 'Info updated', '2026-06-19 16:46');
+  });
+});

--- a/src/app/data/body-histogram.spec.ts
+++ b/src/app/data/body-histogram.spec.ts
@@ -38,9 +38,11 @@ describe('buildBodyHistogram', () => {
     expect(result.bars[result.bars.length - 1].kind).toBe('Other');
   });
 
-  it('excludes synthetic barycentres', () => {
+  it('excludes synthetic barycentres, belts and rings (matching the completeness count)', () => {
     const result = buildBodyHistogram([
       { type: 'Barycentre', subType: '' },
+      { type: 'Belt', subType: 'Metal Rich' },
+      { type: 'Ring', subType: 'Rocky' },
       { type: 'Star', subType: 'G Star' },
     ]);
 

--- a/src/app/data/body-histogram.spec.ts
+++ b/src/app/data/body-histogram.spec.ts
@@ -1,0 +1,68 @@
+import { buildBodyHistogram } from './body-histogram';
+
+describe('buildBodyHistogram', () => {
+  it('counts bodies by sub-type and reports totals', () => {
+    const result = buildBodyHistogram([
+      { type: 'Planet', subType: 'Icy body' },
+      { type: 'Planet', subType: 'Icy body' },
+      { type: 'Planet', subType: 'High metal content world' },
+      { type: 'Star', subType: 'M (Red dwarf) Star' },
+    ]);
+
+    expect(result.total).toBe(4);
+    expect(result.maxCount).toBe(2);
+    expect(result.bars).toEqual([
+      { label: 'M (Red dwarf) Star', count: 1, kind: 'Star' },
+      { label: 'Icy body', count: 2, kind: 'Planet' },
+      { label: 'High metal content world', count: 1, kind: 'Planet' },
+    ]);
+  });
+
+  it('orders stars before planets before other, then by count desc, then label asc', () => {
+    const result = buildBodyHistogram([
+      { type: 'Planet', subType: 'Water world' },
+      { type: 'Planet', subType: 'Ammonia world' },
+      { type: 'Planet', subType: 'Icy body' },
+      { type: 'Planet', subType: 'Icy body' },
+      { type: 'Star', subType: 'A Star' },
+      { type: 'Unknown', subType: 'Mystery' },
+    ]);
+
+    expect(result.bars.map(b => b.label)).toEqual([
+      'A Star', // star first
+      'Icy body', // planets by count desc
+      'Ammonia world', // count tie -> alphabetical
+      'Water world',
+      'Mystery', // other last
+    ]);
+    expect(result.bars[result.bars.length - 1].kind).toBe('Other');
+  });
+
+  it('excludes synthetic barycentres', () => {
+    const result = buildBodyHistogram([
+      { type: 'Barycentre', subType: '' },
+      { type: 'Star', subType: 'G Star' },
+    ]);
+
+    expect(result.total).toBe(1);
+    expect(result.bars).toHaveLength(1);
+    expect(result.bars[0].label).toBe('G Star');
+  });
+
+  it('falls back to type, then "Unknown", when sub-type is missing or blank', () => {
+    const result = buildBodyHistogram([
+      { type: 'Planet', subType: '   ' },
+      { type: 'Planet' },
+      {},
+    ]);
+
+    const labels = result.bars.map(b => b.label);
+    expect(labels).toContain('Planet');
+    expect(labels).toContain('Unknown');
+  });
+
+  it('returns an empty histogram for no bodies', () => {
+    const result = buildBodyHistogram([]);
+    expect(result).toEqual({ bars: [], total: 0, maxCount: 0 });
+  });
+});

--- a/src/app/data/body-histogram.ts
+++ b/src/app/data/body-histogram.ts
@@ -49,16 +49,25 @@ function labelOf(body: HistogramBodyInput): string {
 
 /**
  * Builds a "histogram of bodies": a count of each body sub-type in a system, grouped by
- * kind so stars and planets read as distinct bands. Synthetic barycentres (which are not
- * real bodies but orbital reference points) are excluded so the totals match what a CMDR
- * would scan in-game. The raw API body list already omits belts/rings, so passing
- * `system.bodies` yields one bar per stellar/planetary sub-type.
+ * kind so stars and planets read as distinct bands. Belts, rings and synthetic barycentres
+ * are excluded (the same way the system-completeness count excludes them) so the totals
+ * match what a CMDR would scan in-game. Passing `system.bodies` yields one bar per
+ * stellar/planetary sub-type.
  */
 export function buildBodyHistogram(bodies: readonly HistogramBodyInput[]): BodyHistogram {
   const byLabel = new Map<string, HistogramBar>();
 
   for (const body of bodies) {
-    if (body.type === BODY_TYPE.Barycentre) continue;
+    // Skip non-bodies the same way the system-completeness count does: belts, rings,
+    // and synthetic barycentres are orbital features/reference points, not scannable
+    // bodies, so the histogram total stays consistent with "N bodies known".
+    if (
+      body.type === BODY_TYPE.Belt ||
+      body.type === BODY_TYPE.Ring ||
+      body.type === BODY_TYPE.Barycentre
+    ) {
+      continue;
+    }
     const label = labelOf(body);
     const existing = byLabel.get(label);
     if (existing) {

--- a/src/app/data/body-histogram.ts
+++ b/src/app/data/body-histogram.ts
@@ -1,0 +1,81 @@
+import { BODY_TYPE } from './body-types';
+
+/**
+ * Minimal structural shape the histogram needs from a body. Deliberately a subset of
+ * `CanonnBiostatsBody` so the helper stays framework-free and unit-testable without
+ * pulling in the (large) home-component interface or the API client.
+ */
+export interface HistogramBodyInput {
+  type?: string;
+  subType?: string;
+}
+
+/** Top-level grouping used to colour and order the bars. */
+export type BodyKind = 'Star' | 'Planet' | 'Other';
+
+export interface HistogramBar {
+  /** Display label — the body's sub-type (e.g. "High metal content world"). */
+  label: string;
+  /** Number of bodies in the system matching this label. */
+  count: number;
+  /** Coarse kind, used for bar colour and grouping order. */
+  kind: BodyKind;
+}
+
+export interface BodyHistogram {
+  /** Bars sorted stars-first, then planets, each group descending by count. */
+  bars: HistogramBar[];
+  /** Total number of bodies counted (sum of all bar counts). */
+  total: number;
+  /** Largest single bar count, for scaling bar widths (0 when empty). */
+  maxCount: number;
+}
+
+/** Stars sort before planets before everything else. */
+const KIND_ORDER: Record<BodyKind, number> = { Star: 0, Planet: 1, Other: 2 };
+
+function kindOf(type: string | undefined): BodyKind {
+  if (type === BODY_TYPE.Star) return 'Star';
+  if (type === BODY_TYPE.Planet) return 'Planet';
+  return 'Other';
+}
+
+function labelOf(body: HistogramBodyInput): string {
+  const subType = body.subType?.trim();
+  if (subType) return subType;
+  const type = body.type?.trim();
+  return type || 'Unknown';
+}
+
+/**
+ * Builds a "histogram of bodies": a count of each body sub-type in a system, grouped by
+ * kind so stars and planets read as distinct bands. Synthetic barycentres (which are not
+ * real bodies but orbital reference points) are excluded so the totals match what a CMDR
+ * would scan in-game. The raw API body list already omits belts/rings, so passing
+ * `system.bodies` yields one bar per stellar/planetary sub-type.
+ */
+export function buildBodyHistogram(bodies: readonly HistogramBodyInput[]): BodyHistogram {
+  const byLabel = new Map<string, HistogramBar>();
+
+  for (const body of bodies) {
+    if (body.type === BODY_TYPE.Barycentre) continue;
+    const label = labelOf(body);
+    const existing = byLabel.get(label);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      byLabel.set(label, { label, count: 1, kind: kindOf(body.type) });
+    }
+  }
+
+  const bars = Array.from(byLabel.values()).sort((a, b) => {
+    if (a.kind !== b.kind) return KIND_ORDER[a.kind] - KIND_ORDER[b.kind];
+    if (a.count !== b.count) return b.count - a.count;
+    return a.label.localeCompare(b.label);
+  });
+
+  const total = bars.reduce((sum, bar) => sum + bar.count, 0);
+  const maxCount = bars.reduce((max, bar) => Math.max(max, bar.count), 0);
+
+  return { bars, total, maxCount };
+}

--- a/src/app/data/permit-locked-systems.spec.ts
+++ b/src/app/data/permit-locked-systems.spec.ts
@@ -1,0 +1,67 @@
+import {
+  isPermitLockedSystem,
+  isPermitLockedRegion,
+  PERMIT_LOCKED_SYSTEM_NAMES,
+} from './permit-locked-systems';
+
+describe('permit-locked-systems', () => {
+  describe('isPermitLockedSystem — systems', () => {
+    it('flags known permit-locked systems by name', () => {
+      expect(isPermitLockedSystem('Sol')).toBe(true);
+      expect(isPermitLockedSystem('Shinrarta Dezhra')).toBe(true);
+      expect(isPermitLockedSystem('Alioth')).toBe(true);
+      expect(isPermitLockedSystem('Kamba')).toBe(true); // recovered from the sheet's permit name
+      expect(isPermitLockedSystem("van Maanen's Star")).toBe(true);
+    });
+
+    it('matches case- and whitespace-insensitively', () => {
+      expect(isPermitLockedSystem('  sOl  ')).toBe(true);
+      expect(isPermitLockedSystem('BETA HYDRI')).toBe(true);
+    });
+
+    it('rejects systems not on the list', () => {
+      expect(isPermitLockedSystem('Maia')).toBe(false);
+      expect(isPermitLockedSystem('Colonia')).toBe(false);
+      expect(isPermitLockedSystem('')).toBe(false);
+    });
+
+    it('stores names normalized', () => {
+      expect(PERMIT_LOCKED_SYSTEM_NAMES.has('sol')).toBe(true);
+      expect(PERMIT_LOCKED_SYSTEM_NAMES.has('Sol')).toBe(false);
+    });
+  });
+
+  describe('isPermitLockedRegion — regions (by name prefix)', () => {
+    it('flags systems inside a permit-locked region', () => {
+      expect(isPermitLockedRegion('Col 121 Sector AB-C d1-2')).toBe(true);
+      expect(isPermitLockedRegion('Col 70 Sector AA-D b17-0')).toBe(true);
+      expect(isPermitLockedRegion('NGC 1647 Sector ST-U b3-1')).toBe(true);
+      expect(isPermitLockedRegion('Bleia Flyuae DH-U e3-26')).toBe(true);
+      expect(isPermitLockedRegion('Cone Sector GW-W c1-5')).toBe(true);
+      expect(isPermitLockedRegion('Horsehead Dark Region IR-V c2-9')).toBe(true);
+    });
+
+    it('uses the in-game "Praea" stem, not the sheet\'s "Praei" label', () => {
+      expect(isPermitLockedRegion('Praea Aoscs NM-W e1-407')).toBe(true);
+      expect(isPermitLockedRegion('Praei Whatever AB-C d1-2')).toBe(false);
+    });
+
+    it('requires a whole-token prefix so similar names are not caught', () => {
+      // The populated bubble's "Col 285 Sector" must not match "Col 121/70/97".
+      expect(isPermitLockedRegion('Col 285 Sector XY-Z a1-0')).toBe(false);
+      // A longer numeric token must not be matched by a shorter one.
+      expect(isPermitLockedRegion('Col 1219 Sector AB-C d1-2')).toBe(false);
+    });
+
+    it('rejects ordinary systems', () => {
+      expect(isPermitLockedRegion('Sol')).toBe(false);
+      expect(isPermitLockedRegion('Maia')).toBe(false);
+      expect(isPermitLockedRegion('')).toBe(false);
+    });
+  });
+
+  it('isPermitLockedSystem also covers region members', () => {
+    expect(isPermitLockedSystem('Cone Sector GW-W c1-5')).toBe(true);
+    expect(isPermitLockedSystem('Bleia Flyuae DH-U e3-26')).toBe(true);
+  });
+});

--- a/src/app/data/permit-locked-systems.ts
+++ b/src/app/data/permit-locked-systems.ts
@@ -1,0 +1,139 @@
+/**
+ * Static list of permit-locked Elite Dangerous systems and regions.
+ *
+ * The Canonn biostats API does not report whether a system requires a permit
+ * (even Sol, which is permit-locked in game, returns no permit field), so this is
+ * a hand-maintained list, sourced from the community "Elite Dangerous — Permit
+ * Database" spreadsheet. When that sheet changes, regenerate these arrays from it.
+ *
+ * Two kinds of entry:
+ *  - SYSTEMS: matched by exact (case/whitespace-insensitive) name.
+ *  - REGIONS: nebulae / clusters / proc-gen sectors whose permit covers a whole
+ *    area. There is no per-system region-permit flag in the data, so membership is
+ *    inferred from the system name: a system is in the region when its name equals,
+ *    or begins with, the region's name (e.g. "Col 121 Sector AB-C d1-2" → "Col 121",
+ *    "Bleia Flyuae DH-U e3-26" → "Bleia"). This is best-effort: a region label that
+ *    is not a real in-game name prefix simply matches nothing.
+ *
+ * The sheet's permit-locked *bodies* (Diso 5 C, Lave 2, Sol's Moon/Triton) are
+ * intentionally omitted — their systems are otherwise open, so a system-level permit
+ * flag would be wrong (Sol is already covered as a system).
+ */
+
+/** Lower-cased, trimmed name used as the lookup key. */
+function normalizeSystemName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+/**
+ * Canonical names of permit-locked systems. Stored normalized so lookups are
+ * case- and whitespace-insensitive.
+ */
+const PERMIT_LOCKED_NAMES_RAW = [
+  '4 Sextantis',
+  'Achenar',
+  'Alioth',
+  'Alpha Hydri',
+  'Bellica',
+  'Beta Hydri',
+  'CD-43 11917',
+  'CD-44 1695',
+  'Crom',
+  'Dryio Flyuae IC-B c1-377',
+  'Exbeur',
+  'Facece',
+  'HIP 10332',
+  'HIP 104941',
+  'HIP 22182',
+  'HIP 22460',
+  'HIP 39425',
+  'HIP 51073',
+  'HIP 54530',
+  'HIP 87621',
+  'HR 4413',
+  'Hodack',
+  'Hors',
+  'Isinor',
+  'Jotun',
+  'Kamba',
+  'LFT 509',
+  'LHS 2894',
+  'LHS 2921',
+  'LHS 3091',
+  'LTT 198',
+  'Luyten 347-14',
+  'Mbooni',
+  'Mingfu',
+  'Nastrond',
+  'PLX 695',
+  'Peregrina',
+  'Phekda',
+  'Pi Mensae',
+  'Plaa Ain HA-Z d46',
+  'Polaris',
+  'Ross 128',
+  'Ross 354',
+  'Scheau Bli NB-O d6-1409',
+  'Shinrarta Dezhra',
+  'Sirius',
+  'Sol',
+  'Summerland',
+  'Terra Mater',
+  'Tiliala',
+  'Vega',
+  "Witch's Reach",
+  'Wolf 262',
+  "van Maanen's Star",
+] as const;
+
+export const PERMIT_LOCKED_SYSTEM_NAMES: ReadonlySet<string> = new Set(
+  PERMIT_LOCKED_NAMES_RAW.map(normalizeSystemName),
+);
+
+/**
+ * Permit-locked region name prefixes (normalized). A system is in one of these
+ * regions when its name equals, or starts with, the prefix. Grouped sheet labels
+ * are collapsed to the real in-game name stem: "Bleia1"–"Bleia5" → "Bleia", and
+ * "Praei1"–"Praei6" → "Praea" (the actual systems are named "Praea …", not "Praei…").
+ */
+const PERMIT_LOCKED_REGION_PREFIXES: readonly string[] = [
+  'bleia',
+  'bovomit',
+  'col 121',
+  'col 70',
+  'col 97',
+  'cone sector',
+  'dryman',
+  'froadik',
+  'horsehead dark region',
+  'hyponia',
+  'ic 4673',
+  'm41',
+  'ngc 1647',
+  'ngc 2264',
+  'ngc 2286',
+  'ngc 3603',
+  'praea',
+  'regor',
+  'sidgoir',
+].map(prefix => prefix.toLowerCase());
+
+/** True when the named system falls within a permit-locked region (by name prefix). */
+export function isPermitLockedRegion(name: string): boolean {
+  if (!name) return false;
+  const normalized = normalizeSystemName(name);
+  // Require an exact match or a whole-token prefix (followed by a space) so e.g.
+  // "Col 121" never matches "Col 1219 …" and "Col 70" never matches "Col 700 …".
+  return PERMIT_LOCKED_REGION_PREFIXES.some(
+    prefix => normalized === prefix || normalized.startsWith(`${prefix} `),
+  );
+}
+
+/**
+ * True when the named system requires a permit — either a specific permit-locked
+ * system, or a system inside a permit-locked region.
+ */
+export function isPermitLockedSystem(name: string): boolean {
+  if (!name) return false;
+  return PERMIT_LOCKED_SYSTEM_NAMES.has(normalizeSystemName(name)) || isPermitLockedRegion(name);
+}

--- a/src/app/dialogs/dialog-shell/dialog-shell.component.scss
+++ b/src/app/dialogs/dialog-shell/dialog-shell.component.scss
@@ -1,9 +1,10 @@
 :host {
-    // Every dialog that uses the shell shares one height so they don't jump in size
-    // as content varies. The header and actions stay pinned; the content area scrolls.
+    // Autoscale to the content's natural height, capped at the viewport. Short dialogs
+    // (e.g. the body histogram) hug their content instead of padding out to a fixed
+    // height; tall ones stop growing at the cap and scroll their content area. The
+    // header and actions stay pinned.
     display: flex;
     flex-direction: column;
-    height: 80vh;
     max-height: 90vh;
 }
 
@@ -19,8 +20,11 @@ h2[mat-dialog-title] {
 }
 
 mat-dialog-content {
-    // Fill the remaining height between the header and the actions, scrolling overflow.
+    // Take the space between the header and the actions. `min-height: 0` lets this flex
+    // child shrink below its content height so, once the host hits its max-height cap,
+    // the overflow scrolls here instead of pushing the dialog past the viewport.
     flex: 1 1 auto;
+    min-height: 0;
     max-height: none;
     padding: 24px;
     color: var(--color-text);

--- a/src/app/dialogs/histogram-dialog/histogram-dialog.component.html
+++ b/src/app/dialogs/histogram-dialog/histogram-dialog.component.html
@@ -1,4 +1,5 @@
 <app-dialog-shell [heading]="title">
+  <div class="histogram-dialog">
   @let chart = histogram();
   @if (chart.bars.length) {
     <div class="histogram" role="img"
@@ -18,4 +19,5 @@
   } @else {
     <p class="histogram-empty">No bodies to chart for this system.</p>
   }
+  </div>
 </app-dialog-shell>

--- a/src/app/dialogs/histogram-dialog/histogram-dialog.component.html
+++ b/src/app/dialogs/histogram-dialog/histogram-dialog.component.html
@@ -1,0 +1,21 @@
+<app-dialog-shell [heading]="title">
+  @let chart = histogram();
+  @if (chart.bars.length) {
+    <div class="histogram" role="img"
+      [attr.aria-label]="'Distribution of ' + chart.total + ' bodies across ' + chart.bars.length + ' types'">
+      @for (bar of chart.bars; track bar.label) {
+        <div class="histogram-row">
+          <div class="histogram-label" [title]="bar.label">{{ bar.label }}</div>
+          <div class="histogram-track">
+            <div class="histogram-fill" [class]="'histogram-fill--' + bar.kind.toLowerCase()"
+              [style.width.%]="barWidth(bar.count)"></div>
+          </div>
+          <div class="histogram-count">{{ bar.count | number }}</div>
+        </div>
+      }
+    </div>
+    <div class="histogram-total">{{ chart.total | number }} bodies across {{ chart.bars.length | number }} types</div>
+  } @else {
+    <p class="histogram-empty">No bodies to chart for this system.</p>
+  }
+</app-dialog-shell>

--- a/src/app/dialogs/histogram-dialog/histogram-dialog.component.html
+++ b/src/app/dialogs/histogram-dialog/histogram-dialog.component.html
@@ -16,6 +16,12 @@
       }
     </div>
     <div class="histogram-total">{{ chart.total | number }} bodies across {{ chart.bars.length | number }} types</div>
+    @let unknown = unknownBodies();
+    @if (!unknown.known) {
+      <div class="histogram-unknown">Additional unknown bodies</div>
+    } @else if (unknown.count > 0) {
+      <div class="histogram-unknown">{{ unknown.count | number }} additional unknown {{ unknown.count === 1 ? 'body' : 'bodies' }}</div>
+    }
   } @else {
     <p class="histogram-empty">No bodies to chart for this system.</p>
   }

--- a/src/app/dialogs/histogram-dialog/histogram-dialog.component.scss
+++ b/src/app/dialogs/histogram-dialog/histogram-dialog.component.scss
@@ -1,66 +1,68 @@
-.histogram {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
+.histogram-dialog {
+  .histogram {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
 
-.histogram-row {
-  display: grid;
-  grid-template-columns: minmax(8em, 14em) 1fr 2.5em;
-  align-items: center;
-  gap: 10px;
-}
+  .histogram-row {
+    display: grid;
+    grid-template-columns: minmax(8em, 14em) 1fr minmax(2.5em, max-content);
+    align-items: center;
+    gap: 10px;
+  }
 
-.histogram-label {
-  color: var(--color-text-2);
-  font-size: 0.9em;
-  text-align: right;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
+  .histogram-label {
+    color: var(--color-text-2);
+    font-size: 0.9em;
+    text-align: right;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
-.histogram-track {
-  background: var(--color-surface-3);
-  border-radius: 3px;
-  height: 16px;
-  overflow: hidden;
-}
+  .histogram-track {
+    background: var(--color-surface-3);
+    border-radius: 3px;
+    height: 16px;
+    overflow: hidden;
+  }
 
-.histogram-fill {
-  height: 100%;
-  border-radius: 3px;
-  min-width: 2px;
-  background: var(--color-accent);
-  transition: width 0.2s ease;
-}
+  .histogram-fill {
+    height: 100%;
+    border-radius: 3px;
+    min-width: 2px;
+    background: var(--color-accent);
+    transition: width 0.2s ease;
+  }
 
-.histogram-fill--star {
-  background: var(--color-warning);
-}
+  .histogram-fill--star {
+    background: var(--color-warning);
+  }
 
-.histogram-fill--planet {
-  background: var(--color-info);
-}
+  .histogram-fill--planet {
+    background: var(--color-info);
+  }
 
-.histogram-fill--other {
-  background: var(--color-status-muted);
-}
+  .histogram-fill--other {
+    background: var(--color-status-muted);
+  }
 
-.histogram-count {
-  color: var(--color-text-bright);
-  font-variant-numeric: tabular-nums;
-  text-align: right;
-}
+  .histogram-count {
+    color: var(--color-text-bright);
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }
 
-.histogram-total {
-  margin-top: 14px;
-  color: var(--color-text-muted);
-  font-size: 0.85em;
-  text-align: right;
-}
+  .histogram-total {
+    margin-top: 14px;
+    color: var(--color-text-muted);
+    font-size: 0.85em;
+    text-align: right;
+  }
 
-.histogram-empty {
-  color: var(--color-text-muted);
-  margin: 0;
+  .histogram-empty {
+    color: var(--color-text-muted);
+    margin: 0;
+  }
 }

--- a/src/app/dialogs/histogram-dialog/histogram-dialog.component.scss
+++ b/src/app/dialogs/histogram-dialog/histogram-dialog.component.scss
@@ -61,6 +61,13 @@
     text-align: right;
   }
 
+  .histogram-unknown {
+    margin-top: 2px;
+    color: var(--color-text-muted);
+    font-size: 0.85em;
+    text-align: right;
+  }
+
   .histogram-empty {
     color: var(--color-text-muted);
     margin: 0;

--- a/src/app/dialogs/histogram-dialog/histogram-dialog.component.scss
+++ b/src/app/dialogs/histogram-dialog/histogram-dialog.component.scss
@@ -1,0 +1,66 @@
+.histogram {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.histogram-row {
+  display: grid;
+  grid-template-columns: minmax(8em, 14em) 1fr 2.5em;
+  align-items: center;
+  gap: 10px;
+}
+
+.histogram-label {
+  color: var(--color-text-2);
+  font-size: 0.9em;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.histogram-track {
+  background: var(--color-surface-3);
+  border-radius: 3px;
+  height: 16px;
+  overflow: hidden;
+}
+
+.histogram-fill {
+  height: 100%;
+  border-radius: 3px;
+  min-width: 2px;
+  background: var(--color-accent);
+  transition: width 0.2s ease;
+}
+
+.histogram-fill--star {
+  background: var(--color-warning);
+}
+
+.histogram-fill--planet {
+  background: var(--color-info);
+}
+
+.histogram-fill--other {
+  background: var(--color-status-muted);
+}
+
+.histogram-count {
+  color: var(--color-text-bright);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.histogram-total {
+  margin-top: 14px;
+  color: var(--color-text-muted);
+  font-size: 0.85em;
+  text-align: right;
+}
+
+.histogram-empty {
+  color: var(--color-text-muted);
+  margin: 0;
+}

--- a/src/app/dialogs/histogram-dialog/histogram-dialog.component.spec.ts
+++ b/src/app/dialogs/histogram-dialog/histogram-dialog.component.spec.ts
@@ -49,6 +49,63 @@ describe('HistogramDialogComponent', () => {
     expect(c.barWidth(1)).toBe(50);
   });
 
+  it('reports the count of unknown bodies when the total is known', () => {
+    const fixture = setup({
+      systemName: 'Sol',
+      totalBodyCount: 40,
+      bodies: [
+        { type: 'Star', subType: 'G (White-Yellow) Star' },
+        { type: 'Planet', subType: 'Icy body' },
+      ],
+    });
+    const c = fixture.componentInstance;
+
+    expect(c.unknownBodies()).toEqual({ known: true, count: 38 });
+    expect(fixture.nativeElement.querySelector('.histogram-unknown')?.textContent?.trim())
+      .toBe('38 additional unknown bodies');
+  });
+
+  it('uses the singular for a single unknown body', () => {
+    const fixture = setup({
+      systemName: 'Sol',
+      totalBodyCount: 3,
+      bodies: [
+        { type: 'Star', subType: 'G (White-Yellow) Star' },
+        { type: 'Planet', subType: 'Icy body' },
+      ],
+    });
+
+    expect(fixture.nativeElement.querySelector('.histogram-unknown')?.textContent?.trim())
+      .toBe('1 additional unknown body');
+  });
+
+  it('hides the unknown-bodies line when every reported body is charted', () => {
+    const fixture = setup({
+      systemName: 'Sol',
+      totalBodyCount: 2,
+      bodies: [
+        { type: 'Star', subType: 'G (White-Yellow) Star' },
+        { type: 'Planet', subType: 'Icy body' },
+      ],
+    });
+    const c = fixture.componentInstance;
+
+    expect(c.unknownBodies()).toEqual({ known: true, count: 0 });
+    expect(fixture.nativeElement.querySelector('.histogram-unknown')).toBeNull();
+  });
+
+  it('shows a count-free label when the total body count is unknown', () => {
+    const fixture = setup({
+      systemName: 'Sol',
+      bodies: [{ type: 'Planet', subType: 'Icy body' }],
+    });
+    const c = fixture.componentInstance;
+
+    expect(c.unknownBodies()).toEqual({ known: false, count: 0 });
+    expect(fixture.nativeElement.querySelector('.histogram-unknown')?.textContent?.trim())
+      .toBe('Additional unknown bodies');
+  });
+
   it('returns 0 width when there are no bodies and shows the empty message', () => {
     const fixture = setup({ systemName: 'Empty', bodies: [] });
     const c = fixture.componentInstance;

--- a/src/app/dialogs/histogram-dialog/histogram-dialog.component.spec.ts
+++ b/src/app/dialogs/histogram-dialog/histogram-dialog.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { HistogramDialogComponent, HistogramDialogData } from './histogram-dialog.component';
+
+function setup(data: HistogramDialogData): ComponentFixture<HistogramDialogComponent> {
+  TestBed.configureTestingModule({
+    imports: [HistogramDialogComponent],
+    providers: [provideZonelessChangeDetection(), { provide: MAT_DIALOG_DATA, useValue: data }],
+  });
+  const fixture = TestBed.createComponent(HistogramDialogComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('HistogramDialogComponent', () => {
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('renders one bar per body sub-type with the system name in the title', () => {
+    const fixture = setup({
+      systemName: 'Sol',
+      bodies: [
+        { type: 'Star', subType: 'G (White-Yellow) Star' },
+        { type: 'Planet', subType: 'High metal content world' },
+        { type: 'Planet', subType: 'High metal content world' },
+        { type: 'Planet', subType: 'Icy body' },
+      ],
+    });
+    const c = fixture.componentInstance;
+
+    expect(c.title).toBe('Body types — Sol');
+    expect(c.histogram().total).toBe(4);
+    const rows = fixture.nativeElement.querySelectorAll('.histogram-row');
+    expect(rows.length).toBe(3);
+  });
+
+  it('scales the widest bar to 100% and others proportionally', () => {
+    const fixture = setup({
+      systemName: 'Test',
+      bodies: [
+        { type: 'Planet', subType: 'Icy body' },
+        { type: 'Planet', subType: 'Icy body' },
+        { type: 'Planet', subType: 'Water world' },
+      ],
+    });
+    const c = fixture.componentInstance;
+
+    expect(c.barWidth(2)).toBe(100);
+    expect(c.barWidth(1)).toBe(50);
+  });
+
+  it('returns 0 width when there are no bodies and shows the empty message', () => {
+    const fixture = setup({ systemName: 'Empty', bodies: [] });
+    const c = fixture.componentInstance;
+
+    expect(c.barWidth(0)).toBe(0);
+    expect(fixture.nativeElement.querySelector('.histogram-empty')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.histogram-row')).toBeNull();
+  });
+});

--- a/src/app/dialogs/histogram-dialog/histogram-dialog.component.ts
+++ b/src/app/dialogs/histogram-dialog/histogram-dialog.component.ts
@@ -1,0 +1,39 @@
+import { ChangeDetectionStrategy, Component, Signal, computed, inject } from '@angular/core';
+import { DecimalPipe } from '@angular/common';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { DialogShellComponent } from '../dialog-shell/dialog-shell.component';
+import { BodyHistogram, HistogramBodyInput, buildBodyHistogram } from '../../data/body-histogram';
+
+/** Data the histogram dialog needs, passed via MatDialog's `data`. */
+export interface HistogramDialogData {
+  systemName: string;
+  bodies: HistogramBodyInput[];
+}
+
+/**
+ * Standalone modal that shows a "histogram of bodies": a horizontal bar chart counting
+ * each body sub-type in the system, grouped stars-then-planets. All counting/sorting is
+ * done by the framework-free {@link buildBodyHistogram} helper so it stays unit-testable.
+ */
+@Component({
+  selector: 'app-histogram-dialog',
+  templateUrl: './histogram-dialog.component.html',
+  styleUrls: ['./histogram-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DecimalPipe, DialogShellComponent],
+})
+export class HistogramDialogComponent {
+  readonly data = inject<HistogramDialogData>(MAT_DIALOG_DATA);
+
+  readonly histogram: Signal<BodyHistogram> = computed(() => buildBodyHistogram(this.data.bodies ?? []));
+
+  get title(): string {
+    return `Body types — ${this.data.systemName}`;
+  }
+
+  /** Bar width as a percentage of the widest bar, so the largest count fills the track. */
+  barWidth(count: number): number {
+    const max = this.histogram().maxCount;
+    return max > 0 ? (count / max) * 100 : 0;
+  }
+}

--- a/src/app/dialogs/histogram-dialog/histogram-dialog.component.ts
+++ b/src/app/dialogs/histogram-dialog/histogram-dialog.component.ts
@@ -8,6 +8,11 @@ import { BodyHistogram, HistogramBodyInput, buildBodyHistogram } from '../../dat
 export interface HistogramDialogData {
   systemName: string;
   bodies: HistogramBodyInput[];
+  /**
+   * Reported total body count for the system (`bodyCount`), used to surface how many
+   * bodies are still unknown. `null`/omitted when the total itself is unknown.
+   */
+  totalBodyCount?: number | null;
 }
 
 /**
@@ -26,6 +31,18 @@ export class HistogramDialogComponent {
   readonly data = inject<HistogramDialogData>(MAT_DIALOG_DATA);
 
   readonly histogram: Signal<BodyHistogram> = computed(() => buildBodyHistogram(this.data.bodies ?? []));
+
+  /**
+   * Bodies the system has but the histogram can't chart (no data yet). When the reported
+   * total is known, this is `total − charted` (clamped at 0 in case of a stale/under-reported
+   * count); `known` is false when the total itself is unknown, so the view falls back to a
+   * count-free label.
+   */
+  readonly unknownBodies: Signal<{ known: boolean; count: number }> = computed(() => {
+    const total = this.data.totalBodyCount;
+    if (total === null || total === undefined) return { known: false, count: 0 };
+    return { known: true, count: Math.max(0, total - this.histogram().total) };
+  });
 
   get title(): string {
     return `Body types — ${this.data.systemName}`;

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -321,6 +321,10 @@
                                       : 'System completeness ' + completeness.percent + '% (' + completeness.known + ' of ' + completeness.total + ' bodies known)'">
       <div class="system-completeness-header">
         <span class="system-completeness-label">System Completeness</span>
+        <button type="button" class="histogram-button" (click)="showBodyHistogram()"
+          title="Show a histogram of body types in this system" aria-label="Show histogram of body types">
+          <fa-icon [icon]="faChartColumn" aria-hidden="true"></fa-icon>
+        </button>
         <span class="system-completeness-count">{{ completeness.known }} / {{ completeness.total ?? '?' }} bodies</span>
         <span class="system-completeness-value">{{ completeness.percent === null ? '?' : completeness.percent }}%</span>
       </div>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -149,7 +149,8 @@
             @if (data.system.date) {
             <div class="system-data-entry">
               <div>Info updated</div>
-              <div>{{ formatUpdated(data.system.date) }}</div>
+              <div class="info-updated-value" [matTooltip]="formatUpdatedTooltip(data.system.date)"
+                matTooltipClass="multiline-tooltip">{{ formatUpdated(data.system.date) }}</div>
             </div>
             }
           </div>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -320,11 +320,13 @@
                                       ? 'System completeness unknown (' + completeness.known + ' bodies known, total unknown)'
                                       : 'System completeness ' + completeness.percent + '% (' + completeness.known + ' of ' + completeness.total + ' bodies known)'">
       <div class="system-completeness-header">
-        <span class="system-completeness-label">System Completeness</span>
-        <button type="button" class="histogram-button" (click)="showBodyHistogram()"
-          title="Show a histogram of body types in this system" aria-label="Show histogram of body types">
-          <fa-icon [icon]="faChartColumn" aria-hidden="true"></fa-icon>
-        </button>
+        <span class="system-completeness-label-group">
+          <span class="system-completeness-label">System Completeness</span>
+          <button type="button" class="histogram-button" (click)="showBodyHistogram()"
+            title="Show a histogram of body types in this system" aria-label="Show histogram of body types">
+            <fa-icon [icon]="faChartColumn" aria-hidden="true"></fa-icon>
+          </button>
+        </span>
         <span class="system-completeness-count">{{ completeness.known }} / {{ completeness.total ?? '?' }} bodies</span>
         <span class="system-completeness-value">{{ completeness.percent === null ? '?' : completeness.percent }}%</span>
       </div>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -142,7 +142,52 @@
                 {{ data.system.coords.x }} / {{ data.system.coords.y }} / {{ data.system.coords.z }}
               </div>
             </div>
+            <div class="system-data-entry">
+              <div>Permit required</div>
+              <div>{{ isPermitLocked() ? 'Yes' : 'No' }}</div>
+            </div>
+            @if (data.system.date) {
+            <div class="system-data-entry">
+              <div>Info updated</div>
+              <div>{{ formatUpdated(data.system.date) }}</div>
+            </div>
+            }
           </div>
+          @if (data.system.population > 0) {
+          <div class="system-data-section">
+            <div class="system-data-section-header">Society</div>
+            @if (systemEconomyDisplay(data.system); as economy) {
+            <div class="system-data-entry">
+              <div>Economy</div>
+              <div>{{ economy }}</div>
+            </div>
+            }
+            @if (data.system.government && data.system.government !== 'None') {
+            <div class="system-data-entry">
+              <div>Government</div>
+              <div>{{ data.system.government }}</div>
+            </div>
+            }
+            @if (data.system.allegiance && data.system.allegiance !== 'None') {
+            <div class="system-data-entry">
+              <div>Allegiance</div>
+              <div>{{ data.system.allegiance }}</div>
+            </div>
+            }
+            @if (data.system.controllingFaction?.name; as factionName) {
+            <div class="system-data-entry">
+              <div>Controlling faction</div>
+              <div>{{ factionName }}</div>
+            </div>
+            }
+            @if (data.system.security && data.system.security !== 'None') {
+            <div class="system-data-entry">
+              <div>Security</div>
+              <div>{{ data.system.security }}</div>
+            </div>
+            }
+          </div>
+          }
           @if (edGalaxy?.Simbad?.Name || edGalaxy?.Simbad?.RAJ2000 || edGalaxy?.Simbad?.DEJ2000) {
           <div class="system-data-section">
             <div class="system-data-section-header">Simbad</div>
@@ -276,6 +321,7 @@
                                       : 'System completeness ' + completeness.percent + '% (' + completeness.known + ' of ' + completeness.total + ' bodies known)'">
       <div class="system-completeness-header">
         <span class="system-completeness-label">System Completeness</span>
+        <span class="system-completeness-count">{{ completeness.known }} / {{ completeness.total ?? '?' }} bodies</span>
         <span class="system-completeness-value">{{ completeness.percent === null ? '?' : completeness.percent }}%</span>
       </div>
       <div class="system-completeness-track">

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -68,6 +68,11 @@
     opacity: 0.85;
 }
 
+/* The "Info updated" value carries a tooltip (local time + UTC); hint it with help cursor. */
+.info-updated-value {
+    cursor: help;
+}
+
 /* Label + histogram button form the left group, so the count stays centered
    under the header's `space-between` distribution. */
 .system-completeness-label-group {

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -61,6 +61,13 @@
     font-size: 16px;
 }
 
+/* Known/total body count, sits between the label and the % in the header. */
+.system-completeness-count {
+    font-size: 11px;
+    font-weight: normal;
+    opacity: 0.85;
+}
+
 .system-completeness-track {
     position: relative;
     height: 12px;

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -68,6 +68,25 @@
     opacity: 0.85;
 }
 
+/* Opens the body-type histogram; sits just right of the label, before the counts. */
+.histogram-button {
+    margin-right: auto;
+    margin-left: 8px;
+    padding: 2px 6px;
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    color: var(--color-accent);
+    cursor: pointer;
+    font-size: 13px;
+    line-height: 1;
+}
+
+.histogram-button:hover {
+    background: var(--color-surface-hover);
+    color: var(--color-link-hover);
+}
+
 .system-completeness-track {
     position: relative;
     height: 12px;

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -68,10 +68,18 @@
     opacity: 0.85;
 }
 
-/* Opens the body-type histogram; sits just right of the label, before the counts. */
+/* Label + histogram button form the left group, so the count stays centered
+   under the header's `space-between` distribution. */
+.system-completeness-label-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+/* Opens the body-type histogram; sits just right of the label. */
 .histogram-button {
-    margin-right: auto;
-    margin-left: 8px;
+    display: inline-flex;
+    align-items: center;
     padding: 2px 6px;
     background: transparent;
     border: none;

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -267,23 +267,28 @@ describe('HomeComponent', () => {
   });
 
   describe('showBodyHistogram', () => {
-    it('does nothing when no system is loaded', () => {
+    it('does nothing when no system is loaded', async () => {
       const dialog = TestBed.inject(MatDialog);
       const open = vi.spyOn(dialog, 'open');
       component.data.set(null);
 
-      component.showBodyHistogram();
+      await component.showBodyHistogram();
 
       expect(open).not.toHaveBeenCalled();
     });
 
-    it('opens the histogram dialog with the system name and bodies', () => {
+    it('opens the histogram dialog with the system name and bodies', async () => {
       const dialog = TestBed.inject(MatDialog);
       const open = vi.spyOn(dialog, 'open').mockReturnValue({} as never);
       const bodies = [{ type: 'Star', subType: 'M Star' }];
-      component.data.set({ system: { name: 'Sol', bodies } } as never);
+      component.data.set({
+        system: {
+          name: 'Sol', id64: 1, coords: { x: 0, y: 0, z: 0 },
+          region: { name: 'Inner Orion Spur', region: 18 }, population: 0, bodies,
+        },
+      } as never);
 
-      component.showBodyHistogram();
+      await component.showBodyHistogram();
 
       expect(open).toHaveBeenCalledTimes(1);
       const [, config] = open.mock.calls[0];

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -284,7 +284,7 @@ describe('HomeComponent', () => {
       component.data.set({
         system: {
           name: 'Sol', id64: 1, coords: { x: 0, y: 0, z: 0 },
-          region: { name: 'Inner Orion Spur', region: 18 }, population: 0, bodies,
+          region: { name: 'Inner Orion Spur', region: 18 }, population: 0, bodyCount: 8, bodies,
         },
       } as never);
 
@@ -292,7 +292,7 @@ describe('HomeComponent', () => {
 
       expect(open).toHaveBeenCalledTimes(1);
       const [, config] = open.mock.calls[0];
-      expect(config?.data).toEqual({ systemName: 'Sol', bodies });
+      expect(config?.data).toEqual({ systemName: 'Sol', bodies, totalBodyCount: 8 });
       expect(config?.autoFocus).toBe('first-heading');
     });
   });

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -182,4 +182,67 @@ describe('HomeComponent', () => {
       expect(component.systemCompleteness()).toEqual({ known: 2, total: 4, percent: 50 });
     });
   });
+
+  describe('isPermitLocked', () => {
+    function loadSystemNamed(name: string, id64: bigint) {
+      component.data.set({
+        system: {
+          name, id64, coords: { x: 0, y: 0, z: 0 },
+          region: { name: 'Inner Orion Spur', region: 18 }, population: 0, bodies: [],
+        },
+      } as any);
+    }
+
+    it('is true for a permit-locked system', () => {
+      loadSystemNamed('Sol', 10477373803n);
+      expect(component.isPermitLocked()).toBe(true);
+    });
+
+    it('is false for an open system', () => {
+      loadSystemNamed('Maia', 224644818084n);
+      expect(component.isPermitLocked()).toBe(false);
+    });
+
+    it('is false when no system is loaded', () => {
+      component.data.set(null);
+      expect(component.isPermitLocked()).toBe(false);
+    });
+  });
+
+  describe('systemEconomyDisplay', () => {
+    it('joins primary and secondary economies', () => {
+      expect(component.systemEconomyDisplay({ primaryEconomy: 'Refinery', secondaryEconomy: 'Service' } as any))
+        .toBe('Refinery / Service');
+    });
+
+    it('shows only the primary when the secondary is "None" or a duplicate', () => {
+      expect(component.systemEconomyDisplay({ primaryEconomy: 'Industrial', secondaryEconomy: 'None' } as any))
+        .toBe('Industrial');
+      expect(component.systemEconomyDisplay({ primaryEconomy: 'Extraction', secondaryEconomy: 'Extraction' } as any))
+        .toBe('Extraction');
+    });
+
+    it('returns an empty string when there is no economy', () => {
+      expect(component.systemEconomyDisplay({ primaryEconomy: 'None', secondaryEconomy: 'None' } as any)).toBe('');
+      expect(component.systemEconomyDisplay({ primaryEconomy: null, secondaryEconomy: null } as any)).toBe('');
+    });
+  });
+
+  describe('formatUpdated', () => {
+    it('renders local wall-clock time in a stable YYYY-MM-DD HH:mm layout', () => {
+      expect(component.formatUpdated('2026-06-19 16:46:17+00')).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+    });
+
+    it('honors the source UTC offset (the same instant renders identically)', () => {
+      // 16:46 UTC and 18:46+02 are the same moment, so both map to the same local time
+      // whatever the host time zone — proving the offset is applied, not the raw digits.
+      expect(component.formatUpdated('2026-06-19 18:46:17+02'))
+        .toBe(component.formatUpdated('2026-06-19 16:46:17+00'));
+    });
+
+    it('returns an empty string for a missing date', () => {
+      expect(component.formatUpdated('')).toBe('');
+      expect(component.formatUpdated(null)).toBe('');
+    });
+  });
 });

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -247,6 +247,25 @@ describe('HomeComponent', () => {
     });
   });
 
+  describe('formatUpdatedTooltip', () => {
+    it('shows the local time (with offset) on the first line and UTC on the second', () => {
+      const tip = component.formatUpdatedTooltip('2026-06-19 16:46:17+00');
+      const [localLine, utcLine] = tip.split('\n');
+      expect(localLine).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} local time \(UTC[+-]\d{2}:\d{2}\)$/);
+      expect(utcLine).toBe('2026-06-19 16:46:17 UTC');
+    });
+
+    it('reflects the source UTC offset (same instant → same tooltip)', () => {
+      expect(component.formatUpdatedTooltip('2026-06-19 18:46:17+02'))
+        .toBe(component.formatUpdatedTooltip('2026-06-19 16:46:17+00'));
+    });
+
+    it('returns an empty string for a missing date', () => {
+      expect(component.formatUpdatedTooltip('')).toBe('');
+      expect(component.formatUpdatedTooltip(null)).toBe('');
+    });
+  });
+
   describe('showBodyHistogram', () => {
     it('does nothing when no system is loaded', () => {
       const dialog = TestBed.inject(MatDialog);

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA, provideZonelessChangeDetection, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
 
 import { HomeComponent } from './home.component';
 import { AppService } from '../app.service';
@@ -243,6 +244,32 @@ describe('HomeComponent', () => {
     it('returns an empty string for a missing date', () => {
       expect(component.formatUpdated('')).toBe('');
       expect(component.formatUpdated(null)).toBe('');
+    });
+  });
+
+  describe('showBodyHistogram', () => {
+    it('does nothing when no system is loaded', () => {
+      const dialog = TestBed.inject(MatDialog);
+      const open = vi.spyOn(dialog, 'open');
+      component.data.set(null);
+
+      component.showBodyHistogram();
+
+      expect(open).not.toHaveBeenCalled();
+    });
+
+    it('opens the histogram dialog with the system name and bodies', () => {
+      const dialog = TestBed.inject(MatDialog);
+      const open = vi.spyOn(dialog, 'open').mockReturnValue({} as never);
+      const bodies = [{ type: 'Star', subType: 'M Star' }];
+      component.data.set({ system: { name: 'Sol', bodies } } as never);
+
+      component.showBodyHistogram();
+
+      expect(open).toHaveBeenCalledTimes(1);
+      const [, config] = open.mock.calls[0];
+      expect(config?.data).toEqual({ systemName: 'Sol', bodies });
+      expect(config?.autoFocus).toBe('first-heading');
     });
   });
 });

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -18,6 +18,7 @@ import { logger } from '../data/logger';
 import { decodeHtmlEntities } from '../data/html-entities';
 import { CREDITS_HTML } from '../data/credits.generated';
 import { findNearestNebulae, NearestNebula } from '../data/nebulae';
+import { isPermitLockedSystem } from '../data/permit-locked-systems';
 
 @Component({
   selector: 'app-home',
@@ -288,6 +289,53 @@ export class HomeComponent implements OnInit, OnDestroy {
     const percent = total ? Math.min(100, Math.round((known / total) * 100)) : null;
     return { known, total, percent };
   });
+
+  /**
+   * Whether the loaded system requires a permit. The biostats API carries no
+   * permit field, so this is matched against a hand-maintained static list
+   * (see permit-locked-systems.ts).
+   */
+  readonly isPermitLocked = computed<boolean>(() => {
+    const system = this.data()?.system;
+    return !!system && isPermitLockedSystem(system.name);
+  });
+
+  /**
+   * Combined economy label, e.g. "Refinery / Service". Drops the placeholder
+   * "None" and any null/duplicate so a single-economy system shows just one name
+   * and an unpopulated system shows nothing.
+   */
+  systemEconomyDisplay(system: CanonnBiostats['system']): string {
+    const seen = new Set<string>();
+    const parts: string[] = [];
+    for (const economy of [system.primaryEconomy, system.secondaryEconomy]) {
+      if (!economy || economy === 'None') continue;
+      if (seen.has(economy)) continue;
+      seen.add(economy);
+      parts.push(economy);
+    }
+    return parts.join(' / ');
+  }
+
+  /**
+   * Formats the system's update timestamp — a UTC value like "2026-06-19 16:46:17+00"
+   * — as wall-clock time in the browser's local time zone (e.g. "2026-06-19 18:46" for
+   * a UTC+2 viewer). The layout is fixed ("YYYY-MM-DD HH:mm") and locale-independent;
+   * only the zone offset varies. Uses the timestamp's own offset, not the current
+   * clock, so it stays deterministic under the e2e timezone pin. Returns '' for a
+   * missing date and the raw string if it can't be parsed.
+   */
+  formatUpdated(date: string | null | undefined): string {
+    if (!date) return '';
+    // Normalise the API's "YYYY-MM-DD HH:mm:ss+00" into a parseable ISO instant
+    // (space → 'T', bare "+00" hour offset → "+00:00"), then render local components.
+    const iso = date.trim().replace(' ', 'T').replace(/([+-]\d{2})$/, '$1:00');
+    const instant = new Date(iso);
+    if (isNaN(instant.getTime())) return date;
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${instant.getFullYear()}-${pad(instant.getMonth() + 1)}-${pad(instant.getDate())} `
+      + `${pad(instant.getHours())}:${pad(instant.getMinutes())}`;
+  }
 
   private distance3d(a: { x: number, y: number, z: number }, b: { x: number, y: number, z: number }): number {
     return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2 + (a.z - b.z) ** 2);
@@ -995,11 +1043,17 @@ export class HomeComponent implements OnInit, OnDestroy {
 
 export interface CanonnBiostats {
   system: {
-    allegiance: string;
+    // Null on unpopulated systems (the API reports no allegiance for those).
+    allegiance: string | null;
     bodies: CanonnBiostatsBody[];
     // Optional: some systems (e.g. unsurveyed ones) omit this in the API payload.
     bodyCount?: number;
-    // controllingFaction
+    controllingFaction?: {
+      name: string;
+      allegiance?: string;
+      government?: string;
+      state?: string;
+    };
     coords: {
       x: number;
       y: number;
@@ -1012,7 +1066,7 @@ export interface CanonnBiostats {
     population: number;
     // powerState
     // powers
-    // primaryEconomy
+    primaryEconomy?: string | null;
     // Absent for some systems (e.g. uninhabited deep-space systems served by Spansh), so optional.
     region?: {
       name: string;
@@ -1022,8 +1076,8 @@ export interface CanonnBiostats {
       anomaly?: string[];
       cloud?: string[];
     };
-    // secondaryEconomy
-    // security
+    secondaryEconomy?: string | null;
+    security?: string | null;
   }
 }
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -390,6 +390,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       maxWidth: '95vw',
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
+      autoFocus: 'first-heading',
       data: { systemName: data.system.name, bodies: data.system.bodies },
     });
   }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -10,6 +10,7 @@ import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
 import { MatAutocompleteTrigger, MatAutocomplete, MatOption } from '@angular/material/autocomplete';
 import { MatButton } from '@angular/material/button';
+import { MatTooltip } from '@angular/material/tooltip';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { SystemBodyComponent } from '../system-body/system-body.component';
 import { RegionMapComponent } from '../region-map/region-map.component';
@@ -27,7 +28,7 @@ import { isPermitLockedSystem } from '../data/permit-locked-systems';
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatFormField, MatLabel, MatInput, ReactiveFormsModule, MatAutocompleteTrigger, MatAutocomplete, MatOption, MatError, MatButton, FaIconComponent, SystemBodyComponent, RegionMapComponent, CanonnLogoComponent, DecimalPipe]
+  imports: [MatFormField, MatLabel, MatInput, ReactiveFormsModule, MatAutocompleteTrigger, MatAutocomplete, MatOption, MatError, MatButton, FaIconComponent, SystemBodyComponent, RegionMapComponent, CanonnLogoComponent, DecimalPipe, MatTooltip]
 })
 export class HomeComponent implements OnInit, OnDestroy {
   readonly appService = inject(AppService);
@@ -337,6 +338,32 @@ export class HomeComponent implements OnInit, OnDestroy {
     const pad = (n: number) => String(n).padStart(2, '0');
     return `${instant.getFullYear()}-${pad(instant.getMonth() + 1)}-${pad(instant.getDate())} `
       + `${pad(instant.getHours())}:${pad(instant.getMinutes())}`;
+  }
+
+  /**
+   * Tooltip companion to {@link formatUpdated}: repeats the update timestamp on two lines,
+   * first as the viewer's local time (with the zone offset that applied on that date, so
+   * DST is honoured) and then as UTC. Both lines carry seconds for precision. Uses the
+   * timestamp's own offset rather than the current clock, so it stays deterministic under
+   * the e2e timezone pin. Returns '' for a missing date and the raw string if unparseable.
+   */
+  formatUpdatedTooltip(date: string | null | undefined): string {
+    if (!date) return '';
+    const iso = date.trim().replace(' ', 'T').replace(/([+-]\d{2})$/, '$1:00');
+    const instant = new Date(iso);
+    if (isNaN(instant.getTime())) return date;
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const local = `${instant.getFullYear()}-${pad(instant.getMonth() + 1)}-${pad(instant.getDate())} `
+      + `${pad(instant.getHours())}:${pad(instant.getMinutes())}:${pad(instant.getSeconds())}`;
+    const utc = `${instant.getUTCFullYear()}-${pad(instant.getUTCMonth() + 1)}-${pad(instant.getUTCDate())} `
+      + `${pad(instant.getUTCHours())}:${pad(instant.getUTCMinutes())}:${pad(instant.getUTCSeconds())}`;
+    // getTimezoneOffset() is minutes *behind* UTC, so negate to get the conventional
+    // "minutes east of UTC" used in the "UTC±HH:MM" label.
+    const offsetMin = -instant.getTimezoneOffset();
+    const sign = offsetMin >= 0 ? '+' : '-';
+    const absMin = Math.abs(offsetMin);
+    const offset = `UTC${sign}${pad(Math.floor(absMin / 60))}:${pad(absMin % 60)}`;
+    return `${local} local time (${offset})\n${utc} UTC`;
   }
 
   private distance3d(a: { x: number, y: number, z: number }, b: { x: number, y: number, z: number }): number {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -419,7 +419,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
       autoFocus: 'first-heading',
-      data: { systemName: data.system.name, bodies: data.system.bodies },
+      data: { systemName: data.system.name, bodies: data.system.bodies, totalBodyCount: data.system.bodyCount ?? null },
     });
   }
   private readonly _searching = signal(false);

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, inject, viewChild, signal, computed } from '@angular/core';
 import { AppService, EdastroData } from '../app.service';
 import { ActivatedRoute, Params, Router } from '@angular/router';
-import { faFileCode, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { faChartColumn, faFileCode, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { MatDialog } from '@angular/material/dialog';
+import { HistogramDialogComponent, HistogramDialogData } from '../dialogs/histogram-dialog/histogram-dialog.component';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { PGSystem } from 'src/app/data/pgnames/PGSystem';
 import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
@@ -376,6 +378,21 @@ export class HomeComponent implements OnInit, OnDestroy {
   }
   public readonly faFileCode = faFileCode;
   public readonly faMagnifyingGlass = faMagnifyingGlass;
+  public readonly faChartColumn = faChartColumn;
+  private readonly dialog = inject(MatDialog);
+
+  /** Opens the body-type histogram for the current system. */
+  public showBodyHistogram(): void {
+    const data = this.data();
+    if (!data) return;
+    this.dialog.open<HistogramDialogComponent, HistogramDialogData>(HistogramDialogComponent, {
+      width: '640px',
+      maxWidth: '95vw',
+      hasBackdrop: true,
+      backdropClass: 'cdk-overlay-dark-backdrop',
+      data: { systemName: data.system.name, bodies: data.system.bodies },
+    });
+  }
   private readonly _searching = signal(false);
   /** A system requested (e.g. via query param) while a search was already in flight. */
   private pendingSystemRequest: string | null = null;

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -3,7 +3,7 @@ import { AppService, EdastroData } from '../app.service';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { faChartColumn, faFileCode, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import { MatDialog } from '@angular/material/dialog';
-import { HistogramDialogComponent, HistogramDialogData } from '../dialogs/histogram-dialog/histogram-dialog.component';
+import type { HistogramDialogComponent, HistogramDialogData } from '../dialogs/histogram-dialog/histogram-dialog.component';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { PGSystem } from 'src/app/data/pgnames/PGSystem';
 import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
@@ -409,9 +409,10 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly dialog = inject(MatDialog);
 
   /** Opens the body-type histogram for the current system. */
-  public showBodyHistogram(): void {
+  public async showBodyHistogram(): Promise<void> {
     const data = this.data();
     if (!data) return;
+    const { HistogramDialogComponent } = await import('../dialogs/histogram-dialog/histogram-dialog.component');
     this.dialog.open<HistogramDialogComponent, HistogramDialogData>(HistogramDialogComponent, {
       width: '640px',
       maxWidth: '95vw',


### PR DESCRIPTION
Add a "Society" section to the system view for populated systems (economy, government, allegiance, controlling faction, security), plus all-system rows for "Permit required" and "Info updated" — the latter rendered in the viewer's local time zone. Surface the known/total body count in the System Completeness widget.

Permit-locked status is matched against a hand-maintained list of systems and region name-prefixes derived from the community permit database (no permit field exists in the biostats API). Station counts are omitted because that API only returns surface stations, so an orbital/surface split would mislead.

<img width="1642" height="1078" alt="image" src="https://github.com/user-attachments/assets/bd3021f3-c73f-42d3-8b1e-af02f509c260" />
<img width="994" height="650" alt="image" src="https://github.com/user-attachments/assets/05114e52-6f0b-49be-b165-c95e32277d9a" />


From the original request:
### Added based on API data
- Economy
- Government
- Allegiance
- Controlling faction
- Security level
- Info updated
- Number of bodies
- Histogram of bodies

### Already implemented
- Population
- Coordinates

### Various
- Permit required: Static list based on [this spreadsheet](https://docs.google.com/spreadsheets/d/16qJa4CzOo99Wu4ykALkpzacTWh2TnmZ_8TfzawWSg0k/edit?gid=118416821#gid=118416821), A fork of The Children of Raxxla - Permit Database by r/Sombient

### Omitted
- Number of Stations: orbital/surface: Omitted because the API doesn't provide orbital station information today.

Closes #21

Waiting for #72 merge. Then rebase and move dialog to lazy loading.