### PR TITLE
fix: preload dialog-only Roboto subsets to stop first-dialog reflow

### DIFF
--- a/e2e/dialog-font-preload.spec.ts
+++ b/e2e/dialog-font-preload.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect, type Page } from '@playwright/test';
+import { loadFixtureSystem } from './support/system-fixture';
+
+/**
+ * Regression guard for the "elements briefly jump up when the first dialog opens" bug.
+ *
+ * The dialogs render glyphs (greek Δ θ ω, math ≈ −, symbols ← → ↔ ☉) that live in
+ * Roboto `unicode-range` subsets the main system view never paints. fontsource fetches
+ * each subset lazily on first paint, so before the fix the first dialog open fetched
+ * `roboto-math`/`roboto-symbols`/`roboto-greek` and the fallback→Roboto swap reflowed
+ * the text — the visible jump. `preloadDialogFontSubsets()` (see src/app/preload-fonts.ts)
+ * warms those subsets at startup, so opening a dialog must trigger NO font request.
+ */
+
+const FIXTURE = { fixture: 'alpha-centauri.json', systemName: 'Alpha Centauri', id64: 1178708478315 };
+
+function trackFontRequests(page: Page): string[] {
+  const reqs: string[] = [];
+  page.on('request', (r) => {
+    const u = r.url();
+    if (/\.(woff2?|ttf|otf|eot)(\?|$)/i.test(u)) reqs.push(u.split('/').slice(-1)[0]);
+  });
+  return reqs;
+}
+
+test('opening the first dialog fetches no font (subsets warmed at startup)', async ({ page }) => {
+  const fontReqs = trackFontRequests(page);
+
+  await loadFixtureSystem(page, FIXTURE);
+  // Let the startup warm-up settle so its subset fetches are counted before, not during, the open.
+  await page.evaluate(() => (document as unknown as { fonts: FontFaceSet }).fonts.ready);
+  await page.waitForTimeout(400);
+
+  // The dialog-only subsets must already have been fetched at startup.
+  expect(fontReqs.some((f) => f.includes('roboto-math')), 'roboto-math warmed at startup').toBe(true);
+  expect(fontReqs.some((f) => f.includes('roboto-symbols')), 'roboto-symbols warmed at startup').toBe(true);
+
+  const countBeforeOpen = fontReqs.length;
+
+  // Open the first dialog (tidal-lock, from Alpha Centauri B 1's purple spin/lock badge).
+  await page.locator('#body-5 > .body-title .badge-purple').click();
+  await expect(page.locator('app-tidal-lock-dialog')).toBeVisible();
+  await page.waitForTimeout(600);
+
+  // No new font file was requested by opening the dialog → no swap → no reflow jump.
+  expect(fontReqs.slice(countBeforeOpen), 'no font fetched on first dialog open').toEqual([]);
+});

--- a/src/app/preload-fonts.spec.ts
+++ b/src/app/preload-fonts.spec.ts
@@ -1,0 +1,56 @@
+import { preloadDialogFontSubsets } from './preload-fonts';
+
+/**
+ * `preloadDialogFontSubsets` warms the Roboto subsets the dialogs use so the first
+ * dialog open doesn't fetch+swap fonts and reflow (the "elements jump up" bug).
+ */
+describe('preloadDialogFontSubsets', () => {
+  let originalDescriptor: PropertyDescriptor | undefined;
+
+  function setFonts(value: unknown) {
+    originalDescriptor = Object.getOwnPropertyDescriptor(document, 'fonts');
+    Object.defineProperty(document, 'fonts', { value, configurable: true });
+  }
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(document, 'fonts', originalDescriptor);
+    } else {
+      // jsdom may not define `fonts` natively; drop the stub we added.
+      delete (document as unknown as { fonts?: unknown }).fonts;
+    }
+    originalDescriptor = undefined;
+  });
+
+  it('warms the dialog glyph set at both body (400) and title (500) weights', () => {
+    const load = vi.fn((_font: string, _text: string) => Promise.resolve([]));
+    setFonts({ load });
+
+    preloadDialogFontSubsets();
+
+    expect(load).toHaveBeenCalledTimes(2);
+    const fontArgs = load.mock.calls.map((c) => c[0]);
+    expect(fontArgs).toContain('400 1em Roboto');
+    expect(fontArgs).toContain('500 1em Roboto');
+
+    // Every call warms the same glyph string, which must cover the greek/math/symbols
+    // glyphs that only the dialogs paint (otherwise their subsets stay lazy → the jump).
+    for (const call of load.mock.calls) {
+      const text = call[1];
+      for (const glyph of ['Δ', 'θ', 'ω', '≈', '−', '←', '→', '↔', '☉']) {
+        expect(text).toContain(glyph);
+      }
+    }
+  });
+
+  it('is a no-op when the Font Loading API is unavailable', () => {
+    setFonts(undefined);
+    expect(() => preloadDialogFontSubsets()).not.toThrow();
+  });
+
+  it('swallows font-load rejections (best-effort warm-up)', () => {
+    const load = vi.fn(() => Promise.reject(new Error('network')));
+    setFonts({ load });
+    expect(() => preloadDialogFontSubsets()).not.toThrow();
+  });
+});

--- a/src/app/preload-fonts.ts
+++ b/src/app/preload-fonts.ts
@@ -1,0 +1,34 @@
+/**
+ * Eagerly warm the Roboto unicode-range subsets that ONLY the information dialogs use.
+ *
+ * The app self-hosts Roboto via `@fontsource/roboto`, which splits each weight into
+ * many `unicode-range` subset files (latin, latin-ext, greek, math, symbols, …) under
+ * one `Roboto` family. A subset's woff2 is fetched lazily — only when a glyph in its
+ * range is first painted. The main system view paints only latin glyphs, so the greek
+ * (Δ θ ω), math (≈ −) and symbols (← → ↔ ☉) subsets stay unfetched until the FIRST
+ * dialog opens and renders that notation. The fallback→Roboto swap then reflows the
+ * affected text, which is the brief "elements jump up" seen on the first dialog open.
+ *
+ * Warming those exact glyphs at startup moves the fetch to initial load (where it
+ * changes nothing — the page never paints them) so every dialog opens with the fonts
+ * already cached, eliminating the swap and the jump. It's fire-and-forget: the load is
+ * never awaited, so it can't delay first paint.
+ *
+ * The string is the complete set of non-ASCII glyphs the dialog templates render; keep
+ * it in sync if a dialog introduces a glyph from a new subset. Weights 400 (body) and
+ * 500 (Material dialog titles/buttons) are both warmed.
+ */
+const DIALOG_GLYPHS = '°±²³·½×Δθω–—←↑→↔−≈☉';
+
+export function preloadDialogFontSubsets(): void {
+  // `document.fonts` is unavailable in very old browsers — degrade to a no-op (the
+  // jump simply isn't prevented there). Errors are swallowed: this is a pure warm-up.
+  const fonts = typeof document !== 'undefined' ? document.fonts : undefined;
+  if (!fonts) return;
+
+  for (const weight of [400, 500]) {
+    fonts.load(`${weight} 1em Roboto`, DIALOG_GLYPHS).catch(() => {
+      /* best-effort cache warm — ignore failures */
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,11 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
+import { preloadDialogFontSubsets } from './app/preload-fonts';
+
+// Warm the Roboto subsets only the dialogs use, in parallel with bootstrap, so the
+// first dialog open doesn't fetch+swap fonts and visibly reflow. See preload-fonts.ts.
+preloadDialogFontSubsets();
 
 bootstrapApplication(AppComponent, appConfig)
   .catch(err => console.error(err));


### PR DESCRIPTION
The information dialogs render glyphs (greek Δ θ ω, math ≈ −, symbols ← → ↔ ☉) from Roboto unicode-range subsets the main system view never paints. fontsource fetches each subset lazily on first paint, so the first dialog open fetched roboto-math/symbols/greek and the fallback→Roboto swap reflowed the text — the brief "elements jump up".

Warm those exact subsets at startup (document.fonts.load, weights 400 and 500) so every dialog opens with the fonts already cached: no fetch, no swap, no jump. Fire-and-forget so it can't delay first paint.