### PR TITLE
feat: click-to-convert unit dialog + dynamic-by-magnitude inline units

### DIFF
--- a/e2e/alpha-centauri-bodies.spec.ts
+++ b/e2e/alpha-centauri-bodies.spec.ts
@@ -52,8 +52,8 @@ const BODY_SPECS: BodySpec[] = [
       {
         header: 'Physical Properties',
         rows: {
-          'Solar radius': '1.10',
-          'Solar masses': '1.18',
+          Radius: '1.10 R☉',
+          Mass: '1.18 Solar masses',
           Density: '1.24 g/cm³',
           'Axial tilt': '10.05°',
           Age: '9440 million years',
@@ -90,8 +90,8 @@ const BODY_SPECS: BodySpec[] = [
       {
         header: 'Physical Properties',
         rows: {
-          'Solar radius': '0.90',
-          'Solar masses': '0.86',
+          Radius: '0.90 R☉',
+          Mass: '0.86 Solar masses',
           Density: '1.63 g/cm³',
           'Axial tilt': '11.63°',
           Age: '9212 million years',
@@ -272,7 +272,7 @@ const BODY_SPECS: BodySpec[] = [
           Volcanism: 'Minor Metallic Magma',
         },
       },
-      { header: 'Dynamics', rows: { 'Rotational period': '1.05 days', 'Distance to arrival': '6,395,278.54 ls' } },
+      { header: 'Dynamics', rows: { 'Rotational period': '1.05 days', 'Distance to arrival': '0.20 ly' } },
     ],
   },
 ];

--- a/e2e/alpha-centauri-bodies.spec.ts
+++ b/e2e/alpha-centauri-bodies.spec.ts
@@ -29,13 +29,15 @@ const BODY_SPECS: BodySpec[] = [
         header: 'Orbit',
         rows: {
           'Orbital period': '2.56 decades',
-          'Semi-major axis': '693,042,242.53 km',
+          // Semi-major axis, apoapsis and periapsis share one length unit (chosen from the
+          // semi-major axis magnitude); above ~1 ls the trio reads in light seconds.
+          'Semi-major axis': '2,311.74 ls',
           'Orbital eccentricity': '0.5179 Eccentric',
-          Apoapsis: '1,051,968,819.93 km',
+          Apoapsis: '3,508.99 ls',
           // Day-count to the next apsis. Wall-clock-dependent, but deterministic because
           // the fixture loader pins `now` to 2026-06-14T00:00:00Z (see loadFixtureSystem).
           'Next apoapsis': '3,721.9 days',
-          Periapsis: '334,115,665.12 km',
+          Periapsis: '1,114.49 ls',
           'Next periapsis': '8,396.3 days',
           'Orbital inclination': '79.21°',
           'Argument of periapsis': '116.66°',
@@ -78,10 +80,10 @@ const BODY_SPECS: BodySpec[] = [
         header: 'Orbit',
         rows: {
           'Orbital period': '2.56 decades',
-          'Semi-major axis': '952,535,688.88 km',
+          'Semi-major axis': '3,177.32 ls',
           'Orbital eccentricity': '0.5179 Eccentric',
-          Apoapsis: '1,445,853,922.15 km',
-          Periapsis: '459,217,455.61 km',
+          Apoapsis: '4,822.85 ls',
+          Periapsis: '1,531.78 ls',
           'Orbital inclination': '79.21°',
           'Argument of periapsis': '296.66°',
           'Ascending node': '-155.15°',
@@ -127,7 +129,7 @@ const BODY_SPECS: BodySpec[] = [
         header: 'Orbit',
         rows: {
           'Orbital period': '3.24 days',
-          'Semi-major axis': '6,260,765.19 km',
+          'Semi-major axis': '20.88 ls',
           'Orbital eccentricity': '0.0000 Circular',
           'Orbital inclination': '0.05°',
           'Argument of periapsis': '4.95°',
@@ -173,10 +175,10 @@ const BODY_SPECS: BodySpec[] = [
         header: 'Orbit',
         rows: {
           'Orbital period': '2.56 decades',
-          'Semi-major axis': '1,431,006,133.56 km',
+          'Semi-major axis': '4,773.32 ls',
           'Orbital eccentricity': '0.5179 Eccentric',
-          Apoapsis: '2,172,124,210.13 km',
-          Periapsis: '689,888,056.99 km',
+          Apoapsis: '7,245.43 ls',
+          Periapsis: '2,301.22 ls',
           'Argument of periapsis': '90.00°',
         },
       },
@@ -249,7 +251,7 @@ const BODY_SPECS: BodySpec[] = [
         header: 'Orbit',
         rows: {
           'Orbital period': '4.43 weeks',
-          'Semi-major axis': '1,495,979.73 km',
+          'Semi-major axis': '4.99 ls',
           'Orbital eccentricity': '0.0100 Nearly Circular',
           'Orbital inclination': '77.10°',
         },

--- a/e2e/compact-object-limits.spec.ts
+++ b/e2e/compact-object-limits.spec.ts
@@ -45,19 +45,19 @@ test.describe('Compact-object stability limits (fixture)', () => {
 
   test('white dwarf above the Chandrasekhar limit (1.45 M☉) shows the warning', async ({ page }) => {
     await ensureBodyExpanded(page, 0);
-    await expect(bodyRowValue(page, 0, 'Solar masses')).toContainText('1.45');
+    await expect(bodyRowValue(page, 0, 'Mass')).toContainText('1.45');
     await expectMassStabilityWarning(page, 0, { present: true, tooltip: CHANDRASEKHAR_TOOLTIP, severity: 'danger' });
   });
 
   test('LAWD 96 — white dwarf below the Chandrasekhar limit (1.26 M☉) has no warning', async ({ page }) => {
     await ensureBodyExpanded(page, 1);
-    await expect(bodyRowValue(page, 1, 'Solar masses')).toContainText('1.26');
+    await expect(bodyRowValue(page, 1, 'Mass')).toContainText('1.26');
     await expectMassStabilityWarning(page, 1, { present: false });
   });
 
   test('Clooku BA-A f81 — black hole (4.52 M☉) shows its Schwarzschild radius and no limit warning', async ({ page }) => {
     await ensureBodyExpanded(page, 2);
-    await expect(bodyRowValue(page, 2, 'Solar masses')).toContainText('4.52');
+    await expect(bodyRowValue(page, 2, 'Mass')).toContainText('4.52');
     // r_s = 2GM/c² for 4.52 M☉ ≈ 13.35 km.
     await expect(bodyRowValue(page, 2, 'Schwarzschild radius')).toHaveText('13.35 km');
     await expectMassStabilityWarning(page, 2, { present: false });
@@ -65,19 +65,19 @@ test.describe('Compact-object stability limits (fixture)', () => {
 
   test("Jackson's Lighthouse — neutron star above the observed maximum (13.48 M☉) shows the danger warning", async ({ page }) => {
     await ensureBodyExpanded(page, 3);
-    await expect(bodyRowValue(page, 3, 'Solar masses')).toContainText('13.48');
+    await expect(bodyRowValue(page, 3, 'Mass')).toContainText('13.48');
     await expectMassStabilityWarning(page, 3, { present: true, tooltip: OBSERVED_MAX_TOOLTIP, severity: 'danger' });
   });
 
   test('Sifoae WV-C d13-1 — neutron star below the TOV limit (0.81 M☉) has no warning', async ({ page }) => {
     await ensureBodyExpanded(page, 4);
-    await expect(bodyRowValue(page, 4, 'Solar masses')).toContainText('0.81');
+    await expect(bodyRowValue(page, 4, 'Mass')).toContainText('0.81');
     await expectMassStabilityWarning(page, 4, { present: false });
   });
 
   test('Super-TOV Neutron Star — between the theoretical and observed limits (2.35 M☉) shows the amber warning', async ({ page }) => {
     await ensureBodyExpanded(page, 5);
-    await expect(bodyRowValue(page, 5, 'Solar masses')).toContainText('2.35');
+    await expect(bodyRowValue(page, 5, 'Mass')).toContainText('2.35');
     await expectMassStabilityWarning(page, 5, { present: true, tooltip: TOV_TOOLTIP, severity: 'warning' });
   });
 });

--- a/e2e/merope.spec.ts
+++ b/e2e/merope.spec.ts
@@ -24,8 +24,8 @@ const BODY_SPECS: BodySpec[] = [
       {
         header: 'Physical Properties',
         rows: {
-          'Solar radius': '3.03',
-          'Solar masses': '5.25',
+          Radius: '3.03 R☉',
+          Mass: '5.25 Solar masses',
           Density: '0.27 g/cm³',
           Age: '774 million years',
         },

--- a/e2e/support/system-fixture.ts
+++ b/e2e/support/system-fixture.ts
@@ -140,7 +140,7 @@ export function bodyRowValue(page: Page, bodyId: number, label: string): Locator
 }
 
 /**
- * Asserts the degeneracy-limit warning (⚠) on a star's "Solar masses" row is present
+ * Asserts the degeneracy-limit warning (⚠) on a star's "Mass" row is present
  * or absent, and — when present and an `tooltip` is given — that hovering it shows that
  * text. When a `severity` is given, also asserts the indicator carries the matching colour
  * class (`status-warning` / `status-danger`). Tooltip comparison is whitespace-normalised,
@@ -152,7 +152,7 @@ export async function expectMassStabilityWarning(
   opts: { present: boolean; tooltip?: string; severity?: 'warning' | 'danger' },
 ): Promise<void> {
   const selector = opts.severity ? `.status-${opts.severity}` : '.status-danger, .status-warning';
-  const warning = bodyRowValue(page, bodyId, 'Solar masses').locator(selector);
+  const warning = bodyRowValue(page, bodyId, 'Mass').locator(selector);
   await expect(warning, `#body-${bodyId} mass-stability warning presence`).toHaveCount(opts.present ? 1 : 0);
 
   if (opts.present && opts.tooltip) {

--- a/e2e/synuefe-xr-h-d11-102.spec.ts
+++ b/e2e/synuefe-xr-h-d11-102.spec.ts
@@ -28,8 +28,8 @@ const BODY_SPECS: BodySpec[] = [
       {
         header: 'Physical Properties',
         rows: {
-          'Solar radius': '1.31',
-          'Solar masses': '1.39',
+          Radius: '1.31 R☉',
+          Mass: '1.39 Solar masses',
           Density: '0.88 g/cm³',
           Age: '3600 million years',
         },

--- a/e2e/unit-conversions.spec.ts
+++ b/e2e/unit-conversions.spec.ts
@@ -23,9 +23,10 @@ test.describe('Unit-conversion dialog (fixture)', () => {
     await expect(dialog).toContainText('Radius');
 
     // Units are listed largest-unit-first (declared order, not sorted at runtime). The unit
-    // the value natively arrives in is badged "from journal" (km here — Radius arrives in km).
+    // the value natively arrives in from the game journal is badged "from journal" — the
+    // journal records body radius in metres, so the m row carries the badge.
     await expect(dialog.locator('.conversion-table tbody th')).toHaveText([
-      'Light Years', 'AU', 'Solar Radii', 'Light seconds', 'km from journal', 'm',
+      'Light Years', 'AU', 'Solar Radii', 'Light seconds', 'km', 'm from journal',
     ]);
 
     // Clicking a value copies it and flips the cell to "Copied!" (clipboard is
@@ -33,10 +34,9 @@ test.describe('Unit-conversion dialog (fixture)', () => {
     if (browserName === 'chromium') {
       await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
     }
-    // The km row's header now reads "km from journal" (badged), so match it by prefix.
     const kmValue = dialog
       .locator('.conversion-table tbody tr')
-      .filter({ has: page.getByRole('rowheader', { name: /^km/ }) })
+      .filter({ has: page.getByRole('rowheader', { name: 'km', exact: true }) })
       .locator('td.value');
     await kmValue.click();
     if (browserName === 'chromium') {

--- a/e2e/unit-conversions.spec.ts
+++ b/e2e/unit-conversions.spec.ts
@@ -22,9 +22,10 @@ test.describe('Unit-conversion dialog (fixture)', () => {
     await expect(dialog).toBeVisible();
     await expect(dialog).toContainText('Radius');
 
-    // Units are listed largest-unit-first (declared order, not sorted at runtime).
+    // Units are listed largest-unit-first (declared order, not sorted at runtime). The unit
+    // the value natively arrives in is badged "from journal" (km here — Radius arrives in km).
     await expect(dialog.locator('.conversion-table tbody th')).toHaveText([
-      'Light Years', 'AU', 'Solar Radii', 'Light seconds', 'km', 'm',
+      'Light Years', 'AU', 'Solar Radii', 'Light seconds', 'km from journal', 'm',
     ]);
 
     // Clicking a value copies it and flips the cell to "Copied!" (clipboard is
@@ -32,8 +33,10 @@ test.describe('Unit-conversion dialog (fixture)', () => {
     if (browserName === 'chromium') {
       await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
     }
+    // The km row's header now reads "km from journal" (badged), so match it by prefix.
     const kmValue = dialog
-      .locator('.conversion-table tbody tr', { has: page.getByText('km', { exact: true }) })
+      .locator('.conversion-table tbody tr')
+      .filter({ has: page.getByRole('rowheader', { name: /^km/ }) })
       .locator('td.value');
     await kmValue.click();
     if (browserName === 'chromium') {
@@ -51,7 +54,7 @@ test.describe('Unit-conversion dialog (fixture)', () => {
     const dialog = page.locator('app-unit-conversion-dialog');
     await expect(dialog).toBeVisible();
     await expect(dialog.locator('.conversion-table tbody th')).toHaveText([
-      'Solar Masses', 'Earth Masses', 'Megatonnes',
+      'Solar Masses from journal', 'Earth Masses', 'Megatonnes',
     ]);
     await expect(dialog.locator('.comparisons')).toContainText('African bush elephants');
   });

--- a/e2e/unit-conversions.spec.ts
+++ b/e2e/unit-conversions.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { bodyRowValue, ensureBodyExpanded, loadFixtureSystem } from './support/system-fixture';
+
+/**
+ * Deterministic tests for the click-to-convert dialog: a small "⇄" icon after a value
+ * opens a popup listing it in every scale unit (largest-first), each copyable. Loaded
+ * from the Merope fixture so the values are stable and offline.
+ */
+
+const FIXTURE = { fixture: 'merope.json', systemName: 'Merope', id64: 224644818084 };
+
+test.describe('Unit-conversion dialog (fixture)', () => {
+  test.beforeEach(async ({ page }) => {
+    await loadFixtureSystem(page, FIXTURE);
+  });
+
+  test('a length value opens a conversion dialog listing every scale unit, largest-first', async ({ page, browserName }) => {
+    await ensureBodyExpanded(page, 15);
+    await bodyRowValue(page, 15, 'Radius').locator('.convert-icon').click();
+
+    const dialog = page.locator('app-unit-conversion-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Radius');
+
+    // Units are listed largest-unit-first (declared order, not sorted at runtime).
+    await expect(dialog.locator('.conversion-table tbody th')).toHaveText([
+      'Light Years', 'AU', 'Solar Radii', 'Light seconds', 'km', 'm',
+    ]);
+
+    // Clicking a value copies it and flips the cell to "Copied!" (clipboard is
+    // Chromium-grantable; other engines just exercise the no-throw path).
+    if (browserName === 'chromium') {
+      await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+    }
+    const kmValue = dialog
+      .locator('.conversion-table tbody tr', { has: page.getByText('km', { exact: true }) })
+      .locator('td.value');
+    await kmValue.click();
+    if (browserName === 'chromium') {
+      await expect(kmValue).toHaveText('Copied!');
+    }
+
+    await dialog.getByRole('button', { name: 'Close' }).click();
+    await expect(dialog).toHaveCount(0);
+  });
+
+  test('a mass value lists mass units plus the silly comparisons', async ({ page }) => {
+    await ensureBodyExpanded(page, 0);
+    await bodyRowValue(page, 0, 'Mass').locator('.convert-icon').click();
+
+    const dialog = page.locator('app-unit-conversion-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.locator('.conversion-table tbody th')).toHaveText([
+      'Solar Masses', 'Earth Masses', 'Megatonnes',
+    ]);
+    await expect(dialog.locator('.comparisons')).toContainText('African bush elephants');
+  });
+});

--- a/src/app/data/body-physics.service.spec.ts
+++ b/src/app/data/body-physics.service.spec.ts
@@ -21,9 +21,17 @@ describe('BodyPhysicsService', () => {
       expect(result.value).toBeCloseTo(5.51, 1);
     });
 
-    it('switches to kg/m³ for extreme densities', () => {
-      // A neutron-star-like density: heavy and tiny.
+    it('switches to Mt/cm³ for degenerate-matter densities', () => {
+      // A neutron-star-like density: heavy and tiny (~3.8e17 kg/m³ ≈ 0.38 Mt/cm³).
       const result = service.getPlanetaryDensity({ solarMasses: 1.4, radius: 12 } as CanonnBiostatsBody)!;
+      expect(result.unit).toBe('Mt/cm³');
+      expect(result.value).toBeCloseTo(0.385, 2);
+      expect(result.densityKgM3).toBeCloseTo(3.85e17, -16);
+    });
+
+    it('uses kg/m³ for mid-range densities (white-dwarf scale)', () => {
+      // ~1e9 kg/m³: above the g/cm³ cut-off but below the Mt/cm³ tier.
+      const result = service.getPlanetaryDensity({ earthMasses: 50, radius: 700 } as CanonnBiostatsBody)!;
       expect(result.unit).toBe('kg/m³');
     });
 

--- a/src/app/data/body-physics.service.ts
+++ b/src/app/data/body-physics.service.ts
@@ -1,12 +1,9 @@
 import { Injectable } from '@angular/core';
 import { CanonnBiostatsBody, SystemBody } from '../home/home.component';
 import { BODY_TYPE } from './body-types';
+import { KM_PER_AU, KM_PER_SOLAR_RADIUS, KG_PER_EARTH_MASS, KG_PER_SOLAR_MASS, KG_PER_MEGATONNE } from './unit-conversions';
 
-/** Physical constants and unit conversions used across the body physics maths. */
-const KM_PER_AU = 149597870.7;
-const KM_PER_SOLAR_RADIUS = 695700;
-const KG_PER_EARTH_MASS = 5.972e24;
-const KG_PER_SOLAR_MASS = 1.989e30;
+/** Approximate Earth masses per solar mass, used for parent-mass conversions. */
 const EARTH_MASSES_PER_SOLAR_MASS = 332950;
 
 /** Newtonian gravitational constant (m³ kg⁻¹ s⁻²) and speed of light (m/s). */
@@ -40,6 +37,8 @@ export interface PlanetaryDensity {
   value: number;
   unit: string;
   tooltip: string;
+  /** Raw bulk density in kg/m³ — the base for the unit-conversion dialog. */
+  densityKgM3: number;
 }
 
 export interface ShepherdingHillLimit {
@@ -173,14 +172,26 @@ export class BodyPhysicsService {
 
     const densityKgM3 = massKg / this.sphereVolumeM3(radiusKm * 1000);
 
-    // Use g/cm³ for typical densities, kg/m³ for extreme ones (neutron stars, etc.).
-    const value = densityKgM3 < 10000 ? densityKgM3 / 1000 : densityKgM3;
-    const unit = densityKgM3 < 10000 ? 'g/cm³' : 'kg/m³';
+    // Pick the unit by magnitude: g/cm³ for ordinary bodies, kg/m³ mid-range, and Mt/cm³
+    // for degenerate matter — a neutron star reads a fraction of a Mt/cm³, far tidier than
+    // ~1e17 kg/m³. 1 Mt/cm³ = 1e18 kg/m³ (Elite's teragram megatonne, see KG_PER_MEGATONNE).
+    let value: number;
+    let unit: string;
+    if (densityKgM3 >= 1e15) {
+      value = densityKgM3 / 1e18;
+      unit = 'Mt/cm³';
+    } else if (densityKgM3 < 10000) {
+      value = densityKgM3 / 1000;
+      unit = 'g/cm³';
+    } else {
+      value = densityKgM3;
+      unit = 'kg/m³';
+    }
 
     // Round to 6 significant figures so the tooltip stays readable across scales
     // (ordinary rock ~3936 kg/m³ … neutron-star matter ~1e17 kg/m³) without
     // dumping raw floating-point digits.
-    return { value, unit, tooltip: `${densityKgM3.toPrecision(6)} kg/m³` };
+    return { value, unit, tooltip: `${densityKgM3.toPrecision(6)} kg/m³`, densityKgM3 };
   }
 
   /**

--- a/src/app/data/stellar-physics.service.ts
+++ b/src/app/data/stellar-physics.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
+import { KM_PER_SOLAR_RADIUS } from './unit-conversions';
 
-const KM_PER_SOLAR_RADIUS = 695700;
 const SECONDS_PER_DAY = 86400;
 
 /**

--- a/src/app/data/unit-conversions.spec.ts
+++ b/src/app/data/unit-conversions.spec.ts
@@ -1,10 +1,16 @@
 import {
   buildConversions,
   buildMassComparisons,
+  dynamicAreaUnitLabel,
+  dynamicDistanceUnitLabel,
+  dynamicLengthUnitLabel,
+  dynamicMassUnitLabel,
   formatDynamicArea,
   formatDynamicDistanceLs,
   formatDynamicLength,
   formatDynamicMass,
+  formatLengthInUnit,
+  pickInlineLengthUnit,
   KM_PER_AU,
   KM_PER_LIGHT_SECOND,
   KM_PER_LIGHT_YEAR,
@@ -132,5 +138,54 @@ describe('dynamic inline formatters', () => {
   it('formats area across the km² / ls² ladder', () => {
     expect(formatDynamicArea(1000)).toBe('1,000.00 km²');
     expect(formatDynamicArea(2 * KM_PER_LIGHT_SECOND * KM_PER_LIGHT_SECOND)).toBe('2.00 ls²');
+  });
+});
+
+describe('inline unit dialog-row labels', () => {
+  it('labels length by magnitude, matching the conversion-row names', () => {
+    expect(dynamicLengthUnitLabel(0)).toBe('km');
+    expect(dynamicLengthUnitLabel(0.5)).toBe('m');
+    expect(dynamicLengthUnitLabel(5000)).toBe('km');
+    expect(dynamicLengthUnitLabel(2e6)).toBe('Light seconds');
+    expect(dynamicLengthUnitLabel(2 * KM_PER_LIGHT_YEAR)).toBe('Light Years');
+    expect(dynamicLengthUnitLabel(NaN)).toBe('');
+  });
+
+  it('labels distance-to-arrival in light seconds until Hutton-scale spans', () => {
+    expect(dynamicDistanceUnitLabel(2e6)).toBe('Light seconds');
+    expect(dynamicDistanceUnitLabel(2 * KM_PER_LIGHT_YEAR)).toBe('Light Years');
+    expect(dynamicDistanceUnitLabel(NaN)).toBe('');
+  });
+
+  it('labels mass across the Mt / Earth / Solar ladder', () => {
+    expect(dynamicMassUnitLabel(1e-5 * KG_PER_EARTH_MASS)).toBe('Megatonnes');
+    expect(dynamicMassUnitLabel(0.67 * KG_PER_EARTH_MASS)).toBe('Earth Masses');
+    expect(dynamicMassUnitLabel(5.25 * KG_PER_SOLAR_MASS)).toBe('Solar Masses');
+    expect(dynamicMassUnitLabel(NaN)).toBe('');
+  });
+
+  it('labels area across the km² / ls² ladder', () => {
+    expect(dynamicAreaUnitLabel(1000)).toBe('km²');
+    expect(dynamicAreaUnitLabel(2 * KM_PER_LIGHT_SECOND * KM_PER_LIGHT_SECOND)).toBe('Ls²');
+    expect(dynamicAreaUnitLabel(NaN)).toBe('');
+  });
+});
+
+describe('shared length unit (semi-major / apoapsis / periapsis group)', () => {
+  it('picks one unit from a representative value and formats every member in it', () => {
+    // Semi-major axis ~2e6 km lands in light-seconds; apoapsis and periapsis follow suit.
+    const choice = pickInlineLengthUnit(2e6);
+    expect(choice.unit).toBe('ls');
+    expect(choice.label).toBe('Light seconds');
+    expect(formatLengthInUnit(2e6, choice)).toBe(formatDynamicLength(2e6));
+    // A smaller member of the same group still renders in the shared (ls) unit, not km.
+    expect(formatLengthInUnit(1.5e6, choice)).toMatch(/ ls$/);
+    expect(formatLengthInUnit(NaN, choice)).toBe('—');
+  });
+
+  it('matches formatDynamicLength when each value picks its own unit', () => {
+    for (const km of [0.5, 5000, 2e6, 2 * KM_PER_LIGHT_YEAR]) {
+      expect(formatLengthInUnit(km, pickInlineLengthUnit(km))).toBe(formatDynamicLength(km));
+    }
   });
 });

--- a/src/app/data/unit-conversions.spec.ts
+++ b/src/app/data/unit-conversions.spec.ts
@@ -1,0 +1,136 @@
+import {
+  buildConversions,
+  buildMassComparisons,
+  formatDynamicArea,
+  formatDynamicDistanceLs,
+  formatDynamicLength,
+  formatDynamicMass,
+  KM_PER_AU,
+  KM_PER_LIGHT_SECOND,
+  KM_PER_LIGHT_YEAR,
+  KG_PER_EARTH_MASS,
+  KG_PER_SOLAR_MASS,
+  KG_PER_MEGATONNE,
+  SPEED_OF_LIGHT_KM_S,
+} from './unit-conversions';
+
+/** The display value for a unit label within a conversion row set. */
+function display(rows: { unit: string; display: string }[], unit: string): string {
+  return rows.find(r => r.unit === unit)!.display;
+}
+/** The numeric copy value for a unit label, parsed back to a number. */
+function copyNum(rows: { unit: string; copyText: string }[], unit: string): number {
+  return Number(rows.find(r => r.unit === unit)!.copyText);
+}
+
+describe('buildConversions', () => {
+  it('lists length units largest-first and converts correctly from km', () => {
+    const rows = buildConversions('length', KM_PER_AU);
+    expect(rows.map(r => r.unit)).toEqual(['Light Years', 'AU', 'Solar Radii', 'Light seconds', 'km', 'm']);
+    expect(copyNum(rows, 'AU')).toBeCloseTo(1, 9);
+    expect(copyNum(rows, 'Light seconds')).toBeCloseTo(KM_PER_AU / KM_PER_LIGHT_SECOND, 3);
+    expect(copyNum(rows, 'km')).toBeCloseTo(KM_PER_AU, 1);
+    expect(copyNum(rows, 'm')).toBeCloseTo(KM_PER_AU * 1000, 0);
+  });
+
+  it('converts duration from days', () => {
+    const rows = buildConversions('duration', 1);
+    expect(copyNum(rows, 'Minutes')).toBeCloseTo(1440, 6);
+    expect(copyNum(rows, 'Hours')).toBeCloseTo(24, 6);
+    expect(copyNum(rows, 'Days')).toBeCloseTo(1, 6);
+    expect(copyNum(rows, 'Years')).toBeCloseTo(1 / 365.25, 9);
+  });
+
+  it('converts mass from kilograms', () => {
+    const rows = buildConversions('mass', KG_PER_SOLAR_MASS);
+    expect(copyNum(rows, 'Solar Masses')).toBeCloseTo(1, 9);
+    expect(copyNum(rows, 'Earth Masses')).toBeCloseTo(KG_PER_SOLAR_MASS / KG_PER_EARTH_MASS, 0);
+    expect(copyNum(rows, 'Megatonnes')).toBeCloseTo(KG_PER_SOLAR_MASS / KG_PER_MEGATONNE, -5);
+  });
+
+  it('expresses velocity as a fraction of light speed', () => {
+    const rows = buildConversions('velocity', SPEED_OF_LIGHT_KM_S);
+    expect(copyNum(rows, 'km/s')).toBeCloseTo(SPEED_OF_LIGHT_KM_S, 0);
+    expect(copyNum(rows, 'c (fraction of light)')).toBeCloseTo(1, 9);
+  });
+
+  it('converts density between kg/m³, g/cm³ and Mt/cm³', () => {
+    const rows = buildConversions('density', 1000);
+    expect(copyNum(rows, 'g/cm³')).toBeCloseTo(1, 9);
+    // 1e18 kg/m³ == 1 Mt/cm³.
+    expect(copyNum(buildConversions('density', 1e18), 'Mt/cm³')).toBeCloseTo(1, 6);
+  });
+
+  it('converts area between km² and Ls²', () => {
+    const rows = buildConversions('area', KM_PER_LIGHT_SECOND * KM_PER_LIGHT_SECOND);
+    expect(copyNum(rows, 'km²')).toBeCloseTo(KM_PER_LIGHT_SECOND * KM_PER_LIGHT_SECOND, -3);
+    expect(copyNum(rows, 'Ls²')).toBeCloseTo(1, 6);
+  });
+
+  it('converts pressure from atmospheres', () => {
+    const rows = buildConversions('pressure', 1);
+    expect(copyNum(rows, 'kPa')).toBeCloseTo(101.325, 3);
+    expect(copyNum(rows, 'Pa')).toBeCloseTo(101325, 0);
+    expect(copyNum(rows, 'psi')).toBeCloseTo(14.6959488, 5);
+  });
+
+  it('renders zero across every unit and keeps non-finite values safe', () => {
+    const zero = buildConversions('length', 0);
+    expect(zero.every(r => copyNum(zero, r.unit) === 0)).toBe(true);
+    const bad = buildConversions('mass', NaN);
+    expect(bad.every(r => r.display === '—' && r.copyText === '')).toBe(true);
+  });
+
+  it('uses exponential notation for extreme magnitudes but grouped digits otherwise', () => {
+    expect(display(buildConversions('length', KM_PER_AU), 'km')).toBe('149,597,870.7');
+    expect(display(buildConversions('density', 4e17), 'kg/m³')).toBe('4.0000e+17');
+  });
+
+  it('preserves copy precision beyond the rounded display', () => {
+    const rows = buildConversions('length', 12345.6789);
+    expect(copyNum(rows, 'km')).toBeCloseTo(12345.6789, 4);
+  });
+});
+
+describe('buildMassComparisons', () => {
+  it('produces an elephant-scale comparison for a small mass', () => {
+    const comparisons = buildMassComparisons(6.0e3);
+    const elephants = comparisons.find(c => c.label === 'African bush elephants')!;
+    expect(elephants.display).toBe('≈ 1');
+    expect(comparisons.map(c => c.label)).toContain('Great Pyramids of Giza');
+  });
+
+  it('returns nothing for zero or non-finite mass', () => {
+    expect(buildMassComparisons(0)).toEqual([]);
+    expect(buildMassComparisons(NaN)).toEqual([]);
+  });
+});
+
+describe('dynamic inline formatters', () => {
+  it('formats length across the m / km / ls / ly ladder', () => {
+    expect(formatDynamicLength(0)).toBe('0.00 km');
+    expect(formatDynamicLength(0.5)).toBe('500.00 m');
+    expect(formatDynamicLength(4314.73)).toBe('4,314.73 km');
+    expect(formatDynamicLength(2e6)).toBe(`${(2e6 / KM_PER_LIGHT_SECOND).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ls`);
+    expect(formatDynamicLength(2 * KM_PER_LIGHT_YEAR)).toBe('2.00 ly');
+    expect(formatDynamicLength(NaN)).toBe('—');
+  });
+
+  it('keeps distance in light-seconds until Hutton-scale spans', () => {
+    expect(formatDynamicDistanceLs(0)).toBe('0.00 ls');
+    expect(formatDynamicDistanceLs(2108.23)).toBe('2,108.23 ls');
+    expect(formatDynamicDistanceLs(6395278.54)).toBe('0.20 ly');
+  });
+
+  it('formats mass across the Mt / Earth / Solar ladder', () => {
+    expect(formatDynamicMass(1e-5 * KG_PER_EARTH_MASS)).toMatch(/Mt$/);
+    expect(formatDynamicMass(0.67 * KG_PER_EARTH_MASS)).toBe('0.67 Earth masses');
+    expect(formatDynamicMass(5.25 * KG_PER_SOLAR_MASS)).toBe('5.25 Solar masses');
+    expect(formatDynamicMass(NaN)).toBe('—');
+  });
+
+  it('formats area across the km² / ls² ladder', () => {
+    expect(formatDynamicArea(1000)).toBe('1,000.00 km²');
+    expect(formatDynamicArea(2 * KM_PER_LIGHT_SECOND * KM_PER_LIGHT_SECOND)).toBe('2.00 ls²');
+  });
+});

--- a/src/app/data/unit-conversions.spec.ts
+++ b/src/app/data/unit-conversions.spec.ts
@@ -41,6 +41,7 @@ describe('buildConversions', () => {
 
   it('converts duration from days', () => {
     const rows = buildConversions('duration', 1);
+    expect(copyNum(rows, 'Seconds')).toBeCloseTo(86400, 6);
     expect(copyNum(rows, 'Minutes')).toBeCloseTo(1440, 6);
     expect(copyNum(rows, 'Hours')).toBeCloseTo(24, 6);
     expect(copyNum(rows, 'Days')).toBeCloseTo(1, 6);

--- a/src/app/data/unit-conversions.ts
+++ b/src/app/data/unit-conversions.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit-conversion tables, the dialog row builder, and the dynamic-by-magnitude inline
+ * formatters used across the body/star property displays. Pure functions with no Angular
+ * or DI dependency (mirrors the stateless reference modules such as `white-dwarf.ts` and
+ * `temperature-estimation.ts`) so the conversion maths is trivially testable and shared
+ * between the inline displays and the unit-conversion dialog.
+ */
+
+// --- Length (base: km) ---
+export const KM_PER_AU = 149597870.7;
+export const KM_PER_SOLAR_RADIUS = 695700;
+export const KM_PER_LIGHT_SECOND = 299792.458; // speed of light (m/s) / 1000
+export const KM_PER_LIGHT_YEAR = 9.4607304725808e12; // KM_PER_LIGHT_SECOND × 86400 × 365.25
+export const M_PER_KM = 1000;
+
+// --- Duration (base: days) ---
+export const MINUTES_PER_DAY = 1440;
+export const HOURS_PER_DAY = 24;
+export const WEEKS_PER_DAY = 1 / 7;
+export const DAYS_PER_YEAR = 365.25;
+
+// --- Mass (base: kg) ---
+export const KG_PER_EARTH_MASS = 5.972e24;
+export const KG_PER_SOLAR_MASS = 1.989e30;
+// Elite's body/ring "megatonne" field is 1e12 kg (a teragram). Kept consistent with the
+// existing physics maths (density, Roche limits) rather than the SI 1e9 kg megatonne, so
+// the "Megatonnes" conversion cross-references the rendered ring mass exactly.
+export const KG_PER_MEGATONNE = 1e12;
+
+// --- Velocity (base: km/s) ---
+export const SPEED_OF_LIGHT_KM_S = 299792.458;
+
+// --- Pressure (base: atm) ---
+export const KPA_PER_ATM = 101.325;
+export const PA_PER_ATM = 101325;
+export const PSI_PER_ATM = 14.6959488;
+
+// 1 Mt/cm³ = 1e12 kg ÷ 1e-6 m³ = 1e18 kg/m³ (uses the teragram megatonne above).
+const KG_M3_PER_MT_CM3 = 1e18;
+// km² in one square light-second.
+const KM2_PER_LS2 = KM_PER_LIGHT_SECOND * KM_PER_LIGHT_SECOND;
+
+/** The kinds of quantity a value can be converted between, each with a fixed base unit. */
+export type QuantityKind = 'length' | 'duration' | 'mass' | 'velocity' | 'density' | 'area' | 'pressure';
+
+/** One scale-unit row shown in the conversion dialog. */
+export interface ConversionRow {
+  /** Unit label (e.g. "AU", "Light seconds"). */
+  unit: string;
+  /** Readable, rounded value for display. */
+  display: string;
+  /** Full-precision plain numeric value for copying to the clipboard. */
+  copyText: string;
+}
+
+/**
+ * The scale units for each quantity kind, listed largest-unit-first (descending by unit
+ * magnitude, so the value at the top is the smallest count), with the multiplier that
+ * turns the kind's base value into that unit. The order is declared here, not sorted at
+ * runtime. Density and area factors are derived from the named constants above.
+ */
+const CONVERSIONS: Record<QuantityKind, { unit: string; factor: number }[]> = {
+  length: [
+    { unit: 'Light Years', factor: 1 / KM_PER_LIGHT_YEAR },
+    { unit: 'AU', factor: 1 / KM_PER_AU },
+    { unit: 'Solar Radii', factor: 1 / KM_PER_SOLAR_RADIUS },
+    { unit: 'Light seconds', factor: 1 / KM_PER_LIGHT_SECOND },
+    { unit: 'km', factor: 1 },
+    { unit: 'm', factor: M_PER_KM },
+  ],
+  duration: [
+    { unit: 'Years', factor: 1 / DAYS_PER_YEAR },
+    { unit: 'Weeks', factor: WEEKS_PER_DAY },
+    { unit: 'Days', factor: 1 },
+    { unit: 'Hours', factor: HOURS_PER_DAY },
+    { unit: 'Minutes', factor: MINUTES_PER_DAY },
+  ],
+  mass: [
+    { unit: 'Solar Masses', factor: 1 / KG_PER_SOLAR_MASS },
+    { unit: 'Earth Masses', factor: 1 / KG_PER_EARTH_MASS },
+    { unit: 'Megatonnes', factor: 1 / KG_PER_MEGATONNE },
+  ],
+  velocity: [
+    { unit: 'c (fraction of light)', factor: 1 / SPEED_OF_LIGHT_KM_S },
+    { unit: 'km/s', factor: 1 },
+  ],
+  density: [
+    { unit: 'Mt/cm³', factor: 1 / KG_M3_PER_MT_CM3 },
+    { unit: 'g/cm³', factor: 1 / 1000 },
+    { unit: 'kg/m³', factor: 1 },
+  ],
+  area: [
+    { unit: 'Ls²', factor: 1 / KM2_PER_LS2 },
+    { unit: 'km²', factor: 1 },
+  ],
+  pressure: [
+    { unit: 'atm', factor: 1 },
+    { unit: 'psi', factor: PSI_PER_ATM },
+    { unit: 'kPa', factor: KPA_PER_ATM },
+    { unit: 'Pa', factor: PA_PER_ATM },
+  ],
+};
+
+/** Readable number: grouped with ≤4 fraction digits for ordinary magnitudes, exponential for extremes. */
+function formatDisplayNumber(value: number): string {
+  if (!Number.isFinite(value)) { return '—'; }
+  const abs = Math.abs(value);
+  if (abs !== 0 && (abs < 1e-4 || abs >= 1e15)) {
+    return value.toExponential(4);
+  }
+  return value.toLocaleString('en-US', { maximumFractionDigits: 4 });
+}
+
+/** Plain numeric value for pasting: ~12 significant figures, trailing zeros dropped. */
+function formatCopyNumber(value: number): string {
+  if (!Number.isFinite(value)) { return ''; }
+  if (value === 0) { return '0'; }
+  return Number(value.toPrecision(12)).toString();
+}
+
+/** Builds the full set of scale-unit rows for a base value of the given kind. */
+export function buildConversions(kind: QuantityKind, baseValue: number): ConversionRow[] {
+  return CONVERSIONS[kind].map(({ unit, factor }) => {
+    const value = baseValue * factor;
+    return { unit, display: formatDisplayNumber(value), copyText: formatCopyNumber(value) };
+  });
+}
+
+/** A light-hearted "this mass is roughly N of these" scale comparison. */
+export interface MassComparison {
+  /** Plural object name (e.g. "African bush elephants"). */
+  label: string;
+  /** Formatted count, e.g. "≈ 1.7460e+18". */
+  display: string;
+}
+
+// Approximate masses (kg) of familiar objects, for the "just for fun" comparisons. Body
+// and ring masses are astronomically large, so these counts are intentionally absurd.
+const MASS_REFERENCES: { label: string; kg: number }[] = [
+  { label: 'African bush elephants', kg: 6.0e3 },
+  { label: 'blue whales', kg: 1.5e5 },
+  { label: 'large cruise ships', kg: 1.0e8 },
+  { label: 'Great Pyramids of Giza', kg: 5.9e9 },
+];
+
+/** Builds the silly everyday-object mass comparisons for a mass given in kilograms. */
+export function buildMassComparisons(kg: number): MassComparison[] {
+  if (!Number.isFinite(kg) || kg <= 0) { return []; }
+  return MASS_REFERENCES.map(ref => ({
+    label: ref.label,
+    display: `≈ ${formatDisplayNumber(kg / ref.kg)}`,
+  }));
+}
+
+/** Two-decimal grouped number, matching the existing `| number:'0.2-2'` inline style. */
+function fixed2(value: number): string {
+  return value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+/**
+ * Inline length display (km base), choosing m / km / ls / ly by magnitude. Thresholds are
+ * sensible defaults tuned for in-system distances; AU is intentionally skipped inline (it
+ * is available in the conversion dialog) per the requested km-first display.
+ */
+export function formatDynamicLength(km: number): string {
+  if (!Number.isFinite(km)) { return '—'; }
+  const abs = Math.abs(km);
+  if (abs === 0) { return '0.00 km'; }
+  if (abs < 1) { return `${fixed2(km * M_PER_KM)} m`; }
+  if (abs < 1e6) { return `${fixed2(km)} km`; }
+  if (abs < 0.1 * KM_PER_LIGHT_YEAR) { return `${fixed2(km / KM_PER_LIGHT_SECOND)} ls`; }
+  return `${fixed2(km / KM_PER_LIGHT_YEAR)} ly`;
+}
+
+/**
+ * Inline distance-to-arrival display (light-second base), staying in light-seconds — down
+ * to fractions — and switching to light-years only for Hutton-Orbital-scale spans.
+ */
+export function formatDynamicDistanceLs(ls: number): string {
+  if (!Number.isFinite(ls)) { return '—'; }
+  const lyThresholdLs = (0.1 * KM_PER_LIGHT_YEAR) / KM_PER_LIGHT_SECOND; // 0.1 ly in ls
+  if (Math.abs(ls) < lyThresholdLs) { return `${fixed2(ls)} ls`; }
+  return `${fixed2((ls * KM_PER_LIGHT_SECOND) / KM_PER_LIGHT_YEAR)} ly`;
+}
+
+/**
+ * Inline mass display (kg base), choosing Megatonnes / Earth masses / Solar masses by
+ * magnitude so a small ring reads in Earth masses rather than a huge Mt count.
+ */
+export function formatDynamicMass(kg: number): string {
+  if (!Number.isFinite(kg)) { return '—'; }
+  const abs = Math.abs(kg);
+  if (abs < 1e-3 * KG_PER_EARTH_MASS) { return `${fixed2(kg / KG_PER_MEGATONNE)} Mt`; }
+  if (abs < 0.1 * KG_PER_SOLAR_MASS) { return `${fixed2(kg / KG_PER_EARTH_MASS)} Earth masses`; }
+  return `${fixed2(kg / KG_PER_SOLAR_MASS)} Solar masses`;
+}
+
+/** Inline area display (km² base), choosing km² / ls² by magnitude. */
+export function formatDynamicArea(km2: number): string {
+  if (!Number.isFinite(km2)) { return '—'; }
+  if (Math.abs(km2) < KM2_PER_LS2) { return `${fixed2(km2)} km²`; }
+  return `${fixed2(km2 / KM2_PER_LS2)} ls²`;
+}

--- a/src/app/data/unit-conversions.ts
+++ b/src/app/data/unit-conversions.ts
@@ -164,12 +164,49 @@ function fixed2(value: number): string {
  */
 export function formatDynamicLength(km: number): string {
   if (!Number.isFinite(km)) { return '—'; }
+  return formatLengthInUnit(km, pickInlineLengthUnit(km));
+}
+
+/** An inline length unit: abbreviation shown inline, matching dialog-row label, and km multiplier. */
+export interface InlineLengthUnit {
+  /** Inline abbreviation (e.g. "km", "ls"). */
+  unit: string;
+  /** Matching conversion-dialog row label (e.g. "Light seconds"). */
+  label: string;
+  /** Multiplier turning a km value into this unit. */
+  perKm: number;
+}
+
+/**
+ * Picks the inline length unit (m / km / ls / ly) suiting a representative magnitude, using
+ * the same thresholds as {@link formatDynamicLength}. AU is intentionally skipped inline.
+ * Exposed so a group of related lengths (e.g. semi-major axis, apoapsis, periapsis) can be
+ * shown in one shared unit chosen from the group's representative value.
+ */
+export function pickInlineLengthUnit(km: number): InlineLengthUnit {
   const abs = Math.abs(km);
-  if (abs === 0) { return '0.00 km'; }
-  if (abs < 1) { return `${fixed2(km * M_PER_KM)} m`; }
-  if (abs < 1e6) { return `${fixed2(km)} km`; }
-  if (abs < 0.1 * KM_PER_LIGHT_YEAR) { return `${fixed2(km / KM_PER_LIGHT_SECOND)} ls`; }
-  return `${fixed2(km / KM_PER_LIGHT_YEAR)} ly`;
+  if (!Number.isFinite(km) || abs === 0) { return { unit: 'km', label: 'km', perKm: 1 }; }
+  if (abs < 1) { return { unit: 'm', label: 'm', perKm: M_PER_KM }; }
+  if (abs < 1e6) { return { unit: 'km', label: 'km', perKm: 1 }; }
+  if (abs < 0.1 * KM_PER_LIGHT_YEAR) { return { unit: 'ls', label: 'Light seconds', perKm: 1 / KM_PER_LIGHT_SECOND }; }
+  return { unit: 'ly', label: 'Light Years', perKm: 1 / KM_PER_LIGHT_YEAR };
+}
+
+/** Formats a km value in a pre-chosen length unit (for a group sharing one unit). */
+export function formatLengthInUnit(km: number, choice: InlineLengthUnit): string {
+  if (!Number.isFinite(km)) { return '—'; }
+  return `${fixed2(km * choice.perKm)} ${choice.unit}`;
+}
+
+/** Dialog-row label for the inline length unit chosen at this magnitude. */
+export function dynamicLengthUnitLabel(km: number): string {
+  return Number.isFinite(km) ? pickInlineLengthUnit(km).label : '';
+}
+
+/** Dialog-row label for the inline distance-to-arrival unit chosen at this magnitude (km base). */
+export function dynamicDistanceUnitLabel(km: number): string {
+  if (!Number.isFinite(km)) { return ''; }
+  return Math.abs(km) < 0.1 * KM_PER_LIGHT_YEAR ? 'Light seconds' : 'Light Years';
 }
 
 /**
@@ -183,21 +220,50 @@ export function formatDynamicDistanceLs(ls: number): string {
   return `${fixed2((ls * KM_PER_LIGHT_SECOND) / KM_PER_LIGHT_YEAR)} ly`;
 }
 
+/** Inline mass unit: abbreviation shown inline, matching dialog-row label, and kg multiplier. */
+interface InlineMassUnit { unit: string; label: string; perKg: number; }
+
 /**
- * Inline mass display (kg base), choosing Megatonnes / Earth masses / Solar masses by
- * magnitude so a small ring reads in Earth masses rather than a huge Mt count.
+ * Picks the inline mass unit (Mt / Earth masses / Solar masses) by magnitude, so a small
+ * ring reads in Earth masses rather than a huge Mt count. Single source for both the inline
+ * display ({@link formatDynamicMass}) and the dialog accent label ({@link dynamicMassUnitLabel}).
  */
-export function formatDynamicMass(kg: number): string {
-  if (!Number.isFinite(kg)) { return '—'; }
+function pickInlineMassUnit(kg: number): InlineMassUnit {
   const abs = Math.abs(kg);
-  if (abs < 1e-3 * KG_PER_EARTH_MASS) { return `${fixed2(kg / KG_PER_MEGATONNE)} Mt`; }
-  if (abs < 0.1 * KG_PER_SOLAR_MASS) { return `${fixed2(kg / KG_PER_EARTH_MASS)} Earth masses`; }
-  return `${fixed2(kg / KG_PER_SOLAR_MASS)} Solar masses`;
+  if (abs < 1e-3 * KG_PER_EARTH_MASS) { return { unit: 'Mt', label: 'Megatonnes', perKg: 1 / KG_PER_MEGATONNE }; }
+  if (abs < 0.1 * KG_PER_SOLAR_MASS) { return { unit: 'Earth masses', label: 'Earth Masses', perKg: 1 / KG_PER_EARTH_MASS }; }
+  return { unit: 'Solar masses', label: 'Solar Masses', perKg: 1 / KG_PER_SOLAR_MASS };
 }
 
-/** Inline area display (km² base), choosing km² / ls² by magnitude. */
+/** Inline mass display (kg base). */
+export function formatDynamicMass(kg: number): string {
+  if (!Number.isFinite(kg)) { return '—'; }
+  const u = pickInlineMassUnit(kg);
+  return `${fixed2(kg * u.perKg)} ${u.unit}`;
+}
+
+/** Dialog-row label for the inline mass unit chosen at this magnitude. */
+export function dynamicMassUnitLabel(kg: number): string {
+  return Number.isFinite(kg) ? pickInlineMassUnit(kg).label : '';
+}
+
+/** Inline area unit: abbreviation shown inline, matching dialog-row label, and km² multiplier. */
+interface InlineAreaUnit { unit: string; label: string; perKm2: number; }
+
+/** Picks the inline area unit (km² / ls²) by magnitude. Single source for display and label. */
+function pickInlineAreaUnit(km2: number): InlineAreaUnit {
+  if (Math.abs(km2) < KM2_PER_LS2) { return { unit: 'km²', label: 'km²', perKm2: 1 }; }
+  return { unit: 'ls²', label: 'Ls²', perKm2: 1 / KM2_PER_LS2 };
+}
+
+/** Inline area display (km² base). */
 export function formatDynamicArea(km2: number): string {
   if (!Number.isFinite(km2)) { return '—'; }
-  if (Math.abs(km2) < KM2_PER_LS2) { return `${fixed2(km2)} km²`; }
-  return `${fixed2(km2 / KM2_PER_LS2)} ls²`;
+  const u = pickInlineAreaUnit(km2);
+  return `${fixed2(km2 * u.perKm2)} ${u.unit}`;
+}
+
+/** Dialog-row label for the inline area unit chosen at this magnitude. */
+export function dynamicAreaUnitLabel(km2: number): string {
+  return Number.isFinite(km2) ? pickInlineAreaUnit(km2).label : '';
 }

--- a/src/app/data/unit-conversions.ts
+++ b/src/app/data/unit-conversions.ts
@@ -14,6 +14,7 @@ export const KM_PER_LIGHT_YEAR = 9.4607304725808e12; // KM_PER_LIGHT_SECOND × 8
 export const M_PER_KM = 1000;
 
 // --- Duration (base: days) ---
+export const SECONDS_PER_DAY = 86400;
 export const MINUTES_PER_DAY = 1440;
 export const HOURS_PER_DAY = 24;
 export const WEEKS_PER_DAY = 1 / 7;
@@ -74,6 +75,7 @@ const CONVERSIONS: Record<QuantityKind, { unit: string; factor: number }[]> = {
     { unit: 'Days', factor: 1 },
     { unit: 'Hours', factor: HOURS_PER_DAY },
     { unit: 'Minutes', factor: MINUTES_PER_DAY },
+    { unit: 'Seconds', factor: SECONDS_PER_DAY },
   ],
   mass: [
     { unit: 'Solar Masses', factor: 1 / KG_PER_SOLAR_MASS },

--- a/src/app/dialogs/dialog-shell/dialog-shell.component.scss
+++ b/src/app/dialogs/dialog-shell/dialog-shell.component.scss
@@ -7,6 +7,12 @@
     max-height: 90vh;
 }
 
+// Opt-in (see `fitContent`): size to the content instead, so short dialogs aren't padded
+// out to 80vh. The max-height still caps tall content, which then scrolls as usual.
+:host.fit-content {
+    height: auto;
+}
+
 h2[mat-dialog-title] {
     flex: 0 0 auto;
     margin: 0;

--- a/src/app/dialogs/dialog-shell/dialog-shell.component.ts
+++ b/src/app/dialogs/dialog-shell/dialog-shell.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import {
   MatDialogActions,
@@ -18,6 +18,10 @@ import { MatButton } from '@angular/material/button';
  * and a Close button:
  *  - `[shell-title-extra]` — extra content alongside the heading text (e.g. a link).
  *  - `[shell-actions]` — extra action buttons placed after the Close button.
+ *
+ * By default the shell is a fixed height so the info dialogs don't jump in size as their
+ * content varies. Set `fitContent` for a dialog whose body should size to its content
+ * instead, growing only up to the shared max-height before its content scrolls.
  */
 @Component({
   selector: 'app-dialog-shell',
@@ -29,4 +33,10 @@ import { MatButton } from '@angular/material/button';
 export class DialogShellComponent {
   /** Heading shown in the dialog title bar. */
   @Input({ required: true }) heading!: string;
+
+  /**
+   * When true, the shell sizes to its content (auto height, capped at the shared
+   * max-height) instead of the default fixed height. Reflected to the host as a class.
+   */
+  @Input() @HostBinding('class.fit-content') fitContent = false;
 }

--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.spec.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+
+import { ConvertIconComponent } from './convert-icon.component';
+import { UnitConversionDialogComponent } from './unit-conversion-dialog.component';
+
+describe('ConvertIconComponent', () => {
+  let fixture: ComponentFixture<ConvertIconComponent>;
+  let opened: { component: unknown; config: { data?: any } }[];
+
+  beforeEach(() => {
+    opened = [];
+    const dialogStub = { open: (component: unknown, config: { data?: any } = {}) => { opened.push({ component, config }); } };
+    TestBed.configureTestingModule({
+      imports: [ConvertIconComponent],
+      providers: [provideZonelessChangeDetection(), { provide: MatDialog, useValue: dialogStub }],
+    });
+    fixture = TestBed.createComponent(ConvertIconComponent);
+  });
+
+  function render(kind: string, value: number | null | undefined, label: string): ConvertIconComponent {
+    fixture.componentRef.setInput('kind', kind);
+    fixture.componentRef.setInput('value', value);
+    fixture.componentRef.setInput('label', label);
+    fixture.detectChanges();
+    return fixture.componentInstance;
+  }
+
+  it('opens the conversion dialog with the kind, base value and label, stopping propagation', () => {
+    render('length', 6371, 'Radius');
+    const event = new MouseEvent('click');
+    const stop = vi.spyOn(event, 'stopPropagation');
+    fixture.nativeElement.querySelector('fa-icon').dispatchEvent(event);
+
+    expect(stop).toHaveBeenCalled();
+    expect(opened).toHaveLength(1);
+    expect(opened[0].component).toBe(UnitConversionDialogComponent);
+    expect(opened[0].config.data).toEqual({ title: 'Radius', kind: 'length', baseValue: 6371 });
+  });
+
+  it('does not open for a missing or non-finite value', () => {
+    for (const v of [null, undefined, NaN, Infinity]) {
+      render('mass', v, 'Mass');
+      fixture.nativeElement.querySelector('fa-icon').dispatchEvent(new MouseEvent('click'));
+    }
+    expect(opened).toHaveLength(0);
+  });
+});

--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.spec.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.spec.ts
@@ -35,11 +35,16 @@ describe('ConvertIconComponent', () => {
     return fixture.componentInstance;
   }
 
-  it('opens the conversion dialog with the kind, base value and label, stopping propagation', () => {
-    render('length', 6371, 'Radius');
+  // The click handler is async: it lazy-loads the dialog via a dynamic import() before opening it.
+  // Call it directly and await the returned promise so the assertion sees the resolved open() call.
+  const click = (component: ConvertIconComponent, event: Event = new MouseEvent('click')): Promise<void> =>
+    (component as unknown as { open(e: Event): Promise<void> }).open(event);
+
+  it('opens the conversion dialog with the kind, base value and label, stopping propagation', async () => {
+    const component = render('length', 6371, 'Radius');
     const event = new MouseEvent('click');
     const stop = vi.spyOn(event, 'stopPropagation');
-    fixture.nativeElement.querySelector('fa-icon').dispatchEvent(event);
+    await click(component, event);
 
     expect(stop).toHaveBeenCalled();
     expect(opened).toHaveLength(1);
@@ -49,19 +54,19 @@ describe('ConvertIconComponent', () => {
     });
   });
 
-  it('passes the UI and source unit labels through to the dialog', () => {
-    render('mass', 2.88e30, 'Mass', 'Solar Masses', 'Earth Masses');
-    fixture.nativeElement.querySelector('fa-icon').dispatchEvent(new MouseEvent('click'));
+  it('passes the UI and source unit labels through to the dialog', async () => {
+    const component = render('mass', 2.88e30, 'Mass', 'Solar Masses', 'Earth Masses');
+    await click(component);
 
     expect(opened[0].config.data).toEqual({
       title: 'Mass', kind: 'mass', baseValue: 2.88e30, uiUnit: 'Solar Masses', sourceUnit: 'Earth Masses',
     });
   });
 
-  it('does not open for a missing or non-finite value', () => {
+  it('does not open for a missing or non-finite value', async () => {
     for (const v of [null, undefined, NaN, Infinity]) {
-      render('mass', v, 'Mass');
-      fixture.nativeElement.querySelector('fa-icon').dispatchEvent(new MouseEvent('click'));
+      const component = render('mass', v, 'Mass');
+      await click(component);
     }
     expect(opened).toHaveLength(0);
   });

--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.spec.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.spec.ts
@@ -19,10 +19,18 @@ describe('ConvertIconComponent', () => {
     fixture = TestBed.createComponent(ConvertIconComponent);
   });
 
-  function render(kind: string, value: number | null | undefined, label: string): ConvertIconComponent {
+  function render(
+    kind: string,
+    value: number | null | undefined,
+    label: string,
+    uiUnit?: string,
+    sourceUnit?: string,
+  ): ConvertIconComponent {
     fixture.componentRef.setInput('kind', kind);
     fixture.componentRef.setInput('value', value);
     fixture.componentRef.setInput('label', label);
+    if (uiUnit !== undefined) { fixture.componentRef.setInput('uiUnit', uiUnit); }
+    if (sourceUnit !== undefined) { fixture.componentRef.setInput('sourceUnit', sourceUnit); }
     fixture.detectChanges();
     return fixture.componentInstance;
   }
@@ -36,7 +44,18 @@ describe('ConvertIconComponent', () => {
     expect(stop).toHaveBeenCalled();
     expect(opened).toHaveLength(1);
     expect(opened[0].component).toBe(UnitConversionDialogComponent);
-    expect(opened[0].config.data).toEqual({ title: 'Radius', kind: 'length', baseValue: 6371 });
+    expect(opened[0].config.data).toEqual({
+      title: 'Radius', kind: 'length', baseValue: 6371, uiUnit: null, sourceUnit: null,
+    });
+  });
+
+  it('passes the UI and source unit labels through to the dialog', () => {
+    render('mass', 2.88e30, 'Mass', 'Solar Masses', 'Earth Masses');
+    fixture.nativeElement.querySelector('fa-icon').dispatchEvent(new MouseEvent('click'));
+
+    expect(opened[0].config.data).toEqual({
+      title: 'Mass', kind: 'mass', baseValue: 2.88e30, uiUnit: 'Solar Masses', sourceUnit: 'Earth Masses',
+    });
   });
 
   it('does not open for a missing or non-finite value', () => {

--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
@@ -5,7 +5,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faRightLeft } from '@fortawesome/free-solid-svg-icons';
 import { ClickableDirective } from '../../clickable.directive';
 import { QuantityKind } from '../../data/unit-conversions';
-import { UnitConversionDialogComponent, UnitConversionDialogData } from './unit-conversion-dialog.component';
+import type { UnitConversionDialogComponent, UnitConversionDialogData } from './unit-conversion-dialog.component';
 
 /**
  * Small "⇄" affordance rendered after a property value. Clicking it opens the
@@ -38,10 +38,11 @@ export class ConvertIconComponent {
   /** Conversion-row label for the unit the value natively arrives in (journal/API); badged in the dialog. */
   readonly sourceUnit = input<string | null | undefined>();
 
-  protected open(event: Event): void {
+  protected async open(event: Event): Promise<void> {
     event.stopPropagation();
     const baseValue = this.value();
     if (baseValue == null || !Number.isFinite(baseValue)) { return; }
+    const { UnitConversionDialogComponent } = await import('./unit-conversion-dialog.component');
     this.dialog.open<UnitConversionDialogComponent, UnitConversionDialogData>(UnitConversionDialogComponent, {
       width: '600px',
       maxWidth: '95vw',

--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
@@ -35,7 +35,7 @@ export class ConvertIconComponent {
   readonly label = input.required<string>();
   /** Conversion-row label for the unit shown inline in the UI; that row is accented in the dialog. */
   readonly uiUnit = input<string | null | undefined>();
-  /** Conversion-row label for the unit the value natively arrives in (journal/API); badged in the dialog. */
+  /** Conversion-row label for the unit the value is recorded in by the game journal; badged in the dialog. */
   readonly sourceUnit = input<string | null | undefined>();
 
   protected async open(event: Event): Promise<void> {

--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
@@ -33,6 +33,10 @@ export class ConvertIconComponent {
   readonly value = input.required<number | null | undefined>();
   /** Dialog heading / what the value represents. */
   readonly label = input.required<string>();
+  /** Conversion-row label for the unit shown inline in the UI; that row is accented in the dialog. */
+  readonly uiUnit = input<string | null | undefined>();
+  /** Conversion-row label for the unit the value natively arrives in (journal/API); badged in the dialog. */
+  readonly sourceUnit = input<string | null | undefined>();
 
   protected open(event: Event): void {
     event.stopPropagation();
@@ -42,7 +46,13 @@ export class ConvertIconComponent {
       width: '600px',
       maxWidth: '95vw',
       autoFocus: 'first-heading',
-      data: { title: this.label(), kind: this.kind(), baseValue },
+      data: {
+        title: this.label(),
+        kind: this.kind(),
+        baseValue,
+        uiUnit: this.uiUnit() ?? null,
+        sourceUnit: this.sourceUnit() ?? null,
+      },
     });
   }
 }

--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
@@ -1,0 +1,48 @@
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { MatTooltip } from '@angular/material/tooltip';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { faRightLeft } from '@fortawesome/free-solid-svg-icons';
+import { ClickableDirective } from '../../clickable.directive';
+import { QuantityKind } from '../../data/unit-conversions';
+import { UnitConversionDialogComponent, UnitConversionDialogData } from './unit-conversion-dialog.component';
+
+/**
+ * Small "⇄" affordance rendered after a property value. Clicking it opens the
+ * unit-conversion dialog for that value, listing it in every scale unit of its kind.
+ * Stops the click from bubbling so it never triggers a surrounding row's own click
+ * (e.g. the apoapsis/Roche/Hill chart dialogs). A no-op when the value is missing or
+ * non-finite, so callers can bind it unconditionally.
+ */
+@Component({
+  selector: 'app-convert-icon',
+  template: `<fa-icon class="convert-icon clickable"
+                      matTooltip="Show in other units"
+                      [icon]="faRightLeft"
+                      (click)="open($event)"></fa-icon>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FaIconComponent, MatTooltip, ClickableDirective],
+})
+export class ConvertIconComponent {
+  private readonly dialog = inject(MatDialog);
+  protected readonly faRightLeft = faRightLeft;
+
+  /** Quantity kind, selecting which unit table the dialog shows. */
+  readonly kind = input.required<QuantityKind>();
+  /** The value in the kind's base unit (km, days, kg, km/s, kg/m³, km², atm). */
+  readonly value = input.required<number | null | undefined>();
+  /** Dialog heading / what the value represents. */
+  readonly label = input.required<string>();
+
+  protected open(event: Event): void {
+    event.stopPropagation();
+    const baseValue = this.value();
+    if (baseValue == null || !Number.isFinite(baseValue)) { return; }
+    this.dialog.open<UnitConversionDialogComponent, UnitConversionDialogData>(UnitConversionDialogComponent, {
+      width: '600px',
+      maxWidth: '95vw',
+      autoFocus: 'first-heading',
+      data: { title: this.label(), kind: this.kind(), baseValue },
+    });
+  }
+}

--- a/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.html
+++ b/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.html
@@ -1,4 +1,4 @@
-<app-dialog-shell [heading]="title">
+<app-dialog-shell [heading]="title" [fitContent]="true">
   <div class="unit-conversion-dialog">
     <p class="hint">Click a value to copy it.</p>
     <table class="conversion-table">

--- a/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.html
+++ b/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.html
@@ -1,0 +1,37 @@
+<app-dialog-shell [heading]="title">
+  <div class="unit-conversion-dialog">
+    <p class="hint">Click a value to copy it.</p>
+    <table class="conversion-table">
+      <thead>
+        <tr>
+          <th scope="col">Unit</th>
+          <th scope="col">Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (row of rows; track row.unit; let i = $index) {
+          <tr>
+            <th scope="row">{{ row.unit }}</th>
+            <td class="value clickable"
+                matTooltip="Click to copy"
+                [attr.aria-label]="'Copy value in ' + row.unit"
+                (click)="copy(row, i)">
+              {{ copiedIndex() === i ? 'Copied!' : row.display }}
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+
+    @if (comparisons.length) {
+      <div class="comparisons">
+        <p class="comparisons-heading">Just for fun, that's about</p>
+        <ul>
+          @for (c of comparisons; track c.label) {
+            <li>{{ c.display }} {{ c.label }}</li>
+          }
+        </ul>
+      </div>
+    }
+  </div>
+</app-dialog-shell>

--- a/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.html
+++ b/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.html
@@ -10,8 +10,13 @@
       </thead>
       <tbody>
         @for (row of rows; track row.unit; let i = $index) {
-          <tr>
-            <th scope="row">{{ row.unit }}</th>
+          <tr [class.ui-unit]="row.unit === uiUnit">
+            <th scope="row">
+              {{ row.unit }}
+              @if (row.unit === sourceUnit) {
+                <span class="unit-tag source" matTooltip="The unit this value arrives in from the journal / API">from journal</span>
+              }
+            </th>
             <td class="value clickable"
                 matTooltip="Click to copy"
                 [attr.aria-label]="'Copy value in ' + row.unit"

--- a/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.html
+++ b/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.html
@@ -14,7 +14,7 @@
             <th scope="row">
               {{ row.unit }}
               @if (row.unit === sourceUnit) {
-                <span class="unit-tag source" matTooltip="The unit this value arrives in from the journal / API">from journal</span>
+                <span class="unit-tag source" matTooltip="The unit this value is recorded in by the game journal">from journal</span>
               }
             </th>
             <td class="value clickable"

--- a/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.scss
+++ b/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.scss
@@ -23,6 +23,45 @@
     font-weight: 600
 }
 
+/* The values are right-aligned, so right-align their column header to match. */
+.unit-conversion-dialog .conversion-table thead th:last-child {
+    text-align: right
+}
+
+/* Row whose unit is the one shown inline in the UI. */
+.unit-conversion-dialog .conversion-table tbody tr.ui-unit {
+    background: var(--color-surface-3)
+}
+
+.unit-conversion-dialog .conversion-table tbody tr.ui-unit > th[scope="row"] {
+    box-shadow: inset 3px 0 0 0 var(--color-accent)
+}
+
+/* Small chips marking the UI / source units on a unit row. */
+.unit-conversion-dialog .conversion-table .unit-tag {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 1px 6px;
+    border-radius: 10px;
+    font-size: 0.72em;
+    font-weight: 600;
+    line-height: 1.4;
+    vertical-align: middle;
+    text-transform: uppercase;
+    letter-spacing: 0.03em
+}
+
+.unit-conversion-dialog .conversion-table .unit-tag.ui {
+    background: var(--color-accent);
+    color: var(--color-black)
+}
+
+.unit-conversion-dialog .conversion-table .unit-tag.source {
+    background: transparent;
+    color: var(--color-text);
+    border: 1px solid var(--color-surface-5)
+}
+
 .unit-conversion-dialog .conversion-table tbody th {
     white-space: nowrap;
     font-weight: 600

--- a/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.scss
+++ b/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.scss
@@ -1,0 +1,61 @@
+.unit-conversion-dialog .hint {
+    margin: 0 0 12px;
+    opacity: 0.7;
+    font-size: 0.9em
+}
+
+.unit-conversion-dialog .conversion-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95em
+}
+
+.unit-conversion-dialog .conversion-table th,
+.unit-conversion-dialog .conversion-table td {
+    padding: 8px 12px;
+    text-align: left;
+    vertical-align: middle;
+    border-bottom: 1px solid var(--color-surface-5);
+    line-height: 1.5
+}
+
+.unit-conversion-dialog .conversion-table thead th {
+    font-weight: 600
+}
+
+.unit-conversion-dialog .conversion-table tbody th {
+    white-space: nowrap;
+    font-weight: 600
+}
+
+.unit-conversion-dialog .conversion-table td.value {
+    font-family: monospace;
+    text-align: right;
+    white-space: nowrap;
+    user-select: none
+}
+
+.unit-conversion-dialog .conversion-table td.value.clickable:hover,
+.unit-conversion-dialog .conversion-table td.value.clickable:focus-visible {
+    color: var(--color-white);
+    text-decoration: underline
+}
+
+.unit-conversion-dialog .comparisons {
+    margin-top: 20px;
+    line-height: 1.6
+}
+
+.unit-conversion-dialog .comparisons-heading {
+    font-weight: 600;
+    margin-bottom: 8px
+}
+
+.unit-conversion-dialog .comparisons ul {
+    margin: 0;
+    padding-left: 20px
+}
+
+.unit-conversion-dialog .comparisons ul li {
+    padding: 4px 0
+}

--- a/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.spec.ts
+++ b/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.spec.ts
@@ -1,0 +1,69 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+import { UnitConversionDialogComponent, UnitConversionDialogData } from './unit-conversion-dialog.component';
+
+function setup(data: UnitConversionDialogData): ComponentFixture<UnitConversionDialogComponent> {
+  TestBed.configureTestingModule({
+    imports: [UnitConversionDialogComponent],
+    providers: [provideZonelessChangeDetection(), { provide: MAT_DIALOG_DATA, useValue: data }],
+  });
+  const fixture = TestBed.createComponent(UnitConversionDialogComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('UnitConversionDialogComponent', () => {
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('renders the heading and one row per length unit', () => {
+    const el: HTMLElement = setup({ title: 'Semi-major axis', kind: 'length', baseValue: 149597870.7 }).nativeElement;
+    expect(el.textContent).toContain('Semi-major axis');
+    const rows = el.querySelectorAll('.conversion-table tbody tr');
+    expect(rows.length).toBe(6);
+    expect(el.textContent).toContain('AU');
+    expect(el.textContent).toContain('Light seconds');
+  });
+
+  it('shows mass comparisons for the mass kind', () => {
+    const el: HTMLElement = setup({ title: 'Mass', kind: 'mass', baseValue: 5.972e24 }).nativeElement;
+    expect(el.querySelector('.comparisons')).toBeTruthy();
+    expect(el.textContent).toContain('African bush elephants');
+  });
+
+  it('omits the comparisons section for non-mass kinds', () => {
+    const el: HTMLElement = setup({ title: 'Radius', kind: 'length', baseValue: 6371 }).nativeElement;
+    expect(el.querySelector('.comparisons')).toBeNull();
+  });
+
+  it('copies a value to the clipboard on click and flips it to "Copied!"', async () => {
+    vi.useFakeTimers();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const fixture = setup({ title: 'Radius', kind: 'length', baseValue: 6371 });
+    const el = fixture.nativeElement as HTMLElement;
+    const valueCell = el.querySelector('.conversion-table tbody tr td.value') as HTMLElement;
+
+    valueCell.click();
+    expect(writeText).toHaveBeenCalledOnce();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    fixture.detectChanges();
+    expect(el.textContent).toContain('Copied!');
+
+    vi.advanceTimersByTime(1500);
+    fixture.detectChanges();
+    expect(el.textContent).not.toContain('Copied!');
+    vi.useRealTimers();
+  });
+
+  it('does not throw when the clipboard is unavailable', () => {
+    Object.assign(navigator, { clipboard: undefined });
+    const fixture = setup({ title: 'Radius', kind: 'length', baseValue: 6371 });
+    const valueCell = (fixture.nativeElement as HTMLElement).querySelector('td.value') as HTMLElement;
+    expect(() => valueCell.click()).not.toThrow();
+  });
+});

--- a/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.ts
+++ b/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.ts
@@ -19,6 +19,10 @@ export interface UnitConversionDialogData {
   kind: QuantityKind;
   /** The value, already expressed in the kind's base unit. */
   baseValue: number;
+  /** Conversion-row label for the unit shown inline in the UI (accented), or null. */
+  uiUnit?: string | null;
+  /** Conversion-row label for the unit the value natively arrives in (badged), or null. */
+  sourceUnit?: string | null;
 }
 
 /**
@@ -39,6 +43,10 @@ export class UnitConversionDialogComponent {
 
   protected readonly title = this.data.title;
   protected readonly rows: ConversionRow[] = buildConversions(this.data.kind, this.data.baseValue);
+  /** Conversion-row label shown inline in the UI (accented row), if any. */
+  protected readonly uiUnit = this.data.uiUnit ?? null;
+  /** Conversion-row label the value natively arrives in (source badge), if any. */
+  protected readonly sourceUnit = this.data.sourceUnit ?? null;
   protected readonly comparisons: MassComparison[] =
     this.data.kind === 'mass' ? buildMassComparisons(this.data.baseValue) : [];
 

--- a/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.ts
+++ b/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.ts
@@ -1,0 +1,56 @@
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatTooltip } from '@angular/material/tooltip';
+import { DialogShellComponent } from '../dialog-shell/dialog-shell.component';
+import { ClickableDirective } from '../../clickable.directive';
+import {
+  buildConversions,
+  buildMassComparisons,
+  ConversionRow,
+  MassComparison,
+  QuantityKind,
+} from '../../data/unit-conversions';
+
+/** Data passed to the unit-conversion dialog when it is opened. */
+export interface UnitConversionDialogData {
+  /** Heading / what the value represents (e.g. "Semi-major axis"). */
+  title: string;
+  /** Which quantity the base value is, selecting the unit table. */
+  kind: QuantityKind;
+  /** The value, already expressed in the kind's base unit. */
+  baseValue: number;
+}
+
+/**
+ * Lists a single value across every scale unit of its kind, each copyable to the
+ * clipboard so users can paste the figure in whatever unit suits their tool. Mass also
+ * gets a light-hearted set of everyday-object comparisons. Opened via `MatDialog.open()`
+ * with {@link UnitConversionDialogData}; the rows are computed once on construction.
+ */
+@Component({
+  selector: 'app-unit-conversion-dialog',
+  templateUrl: './unit-conversion-dialog.component.html',
+  styleUrls: ['./unit-conversion-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DialogShellComponent, MatTooltip, ClickableDirective],
+})
+export class UnitConversionDialogComponent {
+  private readonly data = inject<UnitConversionDialogData>(MAT_DIALOG_DATA);
+
+  protected readonly title = this.data.title;
+  protected readonly rows: ConversionRow[] = buildConversions(this.data.kind, this.data.baseValue);
+  protected readonly comparisons: MassComparison[] =
+    this.data.kind === 'mass' ? buildMassComparisons(this.data.baseValue) : [];
+
+  /** Index of the row whose value was just copied, for the transient "Copied!" label. */
+  protected readonly copiedIndex = signal<number | null>(null);
+
+  protected copy(row: ConversionRow, index: number): void {
+    navigator.clipboard?.writeText(row.copyText)
+      .then(() => {
+        this.copiedIndex.set(index);
+        setTimeout(() => this.copiedIndex.set(null), 1500);
+      })
+      .catch(() => { /* clipboard unavailable */ });
+  }
+}

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -91,10 +91,30 @@ describe('SystemBodyComponent (extended coverage)', () => {
       expect(component.radToDeg(undefined)).toBeNull();
     });
 
-    it('formats Earth and Solar masses', () => {
+    it('resolves a body mass (kg) from whichever source field it carries', () => {
+      render(makeBody({ type: 'Star', solarMasses: 2 }));
+      expect(component.getMassKg()).toBeCloseTo(2 * 1.989e30, -25);
+      render(makeBody({ type: 'Planet', earthMasses: 1 }));
+      expect(component.getMassKg()).toBeCloseTo(5.972e24, -19);
+      render(makeBody({ type: 'Ring', mass: 5 }));
+      expect(component.getMassKg()).toBeCloseTo(5e12, 0);
       render(makeBody({}));
-      expect(component.formatEarthMass(1.2345).display).toBe('1.23 Earth masses');
-      expect(component.formatSolarMass(2).display).toBe('2.00');
+      expect(component.getMassKg()).toBeNull();
+    });
+
+    it('formats mass dynamically by magnitude', () => {
+      render(makeBody({}));
+      expect(component.formatMass(5.25 * 1.989e30)).toBe('5.25 Solar masses');
+      expect(component.formatMass(0.67 * 5.972e24)).toBe('0.67 Earth masses');
+    });
+
+    it('shows a star radius in km for compact objects and white dwarfs, solar radii otherwise', () => {
+      render(makeBody({ type: 'Star', subType: 'White Dwarf (DA) Star', solarRadius: 0.011 }));
+      expect(component.getStarRadiusKm()).toBeCloseTo(0.011 * 695700, 0);
+      render(makeBody({ type: 'Star', subType: 'Neutron Star', solarRadius: 0.00002 }));
+      expect(component.getStarRadiusKm()).toBeCloseTo(0.00002 * 695700, 3);
+      render(makeBody({ type: 'Star', subType: 'G (White-Yellow) Star', solarRadius: 1.1 }));
+      expect(component.getStarRadiusKm()).toBeNull();
     });
 
     it('exposes trackBy helpers and mouse-enter state', () => {
@@ -816,6 +836,20 @@ describe('SystemBodyComponent (extended coverage)', () => {
       const badge: HTMLElement = fixture.nativeElement.querySelector('.badge-red');
       expect(badge).not.toBeNull();
       expect(badge!.textContent?.trim()).toBe('Collision In Progress');
+    });
+  });
+
+  describe('conversion base-value getters', () => {
+    it('converts semi-major axis (AU) and distance-to-arrival (ls) to km bases', () => {
+      render(makeBody({ semiMajorAxis: 1, distanceToArrival: 100 }));
+      expect(component.getSemiMajorAxisKm()).toBeCloseTo(149597870.7, 0);
+      expect(component.getDistanceToArrivalKm()).toBeCloseTo(100 * 299792.458, 0);
+      expect(component.getSolarRadiusKm()).toBeNull();
+    });
+
+    it('converts an ordinary star radius (solar radii) to a km base', () => {
+      render(makeBody({ type: 'Star', subType: 'G (White-Yellow) Star', solarRadius: 1.1 }));
+      expect(component.getSolarRadiusKm()).toBeCloseTo(1.1 * 695700, 0);
     });
   });
 

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -198,7 +198,7 @@
                 Orbital period
               </div>
               <div [matTooltip]="body().bodyData.orbitalPeriod + ' days'">
-                {{ getOrbitalPeriodDisplay() }}<app-convert-icon [kind]="'duration'" [value]="body().bodyData.orbitalPeriod" label="Orbital period" />
+                {{ getOrbitalPeriodDisplay() }}<app-convert-icon [kind]="'duration'" [value]="body().bodyData.orbitalPeriod" label="Orbital period" [uiUnit]="durationUnitLabel(body().bodyData.orbitalPeriod)" sourceUnit="Days" />
               </div>
             </div>
             }
@@ -208,7 +208,7 @@
                 Semi-major axis
               </div>
               <div [matTooltip]="body().bodyData.semiMajorAxis + ' au'">
-                {{ (body().bodyData.semiMajorAxis! * 149597870.7) | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="getSemiMajorAxisKm()" label="Semi-major axis" />
+                {{ formatOrbitDistance(getSemiMajorAxisKm()) }}<app-convert-icon [kind]="'length'" [value]="getSemiMajorAxisKm()" label="Semi-major axis" [uiUnit]="orbitDistanceUnitLabel()" sourceUnit="AU" />
               </div>
             </div>
             }
@@ -230,7 +230,7 @@
                 Apoapsis<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
               </div>
               <div [matTooltip]="getApoapsis() + ' km'">
-                {{ getApoapsis() | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="getApoapsis()" label="Apoapsis" />
+                {{ formatOrbitDistance(getApoapsis()) }}<app-convert-icon [kind]="'length'" [value]="getApoapsis()" label="Apoapsis" [uiUnit]="orbitDistanceUnitLabel()" />
               </div>
             </div>
             }
@@ -251,7 +251,7 @@
                 Periapsis<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
               </div>
               <div [matTooltip]="getPeriapsis() + ' km'">
-                {{ getPeriapsis() | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="getPeriapsis()" label="Periapsis" />
+                {{ formatOrbitDistance(getPeriapsis()) }}<app-convert-icon [kind]="'length'" [value]="getPeriapsis()" label="Periapsis" [uiUnit]="orbitDistanceUnitLabel()" />
               </div>
             </div>
             }
@@ -303,7 +303,7 @@
                 Tangential velocity
               </div>
               <div [matTooltip]="getTangentialVelocityTooltip()">
-                {{ getTangentialVelocityDisplay() }}<app-convert-icon [kind]="'velocity'" [value]="getTangentialVelocity()" label="Tangential velocity" />
+                {{ getTangentialVelocityDisplay() }}<app-convert-icon [kind]="'velocity'" [value]="getTangentialVelocity()" label="Tangential velocity" [uiUnit]="velocityUnitLabel(getTangentialVelocity())" />
               </div>
             </div>
             }
@@ -321,7 +321,7 @@
               </div>
               <div
                    [matTooltip]="'Rigid: ' + (rocheLimits.rigid | number:'0.0-0') + ' km, Periapsis: ' + (rocheLimits.periapsis | number:'0.0-0') + ' km' + (rocheLimits.periapsis < rocheLimits.rigid ? ' - BREACHED' : '')">
-                {{ formatLength(rocheLimits.rigid) }}<app-convert-icon [kind]="'length'" [value]="rocheLimits.rigid" label="Roche limit (rigid)" />
+                {{ formatLength(rocheLimits.rigid) }}<app-convert-icon [kind]="'length'" [value]="rocheLimits.rigid" label="Roche limit (rigid)" [uiUnit]="lengthUnitLabel(rocheLimits.rigid)" />
                 @if (rocheLimits.periapsis < rocheLimits.rigid)
                   {
                   <span
@@ -339,7 +339,7 @@
               </div>
               <div
                    [matTooltip]="'Fluid: ' + (rocheLimits.fluid | number:'0.0-0') + ' km, Apoapsis: ' + (rocheLimits.apoapsis | number:'0.0-0') + ' km' + (rocheLimits.apoapsis < rocheLimits.fluid ? ' - BREACHED' : '')">
-                {{ formatLength(rocheLimits.fluid) }}<app-convert-icon [kind]="'length'" [value]="rocheLimits.fluid" label="Roche limit (fluid)" />
+                {{ formatLength(rocheLimits.fluid) }}<app-convert-icon [kind]="'length'" [value]="rocheLimits.fluid" label="Roche limit (fluid)" [uiUnit]="lengthUnitLabel(rocheLimits.fluid)" />
                 @if (rocheLimits.apoapsis < rocheLimits.fluid)
                   {
                   <span
@@ -362,7 +362,7 @@
               Hill sphere radius<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
             </div>
             <div [matTooltip]="'Gravitational influence radius: ' + (hillData.hillRadius | number:'0.0-0') + ' km'">
-              {{ formatLength(hillData.hillRadius) }}<app-convert-icon [kind]="'length'" [value]="hillData.hillRadius" label="Hill sphere radius" />
+              {{ formatLength(hillData.hillRadius) }}<app-convert-icon [kind]="'length'" [value]="hillData.hillRadius" label="Hill sphere radius" [uiUnit]="lengthUnitLabel(hillData.hillRadius)" />
             </div>
           </div>
           @if (hillData.withinRings || hillData.isFirstOutside) {
@@ -395,7 +395,7 @@
               Radius
             </div>
             <div [matTooltip]="body().bodyData.radius + ' km'">
-              {{ body().bodyData.radius | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="body().bodyData.radius" label="Radius" />
+              {{ body().bodyData.radius | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="body().bodyData.radius" label="Radius" uiUnit="km" sourceUnit="km" />
             </div>
           </div>
           }
@@ -405,7 +405,7 @@
               Radius
             </div>
             <div [matTooltip]="starRadiusKm + ' km'">
-              {{ starRadiusKm | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="starRadiusKm" label="Radius" />
+              {{ starRadiusKm | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="starRadiusKm" label="Radius" uiUnit="km" />
             </div>
           </div>
           } @else if (body().bodyData.solarRadius) {
@@ -414,7 +414,7 @@
               Radius
             </div>
             <div [matTooltip]="body().bodyData.solarRadius!.toString() + ' R☉'">
-              {{ body().bodyData.solarRadius | number:'0.2-2' }} R☉<app-convert-icon [kind]="'length'" [value]="getSolarRadiusKm()" label="Radius" />
+              {{ body().bodyData.solarRadius | number:'0.2-2' }} R☉<app-convert-icon [kind]="'length'" [value]="getSolarRadiusKm()" label="Radius" uiUnit="Solar Radii" sourceUnit="Solar Radii" />
             </div>
           </div>
           }
@@ -425,7 +425,7 @@
             </div>
             <div [matTooltip]="'Event-horizon radius r_s = 2GM/c² = ' + (schwarzschildRadius | number:'0.2-4') + ' km'"
                  matTooltipClass="multiline-tooltip">
-              {{ schwarzschildRadius | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="schwarzschildRadius" label="Schwarzschild radius" />
+              {{ schwarzschildRadius | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="schwarzschildRadius" label="Schwarzschild radius" uiUnit="km" />
             </div>
           </div>
           }
@@ -435,7 +435,7 @@
               Mass
             </div>
             <div>
-              <span [matTooltip]="getMassTooltip()">{{ formatMass(massKg) }}</span><app-convert-icon [kind]="'mass'" [value]="massKg" label="Mass" />
+              <span [matTooltip]="getMassTooltip()">{{ formatMass(massKg) }}</span><app-convert-icon [kind]="'mass'" [value]="massKg" label="Mass" [uiUnit]="massUnitLabel(massKg)" [sourceUnit]="massSourceUnit()" />
               @if (getMassStabilityAlert(); as massAlert) {
               <span [class.status-danger]="massAlert.severity === 'danger'"
                 [class.status-warning]="massAlert.severity === 'warning'" [matTooltip]="massAlert.message"
@@ -460,7 +460,7 @@
               Density
             </div>
             <div [matTooltip]="density.tooltip">
-              {{ density.value | number:'0.2-2' }} {{ density.unit }}<app-convert-icon [kind]="'density'" [value]="density.densityKgM3" label="Density" />
+              {{ density.value | number:'0.2-2' }} {{ density.unit }}<app-convert-icon [kind]="'density'" [value]="density.densityKgM3" label="Density" [uiUnit]="density.unit" />
             </div>
           </div>
           }
@@ -508,7 +508,7 @@
               Inner radius
             </div>
             <div [matTooltip]="body().bodyData.innerRadius + ' km'">
-              {{ formatLength(body().bodyData.innerRadius!) }}<app-convert-icon [kind]="'length'" [value]="body().bodyData.innerRadius" label="Inner radius" />
+              {{ formatLength(body().bodyData.innerRadius!) }}<app-convert-icon [kind]="'length'" [value]="body().bodyData.innerRadius" label="Inner radius" [uiUnit]="lengthUnitLabel(body().bodyData.innerRadius)" sourceUnit="km" />
             </div>
           </div>
           }
@@ -518,7 +518,7 @@
               Outer radius
             </div>
             <div [matTooltip]="body().bodyData.outerRadius + ' km'">
-              {{ formatLength(body().bodyData.outerRadius!) }}<app-convert-icon [kind]="'length'" [value]="body().bodyData.outerRadius" label="Outer radius" />
+              {{ formatLength(body().bodyData.outerRadius!) }}<app-convert-icon [kind]="'length'" [value]="body().bodyData.outerRadius" label="Outer radius" [uiUnit]="lengthUnitLabel(body().bodyData.outerRadius)" sourceUnit="km" />
             </div>
           </div>
           }
@@ -528,7 +528,7 @@
               Ring width
             </div>
             <div [matTooltip]="getRingWidth() + ' km'">
-              {{ formatLength(getRingWidth()) }}<app-convert-icon [kind]="'length'" [value]="getRingWidth()" label="Ring width" />
+              {{ formatLength(getRingWidth()) }}<app-convert-icon [kind]="'length'" [value]="getRingWidth()" label="Ring width" [uiUnit]="lengthUnitLabel(getRingWidth())" />
             </div>
           </div>
           }
@@ -538,7 +538,7 @@
               Ring area
             </div>
             <div [matTooltip]="getRingArea() + ' km²'">
-              {{ formatArea(getRingArea()) }}<app-convert-icon [kind]="'area'" [value]="getRingArea()" label="Ring area" />
+              {{ formatArea(getRingArea()) }}<app-convert-icon [kind]="'area'" [value]="getRingArea()" label="Ring area" [uiUnit]="areaUnitLabel(getRingArea())" />
             </div>
           </div>
           }
@@ -565,7 +565,7 @@
               Orbital period
             </div>
             <div [matTooltip]="getRingOrbitalPeriodTooltip()">
-              {{ getRingOrbitalPeriodDisplay() }}
+              {{ getRingOrbitalPeriodDisplay() }}<app-convert-icon [kind]="'duration'" [value]="getRingOrbitalPeriod()" label="Orbital period" [uiUnit]="durationUnitLabel(getRingOrbitalPeriod())" />
             </div>
           </div>
           }
@@ -575,7 +575,7 @@
               Min velocity
             </div>
             <div [matTooltip]="getRingMinVelocityTooltip()">
-              {{ getRingMinVelocityDisplay() }}
+              {{ getRingMinVelocityDisplay() }}<app-convert-icon [kind]="'velocity'" [value]="getRingMinVelocity()" label="Min velocity" [uiUnit]="velocityUnitLabel(getRingMinVelocity())" />
             </div>
           </div>
           }
@@ -585,7 +585,7 @@
               Max velocity
             </div>
             <div [matTooltip]="getRingMaxVelocityTooltip()">
-              {{ getRingMaxVelocityDisplay() }}
+              {{ getRingMaxVelocityDisplay() }}<app-convert-icon [kind]="'velocity'" [value]="getRingMaxVelocity()" label="Max velocity" [uiUnit]="velocityUnitLabel(getRingMaxVelocity())" />
             </div>
           </div>
           }
@@ -595,7 +595,7 @@
               Distance {{ getRingNeighbourDistanceLabel() }}
             </div>
             <div [matTooltip]="getRingNeighbourDistance() + ' km'">
-              {{ getRingNeighbourDistance() | number:'0.0-0' }} km
+              {{ getRingNeighbourDistance() | number:'0.0-0' }} km<app-convert-icon [kind]="'length'" [value]="getRingNeighbourDistance()" [label]="'Distance ' + getRingNeighbourDistanceLabel()" uiUnit="km" />
             </div>
           </div>
           }
@@ -605,7 +605,7 @@
               Velocity Difference {{ getRingNeighbourDistanceLabel() }}
             </div>
             <div [matTooltip]="getRingVelocityDiffTooltip()">
-              {{ getRingVelocityDiffDisplay() }}
+              {{ getRingVelocityDiffDisplay() }}<app-convert-icon [kind]="'velocity'" [value]="getRingVelocityDiff()" [label]="'Velocity Difference ' + getRingNeighbourDistanceLabel()" [uiUnit]="velocityUnitLabel(getRingVelocityDiff())" />
             </div>
           </div>
           }
@@ -623,7 +623,7 @@
                 [icon]="faInfo"></fa-icon>
             </div>
             <div [matTooltip]="'Rigid body Roche limit: ' + calculateRigidRocheLimit()! + ' km'">
-              {{ formatLength(calculateRigidRocheLimit()!) }}<app-convert-icon [kind]="'length'" [value]="calculateRigidRocheLimit()" label="Roche limit (rigid)" />
+              {{ formatLength(calculateRigidRocheLimit()!) }}<app-convert-icon [kind]="'length'" [value]="calculateRigidRocheLimit()" label="Roche limit (rigid)" [uiUnit]="lengthUnitLabel(calculateRigidRocheLimit())" />
             </div>
           </div>
           }
@@ -634,7 +634,7 @@
                 [icon]="faInfo"></fa-icon>
             </div>
             <div [matTooltip]="'Fluid body Roche limit: ' + calculateFluidRocheLimit()! + ' km'">
-              {{ formatLength(calculateFluidRocheLimit()!) }}<app-convert-icon [kind]="'length'" [value]="calculateFluidRocheLimit()" label="Roche limit (fluid)" />
+              {{ formatLength(calculateFluidRocheLimit()!) }}<app-convert-icon [kind]="'length'" [value]="calculateFluidRocheLimit()" label="Roche limit (fluid)" [uiUnit]="lengthUnitLabel(calculateFluidRocheLimit())" />
             </div>
           </div>
           }
@@ -674,7 +674,7 @@
             </div>
             <div [matTooltip]="cachedSurfacePressureTooltip() || ''"
                  matTooltipClass="multiline-tooltip">
-              {{ body().bodyData.surfacePressure | number:'0.2-2' }} atmospheres<app-convert-icon [kind]="'pressure'" [value]="body().bodyData.surfacePressure" label="Surface pressure" />
+              {{ body().bodyData.surfacePressure | number:'0.2-2' }} atmospheres<app-convert-icon [kind]="'pressure'" [value]="body().bodyData.surfacePressure" label="Surface pressure" uiUnit="atm" sourceUnit="atm" />
             </div>
           </div>
           }
@@ -700,7 +700,7 @@
               Rotational period
             </div>
             <div [matTooltip]="body().bodyData.rotationalPeriod + ' days'">
-              {{ getRotationalPeriodDisplay() }}<app-convert-icon [kind]="'duration'" [value]="body().bodyData.rotationalPeriod" label="Rotational period" />
+              {{ getRotationalPeriodDisplay() }}<app-convert-icon [kind]="'duration'" [value]="body().bodyData.rotationalPeriod" label="Rotational period" [uiUnit]="durationUnitLabel(body().bodyData.rotationalPeriod)" sourceUnit="Days" />
             </div>
           </div>
           }
@@ -711,7 +711,7 @@
               Distance to arrival
             </div>
             <div [matTooltip]="body().bodyData.distanceToArrival + ' ls'">
-              {{ formatDistanceLs(body().bodyData.distanceToArrival!) }}<app-convert-icon [kind]="'length'" [value]="getDistanceToArrivalKm()" label="Distance to arrival" />
+              {{ formatDistanceLs(body().bodyData.distanceToArrival!) }}<app-convert-icon [kind]="'length'" [value]="getDistanceToArrivalKm()" label="Distance to arrival" [uiUnit]="distanceUnitLabel(getDistanceToArrivalKm())" sourceUnit="Light seconds" />
             </div>
           </div>
           }

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -198,7 +198,7 @@
                 Orbital period
               </div>
               <div>
-                <span [matTooltip]="body().bodyData.orbitalPeriod + ' days'">{{ getOrbitalPeriodDisplay() }}</span><app-convert-icon [kind]="'duration'" [value]="body().bodyData.orbitalPeriod" label="Orbital period" [uiUnit]="durationUnitLabel(body().bodyData.orbitalPeriod)" sourceUnit="Days" />
+                <span [matTooltip]="body().bodyData.orbitalPeriod + ' days'">{{ getOrbitalPeriodDisplay() }}</span><app-convert-icon [kind]="'duration'" [value]="body().bodyData.orbitalPeriod" label="Orbital period" [uiUnit]="durationUnitLabel(body().bodyData.orbitalPeriod)" sourceUnit="Seconds" />
               </div>
             </div>
             }
@@ -208,7 +208,7 @@
                 Semi-major axis
               </div>
               <div>
-                <span [matTooltip]="body().bodyData.semiMajorAxis + ' au'">{{ formatOrbitDistance(getSemiMajorAxisKm()) }}</span><app-convert-icon [kind]="'length'" [value]="getSemiMajorAxisKm()" label="Semi-major axis" [uiUnit]="orbitDistanceUnitLabel()" sourceUnit="AU" />
+                <span [matTooltip]="body().bodyData.semiMajorAxis + ' au'">{{ formatOrbitDistance(getSemiMajorAxisKm()) }}</span><app-convert-icon [kind]="'length'" [value]="getSemiMajorAxisKm()" label="Semi-major axis" [uiUnit]="orbitDistanceUnitLabel()" sourceUnit="m" />
               </div>
             </div>
             }
@@ -393,7 +393,7 @@
               Radius
             </div>
             <div>
-              <span [matTooltip]="body().bodyData.radius + ' km'">{{ body().bodyData.radius | number:'0.2-2' }} km</span><app-convert-icon [kind]="'length'" [value]="body().bodyData.radius" label="Radius" uiUnit="km" sourceUnit="km" />
+              <span [matTooltip]="body().bodyData.radius + ' km'">{{ body().bodyData.radius | number:'0.2-2' }} km</span><app-convert-icon [kind]="'length'" [value]="body().bodyData.radius" label="Radius" uiUnit="km" sourceUnit="m" />
             </div>
           </div>
           }
@@ -412,7 +412,7 @@
               Radius
             </div>
             <div>
-              <span [matTooltip]="body().bodyData.solarRadius!.toString() + ' R☉'">{{ body().bodyData.solarRadius | number:'0.2-2' }} R☉</span><app-convert-icon [kind]="'length'" [value]="getSolarRadiusKm()" label="Radius" uiUnit="Solar Radii" sourceUnit="Solar Radii" />
+              <span [matTooltip]="body().bodyData.solarRadius!.toString() + ' R☉'">{{ body().bodyData.solarRadius | number:'0.2-2' }} R☉</span><app-convert-icon [kind]="'length'" [value]="getSolarRadiusKm()" label="Radius" uiUnit="Solar Radii" sourceUnit="m" />
             </div>
           </div>
           }
@@ -506,7 +506,7 @@
               Inner radius
             </div>
             <div>
-              <span [matTooltip]="body().bodyData.innerRadius + ' km'">{{ formatLength(body().bodyData.innerRadius!) }}</span><app-convert-icon [kind]="'length'" [value]="body().bodyData.innerRadius" label="Inner radius" [uiUnit]="lengthUnitLabel(body().bodyData.innerRadius)" sourceUnit="km" />
+              <span [matTooltip]="body().bodyData.innerRadius + ' km'">{{ formatLength(body().bodyData.innerRadius!) }}</span><app-convert-icon [kind]="'length'" [value]="body().bodyData.innerRadius" label="Inner radius" [uiUnit]="lengthUnitLabel(body().bodyData.innerRadius)" sourceUnit="m" />
             </div>
           </div>
           }
@@ -516,7 +516,7 @@
               Outer radius
             </div>
             <div>
-              <span [matTooltip]="body().bodyData.outerRadius + ' km'">{{ formatLength(body().bodyData.outerRadius!) }}</span><app-convert-icon [kind]="'length'" [value]="body().bodyData.outerRadius" label="Outer radius" [uiUnit]="lengthUnitLabel(body().bodyData.outerRadius)" sourceUnit="km" />
+              <span [matTooltip]="body().bodyData.outerRadius + ' km'">{{ formatLength(body().bodyData.outerRadius!) }}</span><app-convert-icon [kind]="'length'" [value]="body().bodyData.outerRadius" label="Outer radius" [uiUnit]="lengthUnitLabel(body().bodyData.outerRadius)" sourceUnit="m" />
             </div>
           </div>
           }
@@ -672,7 +672,7 @@
             </div>
             <div>
               <span [matTooltip]="cachedSurfacePressureTooltip() || ''"
-                    matTooltipClass="multiline-tooltip">{{ body().bodyData.surfacePressure | number:'0.2-2' }} atmospheres</span><app-convert-icon [kind]="'pressure'" [value]="body().bodyData.surfacePressure" label="Surface pressure" uiUnit="atm" sourceUnit="atm" />
+                    matTooltipClass="multiline-tooltip">{{ body().bodyData.surfacePressure | number:'0.2-2' }} atmospheres</span><app-convert-icon [kind]="'pressure'" [value]="body().bodyData.surfacePressure" label="Surface pressure" uiUnit="atm" sourceUnit="Pa" />
             </div>
           </div>
           }
@@ -698,7 +698,7 @@
               Rotational period
             </div>
             <div>
-              <span [matTooltip]="body().bodyData.rotationalPeriod + ' days'">{{ getRotationalPeriodDisplay() }}</span><app-convert-icon [kind]="'duration'" [value]="body().bodyData.rotationalPeriod" label="Rotational period" [uiUnit]="durationUnitLabel(body().bodyData.rotationalPeriod)" sourceUnit="Days" />
+              <span [matTooltip]="body().bodyData.rotationalPeriod + ' days'">{{ getRotationalPeriodDisplay() }}</span><app-convert-icon [kind]="'duration'" [value]="body().bodyData.rotationalPeriod" label="Rotational period" [uiUnit]="durationUnitLabel(body().bodyData.rotationalPeriod)" sourceUnit="Seconds" />
             </div>
           </div>
           }

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -197,8 +197,8 @@
               <div>
                 Orbital period
               </div>
-              <div [matTooltip]="body().bodyData.orbitalPeriod + ' days'">
-                {{ getOrbitalPeriodDisplay() }}<app-convert-icon [kind]="'duration'" [value]="body().bodyData.orbitalPeriod" label="Orbital period" [uiUnit]="durationUnitLabel(body().bodyData.orbitalPeriod)" sourceUnit="Days" />
+              <div>
+                <span [matTooltip]="body().bodyData.orbitalPeriod + ' days'">{{ getOrbitalPeriodDisplay() }}</span><app-convert-icon [kind]="'duration'" [value]="body().bodyData.orbitalPeriod" label="Orbital period" [uiUnit]="durationUnitLabel(body().bodyData.orbitalPeriod)" sourceUnit="Days" />
               </div>
             </div>
             }
@@ -207,8 +207,8 @@
               <div>
                 Semi-major axis
               </div>
-              <div [matTooltip]="body().bodyData.semiMajorAxis + ' au'">
-                {{ formatOrbitDistance(getSemiMajorAxisKm()) }}<app-convert-icon [kind]="'length'" [value]="getSemiMajorAxisKm()" label="Semi-major axis" [uiUnit]="orbitDistanceUnitLabel()" sourceUnit="AU" />
+              <div>
+                <span [matTooltip]="body().bodyData.semiMajorAxis + ' au'">{{ formatOrbitDistance(getSemiMajorAxisKm()) }}</span><app-convert-icon [kind]="'length'" [value]="getSemiMajorAxisKm()" label="Semi-major axis" [uiUnit]="orbitDistanceUnitLabel()" sourceUnit="AU" />
               </div>
             </div>
             }
@@ -229,8 +229,8 @@
               <div>
                 Apoapsis<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
               </div>
-              <div [matTooltip]="getApoapsis() + ' km'">
-                {{ formatOrbitDistance(getApoapsis()) }}<app-convert-icon [kind]="'length'" [value]="getApoapsis()" label="Apoapsis" [uiUnit]="orbitDistanceUnitLabel()" />
+              <div>
+                <span [matTooltip]="getApoapsis() + ' km'">{{ formatOrbitDistance(getApoapsis()) }}</span><app-convert-icon [kind]="'length'" [value]="getApoapsis()" label="Apoapsis" [uiUnit]="orbitDistanceUnitLabel()" />
               </div>
             </div>
             }
@@ -250,8 +250,8 @@
               <div>
                 Periapsis<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
               </div>
-              <div [matTooltip]="getPeriapsis() + ' km'">
-                {{ formatOrbitDistance(getPeriapsis()) }}<app-convert-icon [kind]="'length'" [value]="getPeriapsis()" label="Periapsis" [uiUnit]="orbitDistanceUnitLabel()" />
+              <div>
+                <span [matTooltip]="getPeriapsis() + ' km'">{{ formatOrbitDistance(getPeriapsis()) }}</span><app-convert-icon [kind]="'length'" [value]="getPeriapsis()" label="Periapsis" [uiUnit]="orbitDistanceUnitLabel()" />
               </div>
             </div>
             }
@@ -302,8 +302,8 @@
               <div>
                 Tangential velocity
               </div>
-              <div [matTooltip]="getTangentialVelocityTooltip()">
-                {{ getTangentialVelocityDisplay() }}<app-convert-icon [kind]="'velocity'" [value]="getTangentialVelocity()" label="Tangential velocity" [uiUnit]="velocityUnitLabel(getTangentialVelocity())" />
+              <div>
+                <span [matTooltip]="getTangentialVelocityTooltip()">{{ getTangentialVelocityDisplay() }}</span><app-convert-icon [kind]="'velocity'" [value]="getTangentialVelocity()" label="Tangential velocity" [uiUnit]="velocityUnitLabel(getTangentialVelocity())" />
               </div>
             </div>
             }
@@ -319,9 +319,8 @@
                 Roche limit (rigid)<fa-icon class="info-icon" title="Click for more information"
                   [icon]="faInfo"></fa-icon>
               </div>
-              <div
-                   [matTooltip]="'Rigid: ' + (rocheLimits.rigid | number:'0.0-0') + ' km, Periapsis: ' + (rocheLimits.periapsis | number:'0.0-0') + ' km' + (rocheLimits.periapsis < rocheLimits.rigid ? ' - BREACHED' : '')">
-                {{ formatLength(rocheLimits.rigid) }}<app-convert-icon [kind]="'length'" [value]="rocheLimits.rigid" label="Roche limit (rigid)" [uiUnit]="lengthUnitLabel(rocheLimits.rigid)" />
+              <div>
+                <span [matTooltip]="'Rigid: ' + (rocheLimits.rigid | number:'0.0-0') + ' km, Periapsis: ' + (rocheLimits.periapsis | number:'0.0-0') + ' km' + (rocheLimits.periapsis < rocheLimits.rigid ? ' - BREACHED' : '')">{{ formatLength(rocheLimits.rigid) }}</span><app-convert-icon [kind]="'length'" [value]="rocheLimits.rigid" label="Roche limit (rigid)" [uiUnit]="lengthUnitLabel(rocheLimits.rigid)" />
                 @if (rocheLimits.periapsis < rocheLimits.rigid)
                   {
                   <span
@@ -337,9 +336,8 @@
                 Roche limit (fluid)<fa-icon class="info-icon" title="Click for more information"
                   [icon]="faInfo"></fa-icon>
               </div>
-              <div
-                   [matTooltip]="'Fluid: ' + (rocheLimits.fluid | number:'0.0-0') + ' km, Apoapsis: ' + (rocheLimits.apoapsis | number:'0.0-0') + ' km' + (rocheLimits.apoapsis < rocheLimits.fluid ? ' - BREACHED' : '')">
-                {{ formatLength(rocheLimits.fluid) }}<app-convert-icon [kind]="'length'" [value]="rocheLimits.fluid" label="Roche limit (fluid)" [uiUnit]="lengthUnitLabel(rocheLimits.fluid)" />
+              <div>
+                <span [matTooltip]="'Fluid: ' + (rocheLimits.fluid | number:'0.0-0') + ' km, Apoapsis: ' + (rocheLimits.apoapsis | number:'0.0-0') + ' km' + (rocheLimits.apoapsis < rocheLimits.fluid ? ' - BREACHED' : '')">{{ formatLength(rocheLimits.fluid) }}</span><app-convert-icon [kind]="'length'" [value]="rocheLimits.fluid" label="Roche limit (fluid)" [uiUnit]="lengthUnitLabel(rocheLimits.fluid)" />
                 @if (rocheLimits.apoapsis < rocheLimits.fluid)
                   {
                   <span
@@ -361,8 +359,8 @@
             <div>
               Hill sphere radius<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
             </div>
-            <div [matTooltip]="'Gravitational influence radius: ' + (hillData.hillRadius | number:'0.0-0') + ' km'">
-              {{ formatLength(hillData.hillRadius) }}<app-convert-icon [kind]="'length'" [value]="hillData.hillRadius" label="Hill sphere radius" [uiUnit]="lengthUnitLabel(hillData.hillRadius)" />
+            <div>
+              <span [matTooltip]="'Gravitational influence radius: ' + (hillData.hillRadius | number:'0.0-0') + ' km'">{{ formatLength(hillData.hillRadius) }}</span><app-convert-icon [kind]="'length'" [value]="hillData.hillRadius" label="Hill sphere radius" [uiUnit]="lengthUnitLabel(hillData.hillRadius)" />
             </div>
           </div>
           @if (hillData.withinRings || hillData.isFirstOutside) {
@@ -394,8 +392,8 @@
             <div>
               Radius
             </div>
-            <div [matTooltip]="body().bodyData.radius + ' km'">
-              {{ body().bodyData.radius | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="body().bodyData.radius" label="Radius" uiUnit="km" sourceUnit="km" />
+            <div>
+              <span [matTooltip]="body().bodyData.radius + ' km'">{{ body().bodyData.radius | number:'0.2-2' }} km</span><app-convert-icon [kind]="'length'" [value]="body().bodyData.radius" label="Radius" uiUnit="km" sourceUnit="km" />
             </div>
           </div>
           }
@@ -404,8 +402,8 @@
             <div>
               Radius
             </div>
-            <div [matTooltip]="starRadiusKm + ' km'">
-              {{ starRadiusKm | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="starRadiusKm" label="Radius" uiUnit="km" />
+            <div>
+              <span [matTooltip]="starRadiusKm + ' km'">{{ starRadiusKm | number:'0.2-2' }} km</span><app-convert-icon [kind]="'length'" [value]="starRadiusKm" label="Radius" uiUnit="km" />
             </div>
           </div>
           } @else if (body().bodyData.solarRadius) {
@@ -413,8 +411,8 @@
             <div>
               Radius
             </div>
-            <div [matTooltip]="body().bodyData.solarRadius!.toString() + ' R☉'">
-              {{ body().bodyData.solarRadius | number:'0.2-2' }} R☉<app-convert-icon [kind]="'length'" [value]="getSolarRadiusKm()" label="Radius" uiUnit="Solar Radii" sourceUnit="Solar Radii" />
+            <div>
+              <span [matTooltip]="body().bodyData.solarRadius!.toString() + ' R☉'">{{ body().bodyData.solarRadius | number:'0.2-2' }} R☉</span><app-convert-icon [kind]="'length'" [value]="getSolarRadiusKm()" label="Radius" uiUnit="Solar Radii" sourceUnit="Solar Radii" />
             </div>
           </div>
           }
@@ -423,9 +421,9 @@
             <div>
               Schwarzschild radius
             </div>
-            <div [matTooltip]="'Event-horizon radius r_s = 2GM/c² = ' + (schwarzschildRadius | number:'0.2-4') + ' km'"
-                 matTooltipClass="multiline-tooltip">
-              {{ schwarzschildRadius | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="schwarzschildRadius" label="Schwarzschild radius" uiUnit="km" />
+            <div>
+              <span [matTooltip]="'Event-horizon radius r_s = 2GM/c² = ' + (schwarzschildRadius | number:'0.2-4') + ' km'"
+                    matTooltipClass="multiline-tooltip">{{ schwarzschildRadius | number:'0.2-2' }} km</span><app-convert-icon [kind]="'length'" [value]="schwarzschildRadius" label="Schwarzschild radius" uiUnit="km" />
             </div>
           </div>
           }
@@ -459,8 +457,8 @@
             <div>
               Density
             </div>
-            <div [matTooltip]="density.tooltip">
-              {{ density.value | number:'0.2-2' }} {{ density.unit }}<app-convert-icon [kind]="'density'" [value]="density.densityKgM3" label="Density" [uiUnit]="density.unit" />
+            <div>
+              <span [matTooltip]="density.tooltip">{{ density.value | number:'0.2-2' }} {{ density.unit }}</span><app-convert-icon [kind]="'density'" [value]="density.densityKgM3" label="Density" [uiUnit]="density.unit" />
             </div>
           </div>
           }
@@ -507,8 +505,8 @@
             <div>
               Inner radius
             </div>
-            <div [matTooltip]="body().bodyData.innerRadius + ' km'">
-              {{ formatLength(body().bodyData.innerRadius!) }}<app-convert-icon [kind]="'length'" [value]="body().bodyData.innerRadius" label="Inner radius" [uiUnit]="lengthUnitLabel(body().bodyData.innerRadius)" sourceUnit="km" />
+            <div>
+              <span [matTooltip]="body().bodyData.innerRadius + ' km'">{{ formatLength(body().bodyData.innerRadius!) }}</span><app-convert-icon [kind]="'length'" [value]="body().bodyData.innerRadius" label="Inner radius" [uiUnit]="lengthUnitLabel(body().bodyData.innerRadius)" sourceUnit="km" />
             </div>
           </div>
           }
@@ -517,8 +515,8 @@
             <div>
               Outer radius
             </div>
-            <div [matTooltip]="body().bodyData.outerRadius + ' km'">
-              {{ formatLength(body().bodyData.outerRadius!) }}<app-convert-icon [kind]="'length'" [value]="body().bodyData.outerRadius" label="Outer radius" [uiUnit]="lengthUnitLabel(body().bodyData.outerRadius)" sourceUnit="km" />
+            <div>
+              <span [matTooltip]="body().bodyData.outerRadius + ' km'">{{ formatLength(body().bodyData.outerRadius!) }}</span><app-convert-icon [kind]="'length'" [value]="body().bodyData.outerRadius" label="Outer radius" [uiUnit]="lengthUnitLabel(body().bodyData.outerRadius)" sourceUnit="km" />
             </div>
           </div>
           }
@@ -527,8 +525,8 @@
             <div>
               Ring width
             </div>
-            <div [matTooltip]="getRingWidth() + ' km'">
-              {{ formatLength(getRingWidth()) }}<app-convert-icon [kind]="'length'" [value]="getRingWidth()" label="Ring width" [uiUnit]="lengthUnitLabel(getRingWidth())" />
+            <div>
+              <span [matTooltip]="getRingWidth() + ' km'">{{ formatLength(getRingWidth()) }}</span><app-convert-icon [kind]="'length'" [value]="getRingWidth()" label="Ring width" [uiUnit]="lengthUnitLabel(getRingWidth())" />
             </div>
           </div>
           }
@@ -537,8 +535,8 @@
             <div>
               Ring area
             </div>
-            <div [matTooltip]="getRingArea() + ' km²'">
-              {{ formatArea(getRingArea()) }}<app-convert-icon [kind]="'area'" [value]="getRingArea()" label="Ring area" [uiUnit]="areaUnitLabel(getRingArea())" />
+            <div>
+              <span [matTooltip]="getRingArea() + ' km²'">{{ formatArea(getRingArea()) }}</span><app-convert-icon [kind]="'area'" [value]="getRingArea()" label="Ring area" [uiUnit]="areaUnitLabel(getRingArea())" />
             </div>
           </div>
           }
@@ -564,8 +562,8 @@
             <div [matTooltip]="'Orbital period calculated at nominal radius (inner + (outer−inner)×3/8)'">
               Orbital period
             </div>
-            <div [matTooltip]="getRingOrbitalPeriodTooltip()">
-              {{ getRingOrbitalPeriodDisplay() }}<app-convert-icon [kind]="'duration'" [value]="getRingOrbitalPeriod()" label="Orbital period" [uiUnit]="durationUnitLabel(getRingOrbitalPeriod())" />
+            <div>
+              <span [matTooltip]="getRingOrbitalPeriodTooltip()">{{ getRingOrbitalPeriodDisplay() }}</span><app-convert-icon [kind]="'duration'" [value]="getRingOrbitalPeriod()" label="Orbital period" [uiUnit]="durationUnitLabel(getRingOrbitalPeriod())" />
             </div>
           </div>
           }
@@ -574,8 +572,8 @@
             <div [matTooltip]="'Tangential velocity at inner radius using the nominal orbital period'">
               Min velocity
             </div>
-            <div [matTooltip]="getRingMinVelocityTooltip()">
-              {{ getRingMinVelocityDisplay() }}<app-convert-icon [kind]="'velocity'" [value]="getRingMinVelocity()" label="Min velocity" [uiUnit]="velocityUnitLabel(getRingMinVelocity())" />
+            <div>
+              <span [matTooltip]="getRingMinVelocityTooltip()">{{ getRingMinVelocityDisplay() }}</span><app-convert-icon [kind]="'velocity'" [value]="getRingMinVelocity()" label="Min velocity" [uiUnit]="velocityUnitLabel(getRingMinVelocity())" />
             </div>
           </div>
           }
@@ -584,8 +582,8 @@
             <div [matTooltip]="'Tangential velocity at outer radius using the nominal orbital period'">
               Max velocity
             </div>
-            <div [matTooltip]="getRingMaxVelocityTooltip()">
-              {{ getRingMaxVelocityDisplay() }}<app-convert-icon [kind]="'velocity'" [value]="getRingMaxVelocity()" label="Max velocity" [uiUnit]="velocityUnitLabel(getRingMaxVelocity())" />
+            <div>
+              <span [matTooltip]="getRingMaxVelocityTooltip()">{{ getRingMaxVelocityDisplay() }}</span><app-convert-icon [kind]="'velocity'" [value]="getRingMaxVelocity()" label="Max velocity" [uiUnit]="velocityUnitLabel(getRingMaxVelocity())" />
             </div>
           </div>
           }
@@ -594,8 +592,8 @@
             <div>
               Distance {{ getRingNeighbourDistanceLabel() }}
             </div>
-            <div [matTooltip]="getRingNeighbourDistance() + ' km'">
-              {{ getRingNeighbourDistance() | number:'0.0-0' }} km<app-convert-icon [kind]="'length'" [value]="getRingNeighbourDistance()" [label]="'Distance ' + getRingNeighbourDistanceLabel()" uiUnit="km" />
+            <div>
+              <span [matTooltip]="getRingNeighbourDistance() + ' km'">{{ getRingNeighbourDistance() | number:'0.0-0' }} km</span><app-convert-icon [kind]="'length'" [value]="getRingNeighbourDistance()" [label]="'Distance ' + getRingNeighbourDistanceLabel()" uiUnit="km" />
             </div>
           </div>
           }
@@ -604,8 +602,8 @@
             <div>
               Velocity Difference {{ getRingNeighbourDistanceLabel() }}
             </div>
-            <div [matTooltip]="getRingVelocityDiffTooltip()">
-              {{ getRingVelocityDiffDisplay() }}<app-convert-icon [kind]="'velocity'" [value]="getRingVelocityDiff()" [label]="'Velocity Difference ' + getRingNeighbourDistanceLabel()" [uiUnit]="velocityUnitLabel(getRingVelocityDiff())" />
+            <div>
+              <span [matTooltip]="getRingVelocityDiffTooltip()">{{ getRingVelocityDiffDisplay() }}</span><app-convert-icon [kind]="'velocity'" [value]="getRingVelocityDiff()" [label]="'Velocity Difference ' + getRingNeighbourDistanceLabel()" [uiUnit]="velocityUnitLabel(getRingVelocityDiff())" />
             </div>
           </div>
           }
@@ -622,8 +620,8 @@
               Roche limit (rigid)<fa-icon class="info-icon" title="Click for more information"
                 [icon]="faInfo"></fa-icon>
             </div>
-            <div [matTooltip]="'Rigid body Roche limit: ' + calculateRigidRocheLimit()! + ' km'">
-              {{ formatLength(calculateRigidRocheLimit()!) }}<app-convert-icon [kind]="'length'" [value]="calculateRigidRocheLimit()" label="Roche limit (rigid)" [uiUnit]="lengthUnitLabel(calculateRigidRocheLimit())" />
+            <div>
+              <span [matTooltip]="'Rigid body Roche limit: ' + calculateRigidRocheLimit()! + ' km'">{{ formatLength(calculateRigidRocheLimit()!) }}</span><app-convert-icon [kind]="'length'" [value]="calculateRigidRocheLimit()" label="Roche limit (rigid)" [uiUnit]="lengthUnitLabel(calculateRigidRocheLimit())" />
             </div>
           </div>
           }
@@ -633,8 +631,8 @@
               Roche limit (fluid)<fa-icon class="info-icon" title="Click for more information"
                 [icon]="faInfo"></fa-icon>
             </div>
-            <div [matTooltip]="'Fluid body Roche limit: ' + calculateFluidRocheLimit()! + ' km'">
-              {{ formatLength(calculateFluidRocheLimit()!) }}<app-convert-icon [kind]="'length'" [value]="calculateFluidRocheLimit()" label="Roche limit (fluid)" [uiUnit]="lengthUnitLabel(calculateFluidRocheLimit())" />
+            <div>
+              <span [matTooltip]="'Fluid body Roche limit: ' + calculateFluidRocheLimit()! + ' km'">{{ formatLength(calculateFluidRocheLimit()!) }}</span><app-convert-icon [kind]="'length'" [value]="calculateFluidRocheLimit()" label="Roche limit (fluid)" [uiUnit]="lengthUnitLabel(calculateFluidRocheLimit())" />
             </div>
           </div>
           }
@@ -672,9 +670,9 @@
             <div>
               Surface pressure
             </div>
-            <div [matTooltip]="cachedSurfacePressureTooltip() || ''"
-                 matTooltipClass="multiline-tooltip">
-              {{ body().bodyData.surfacePressure | number:'0.2-2' }} atmospheres<app-convert-icon [kind]="'pressure'" [value]="body().bodyData.surfacePressure" label="Surface pressure" uiUnit="atm" sourceUnit="atm" />
+            <div>
+              <span [matTooltip]="cachedSurfacePressureTooltip() || ''"
+                    matTooltipClass="multiline-tooltip">{{ body().bodyData.surfacePressure | number:'0.2-2' }} atmospheres</span><app-convert-icon [kind]="'pressure'" [value]="body().bodyData.surfacePressure" label="Surface pressure" uiUnit="atm" sourceUnit="atm" />
             </div>
           </div>
           }
@@ -699,8 +697,8 @@
             <div>
               Rotational period
             </div>
-            <div [matTooltip]="body().bodyData.rotationalPeriod + ' days'">
-              {{ getRotationalPeriodDisplay() }}<app-convert-icon [kind]="'duration'" [value]="body().bodyData.rotationalPeriod" label="Rotational period" [uiUnit]="durationUnitLabel(body().bodyData.rotationalPeriod)" sourceUnit="Days" />
+            <div>
+              <span [matTooltip]="body().bodyData.rotationalPeriod + ' days'">{{ getRotationalPeriodDisplay() }}</span><app-convert-icon [kind]="'duration'" [value]="body().bodyData.rotationalPeriod" label="Rotational period" [uiUnit]="durationUnitLabel(body().bodyData.rotationalPeriod)" sourceUnit="Days" />
             </div>
           </div>
           }
@@ -710,8 +708,8 @@
             <div>
               Distance to arrival
             </div>
-            <div [matTooltip]="body().bodyData.distanceToArrival + ' ls'">
-              {{ formatDistanceLs(body().bodyData.distanceToArrival!) }}<app-convert-icon [kind]="'length'" [value]="getDistanceToArrivalKm()" label="Distance to arrival" [uiUnit]="distanceUnitLabel(getDistanceToArrivalKm())" sourceUnit="Light seconds" />
+            <div>
+              <span [matTooltip]="body().bodyData.distanceToArrival + ' ls'">{{ formatDistanceLs(body().bodyData.distanceToArrival!) }}</span><app-convert-icon [kind]="'length'" [value]="getDistanceToArrivalKm()" label="Distance to arrival" [uiUnit]="distanceUnitLabel(getDistanceToArrivalKm())" sourceUnit="Light seconds" />
             </div>
           </div>
           }

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -198,7 +198,7 @@
                 Orbital period
               </div>
               <div [matTooltip]="body().bodyData.orbitalPeriod + ' days'">
-                {{ getOrbitalPeriodDisplay() }}
+                {{ getOrbitalPeriodDisplay() }}<app-convert-icon [kind]="'duration'" [value]="body().bodyData.orbitalPeriod" label="Orbital period" />
               </div>
             </div>
             }
@@ -208,7 +208,7 @@
                 Semi-major axis
               </div>
               <div [matTooltip]="body().bodyData.semiMajorAxis + ' au'">
-                {{ (body().bodyData.semiMajorAxis! * 149597870.7) | number:'0.2-2' }} km
+                {{ (body().bodyData.semiMajorAxis! * 149597870.7) | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="getSemiMajorAxisKm()" label="Semi-major axis" />
               </div>
             </div>
             }
@@ -230,7 +230,7 @@
                 Apoapsis<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
               </div>
               <div [matTooltip]="getApoapsis() + ' km'">
-                {{ getApoapsis() | number:'0.2-2' }} km
+                {{ getApoapsis() | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="getApoapsis()" label="Apoapsis" />
               </div>
             </div>
             }
@@ -251,7 +251,7 @@
                 Periapsis<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
               </div>
               <div [matTooltip]="getPeriapsis() + ' km'">
-                {{ getPeriapsis() | number:'0.2-2' }} km
+                {{ getPeriapsis() | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="getPeriapsis()" label="Periapsis" />
               </div>
             </div>
             }
@@ -303,7 +303,7 @@
                 Tangential velocity
               </div>
               <div [matTooltip]="getTangentialVelocityTooltip()">
-                {{ getTangentialVelocityDisplay() }}
+                {{ getTangentialVelocityDisplay() }}<app-convert-icon [kind]="'velocity'" [value]="getTangentialVelocity()" label="Tangential velocity" />
               </div>
             </div>
             }
@@ -320,9 +320,12 @@
                   [icon]="faInfo"></fa-icon>
               </div>
               <div
-                [matTooltip]="'Rigid: ' + (rocheLimits.rigid | number:'0.0-0') + ' km, Periapsis: ' + (rocheLimits.periapsis | number:'0.0-0') + ' km' + (rocheLimits.periapsis < rocheLimits.rigid ? ' - BREACHED' : '')">
-                {{ rocheLimits.rigid | number:'0.2-2' }} km
-                @if (rocheLimits.periapsis < rocheLimits.rigid) { <span class="status-danger">⚠</span>
+                   [matTooltip]="'Rigid: ' + (rocheLimits.rigid | number:'0.0-0') + ' km, Periapsis: ' + (rocheLimits.periapsis | number:'0.0-0') + ' km' + (rocheLimits.periapsis < rocheLimits.rigid ? ' - BREACHED' : '')">
+                {{ formatLength(rocheLimits.rigid) }}<app-convert-icon [kind]="'length'" [value]="rocheLimits.rigid" label="Roche limit (rigid)" />
+                @if (rocheLimits.periapsis < rocheLimits.rigid)
+                  {
+                  <span
+                  class="status-danger">⚠</span>
                   }
                   @if (rocheLimits.periapsis >= rocheLimits.rigid) {
                   <span class="status-success">✓</span>
@@ -335,9 +338,12 @@
                   [icon]="faInfo"></fa-icon>
               </div>
               <div
-                [matTooltip]="'Fluid: ' + (rocheLimits.fluid | number:'0.0-0') + ' km, Apoapsis: ' + (rocheLimits.apoapsis | number:'0.0-0') + ' km' + (rocheLimits.apoapsis < rocheLimits.fluid ? ' - BREACHED' : '')">
-                {{ rocheLimits.fluid | number:'0.2-2' }} km
-                @if (rocheLimits.apoapsis < rocheLimits.fluid) { <span class="status-danger">⚠</span>
+                   [matTooltip]="'Fluid: ' + (rocheLimits.fluid | number:'0.0-0') + ' km, Apoapsis: ' + (rocheLimits.apoapsis | number:'0.0-0') + ' km' + (rocheLimits.apoapsis < rocheLimits.fluid ? ' - BREACHED' : '')">
+                {{ formatLength(rocheLimits.fluid) }}<app-convert-icon [kind]="'length'" [value]="rocheLimits.fluid" label="Roche limit (fluid)" />
+                @if (rocheLimits.apoapsis < rocheLimits.fluid)
+                  {
+                  <span
+                  class="status-danger">⚠</span>
                   }
                   @if (rocheLimits.apoapsis >= rocheLimits.fluid) {
                   <span class="status-success">✓</span>
@@ -356,7 +362,7 @@
               Hill sphere radius<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
             </div>
             <div [matTooltip]="'Gravitational influence radius: ' + (hillData.hillRadius | number:'0.0-0') + ' km'">
-              {{ hillData.hillRadius | number:'0.2-2' }} km
+              {{ formatLength(hillData.hillRadius) }}<app-convert-icon [kind]="'length'" [value]="hillData.hillRadius" label="Hill sphere radius" />
             </div>
           </div>
           @if (hillData.withinRings || hillData.isFirstOutside) {
@@ -389,26 +395,26 @@
               Radius
             </div>
             <div [matTooltip]="body().bodyData.radius + ' km'">
-              {{ body().bodyData.radius | number:'0.2-2' }} km
+              {{ body().bodyData.radius | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="body().bodyData.radius" label="Radius" />
             </div>
           </div>
           }
-          @if (getCompactObjectRadiusKm(); as compactRadiusKm) {
+          @if (getStarRadiusKm(); as starRadiusKm) {
           <div class="body-data-entry">
             <div>
               Radius
             </div>
-            <div [matTooltip]="compactRadiusKm + ' km'">
-              {{ compactRadiusKm | number:'0.2-2' }} km
+            <div [matTooltip]="starRadiusKm + ' km'">
+              {{ starRadiusKm | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="starRadiusKm" label="Radius" />
             </div>
           </div>
           } @else if (body().bodyData.solarRadius) {
           <div class="body-data-entry">
             <div>
-              Solar radius
+              Radius
             </div>
-            <div [matTooltip]="body().bodyData.solarRadius!.toString()">
-              {{ body().bodyData.solarRadius | number:'0.2-2' }}
+            <div [matTooltip]="body().bodyData.solarRadius!.toString() + ' R☉'">
+              {{ body().bodyData.solarRadius | number:'0.2-2' }} R☉<app-convert-icon [kind]="'length'" [value]="getSolarRadiusKm()" label="Radius" />
             </div>
           </div>
           }
@@ -418,45 +424,23 @@
               Schwarzschild radius
             </div>
             <div [matTooltip]="'Event-horizon radius r_s = 2GM/c² = ' + (schwarzschildRadius | number:'0.2-4') + ' km'"
-              matTooltipClass="multiline-tooltip">
-              {{ schwarzschildRadius | number:'0.2-2' }} km
+                 matTooltipClass="multiline-tooltip">
+              {{ schwarzschildRadius | number:'0.2-2' }} km<app-convert-icon [kind]="'length'" [value]="schwarzschildRadius" label="Schwarzschild radius" />
             </div>
           </div>
           }
-          @if (body().bodyData.earthMasses && body().bodyData.type === 'Planet') {
+          @if (getMassKg(); as massKg) {
           <div class="body-data-entry">
             <div>
               Mass
             </div>
-            <div [matTooltip]="formattedEarthMass?.tooltip || ''">
-              {{ formattedEarthMass?.display }}
-            </div>
-          </div>
-          }
-          @if (body().bodyData.solarMasses) {
-          <div class="body-data-entry">
             <div>
-              Solar masses
-            </div>
-            <div>
-              <span [matTooltip]="formattedSolarMass?.tooltip || ''">
-                {{ formattedSolarMass?.display }}
-              </span>
+              <span [matTooltip]="getMassTooltip()">{{ formatMass(massKg) }}</span><app-convert-icon [kind]="'mass'" [value]="massKg" label="Mass" />
               @if (getMassStabilityAlert(); as massAlert) {
               <span [class.status-danger]="massAlert.severity === 'danger'"
                 [class.status-warning]="massAlert.severity === 'warning'" [matTooltip]="massAlert.message"
                 matTooltipClass="multiline-tooltip">⚠</span>
               }
-            </div>
-          </div>
-          }
-          @if (body().bodyData.mass) {
-          <div class="body-data-entry">
-            <div>
-              Mass
-            </div>
-            <div [matTooltip]="body().bodyData.mass + ' Mt'">
-              {{ body().bodyData.mass | number:'0.2-2' }} Mt
             </div>
           </div>
           }
@@ -470,13 +454,13 @@
             </div>
           </div>
           }
-          @if (getPlanetaryDensity()) {
+          @if (getPlanetaryDensity(); as density) {
           <div class="body-data-entry">
             <div>
               Density
             </div>
-            <div [matTooltip]="getPlanetaryDensity()!.tooltip">
-              {{ getPlanetaryDensity()!.value | number:'0.2-2' }} {{ getPlanetaryDensity()!.unit }}
+            <div [matTooltip]="density.tooltip">
+              {{ density.value | number:'0.2-2' }} {{ density.unit }}<app-convert-icon [kind]="'density'" [value]="density.densityKgM3" label="Density" />
             </div>
           </div>
           }
@@ -524,7 +508,7 @@
               Inner radius
             </div>
             <div [matTooltip]="body().bodyData.innerRadius + ' km'">
-              {{ body().bodyData.innerRadius | number:'0.2-2' }} km
+              {{ formatLength(body().bodyData.innerRadius!) }}<app-convert-icon [kind]="'length'" [value]="body().bodyData.innerRadius" label="Inner radius" />
             </div>
           </div>
           }
@@ -534,7 +518,7 @@
               Outer radius
             </div>
             <div [matTooltip]="body().bodyData.outerRadius + ' km'">
-              {{ body().bodyData.outerRadius | number:'0.2-2' }} km
+              {{ formatLength(body().bodyData.outerRadius!) }}<app-convert-icon [kind]="'length'" [value]="body().bodyData.outerRadius" label="Outer radius" />
             </div>
           </div>
           }
@@ -544,7 +528,7 @@
               Ring width
             </div>
             <div [matTooltip]="getRingWidth() + ' km'">
-              {{ getRingWidth() | number:'0.2-2' }} km
+              {{ formatLength(getRingWidth()) }}<app-convert-icon [kind]="'length'" [value]="getRingWidth()" label="Ring width" />
             </div>
           </div>
           }
@@ -554,7 +538,7 @@
               Ring area
             </div>
             <div [matTooltip]="getRingArea() + ' km²'">
-              {{ getRingArea() | number:'0.2-2' }} km²
+              {{ formatArea(getRingArea()) }}<app-convert-icon [kind]="'area'" [value]="getRingArea()" label="Ring area" />
             </div>
           </div>
           }
@@ -639,7 +623,7 @@
                 [icon]="faInfo"></fa-icon>
             </div>
             <div [matTooltip]="'Rigid body Roche limit: ' + calculateRigidRocheLimit()! + ' km'">
-              {{ calculateRigidRocheLimit()! | number:'0.2-2' }} km
+              {{ formatLength(calculateRigidRocheLimit()!) }}<app-convert-icon [kind]="'length'" [value]="calculateRigidRocheLimit()" label="Roche limit (rigid)" />
             </div>
           </div>
           }
@@ -650,7 +634,7 @@
                 [icon]="faInfo"></fa-icon>
             </div>
             <div [matTooltip]="'Fluid body Roche limit: ' + calculateFluidRocheLimit()! + ' km'">
-              {{ calculateFluidRocheLimit()! | number:'0.2-2' }} km
+              {{ formatLength(calculateFluidRocheLimit()!) }}<app-convert-icon [kind]="'length'" [value]="calculateFluidRocheLimit()" label="Roche limit (fluid)" />
             </div>
           </div>
           }
@@ -688,8 +672,9 @@
             <div>
               Surface pressure
             </div>
-            <div [matTooltip]="cachedSurfacePressureTooltip() || ''" matTooltipClass="multiline-tooltip">
-              {{ body().bodyData.surfacePressure | number:'0.2-2' }} atmospheres
+            <div [matTooltip]="cachedSurfacePressureTooltip() || ''"
+                 matTooltipClass="multiline-tooltip">
+              {{ body().bodyData.surfacePressure | number:'0.2-2' }} atmospheres<app-convert-icon [kind]="'pressure'" [value]="body().bodyData.surfacePressure" label="Surface pressure" />
             </div>
           </div>
           }
@@ -715,7 +700,7 @@
               Rotational period
             </div>
             <div [matTooltip]="body().bodyData.rotationalPeriod + ' days'">
-              {{ getRotationalPeriodDisplay() }}
+              {{ getRotationalPeriodDisplay() }}<app-convert-icon [kind]="'duration'" [value]="body().bodyData.rotationalPeriod" label="Rotational period" />
             </div>
           </div>
           }
@@ -726,7 +711,7 @@
               Distance to arrival
             </div>
             <div [matTooltip]="body().bodyData.distanceToArrival + ' ls'">
-              {{ body().bodyData.distanceToArrival | number:'0.2-2' }} ls
+              {{ formatDistanceLs(body().bodyData.distanceToArrival!) }}<app-convert-icon [kind]="'length'" [value]="getDistanceToArrivalKm()" label="Distance to arrival" />
             </div>
           </div>
           }

--- a/src/app/system-body/system-body.component.scss
+++ b/src/app/system-body/system-body.component.scss
@@ -210,6 +210,13 @@
     overflow-wrap: anywhere;
 }
 
+/* Values that have no "⇄" convert affordance reserve the same trailing gutter the icon
+   would occupy (margin-left 6px + width 14px), so every value's text right-edge lines up
+   in one column whether or not it is convertible. */
+.system-body .body-data-entry > div:last-child:not(:has(.convert-icon)):not(:has(.unit-select-field)) {
+    padding-right: 20px;
+}
+
 /* ---------------------------------------------------------------------------
  * Responsive — small screens (phones).
  * ------------------------------------------------------------------------- */

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -30,6 +30,19 @@ import { formatBodyJson } from '../dialogs/json-dialog/format-body-json';
 import type { LagrangeDialogData } from '../dialogs/lagrange-dialog/lagrange-dialog.component';
 import type { OnFootSafetyDialogData } from '../dialogs/on-foot-safety-dialog/on-foot-safety-dialog.component';
 import { StellarAgeAssessment, assessStellarAge, isPlottableStarClass } from '../data/stellar-reference';
+import { ConvertIconComponent } from '../dialogs/unit-conversion-dialog/convert-icon.component';
+import {
+  formatDynamicArea,
+  formatDynamicDistanceLs,
+  formatDynamicLength,
+  formatDynamicMass,
+  KM_PER_AU,
+  KM_PER_LIGHT_SECOND,
+  KM_PER_SOLAR_RADIUS,
+  KG_PER_EARTH_MASS,
+  KG_PER_MEGATONNE,
+  KG_PER_SOLAR_MASS,
+} from '../data/unit-conversions';
 
 /** Horizon (days) over which simultaneous (multi-body) collisions are scanned for the dialog's section. */
 const SIMULTANEOUS_COLLISION_HORIZON_DAYS = 180;
@@ -66,7 +79,7 @@ const RACING_RINGS_MIN_SPEED_DIFF_KMS = 5;
   templateUrl: './system-body.component.html',
   styleUrls: ['./system-body.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FaIconComponent, MatTooltip, DecimalPipe, DatePipe, ClickableDirective]
+  imports: [FaIconComponent, MatTooltip, DecimalPipe, DatePipe, ClickableDirective, ConvertIconComponent]
 })
 export class SystemBodyComponent implements OnChanges {
   private readonly appService = inject(AppService);
@@ -122,9 +135,6 @@ export class SystemBodyComponent implements OnChanges {
   public readonly expanded = signal(false);
 
   public hoveredIndex: number = -1;
-
-  public formattedEarthMass: { display: string; tooltip: string } | null = null;
-  public formattedSolarMass: { display: string; tooltip: string } | null = null;
 
   // Cache for expensive computed properties
   public readonly getMaterialBadges = signal<{ name: string, class: string, tooltip: string }[]>([]);
@@ -230,14 +240,6 @@ export class SystemBodyComponent implements OnChanges {
     this.getNextApoapsis.set(this.calculateNextApoapsis());
     this.getRocheExcess.set(this.calculateRocheExcess());
     this.getStellarAgeAssessment.set(this.computeStellarAgeAssessment());
-
-    // Calculate formatted mass values once when body changes
-    this.formattedEarthMass = body.bodyData.earthMasses
-      ? this.formatEarthMass(body.bodyData.earthMasses)
-      : null;
-    this.formattedSolarMass = body.bodyData.solarMasses
-      ? this.formatSolarMass(body.bodyData.solarMasses)
-      : null;
 
     this.bodyCoronaImage = "";
     this.bodyImage = "";
@@ -664,19 +666,66 @@ export class SystemBodyComponent implements OnChanges {
       && isPlottableStarClass(bodyData.spectralClass, bodyData.subType);
   }
 
-  public formatEarthMass(earthMasses: number): { display: string; tooltip: string } {
-    return {
-      display: `${earthMasses.toFixed(2)} Earth masses`,
-      tooltip: `${earthMasses} Earth masses`
-    };
+  // --- Inline dynamic-by-magnitude formatters (delegated to the shared pure module) ---
+  public formatLength(km: number): string { return formatDynamicLength(km); }
+  public formatDistanceLs(ls: number): string { return formatDynamicDistanceLs(ls); }
+  public formatMass(kg: number): string { return formatDynamicMass(kg); }
+  public formatArea(km2: number): string { return formatDynamicArea(km2); }
+
+  /** This body's mass in kilograms from whichever source field it carries, or null. */
+  public getMassKg(): number | null {
+    const bd = this.body().bodyData;
+    if (bd.solarMasses != null) { return bd.solarMasses * KG_PER_SOLAR_MASS; }
+    if (bd.earthMasses != null) { return bd.earthMasses * KG_PER_EARTH_MASS; }
+    if (bd.mass != null) { return bd.mass * KG_PER_MEGATONNE; }
+    return null;
   }
 
-  public formatSolarMass(solarMasses: number): { display: string; tooltip: string } {
-    return {
-      display: `${solarMasses.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
-      tooltip: `${solarMasses.toLocaleString('en-US', { maximumFractionDigits: 20 })} Solar masses`
-    };
+  /** Tooltip for the mass row: the value in its stored unit at full precision. */
+  public getMassTooltip(): string {
+    const bd = this.body().bodyData;
+    if (bd.solarMasses != null) {
+      return `${bd.solarMasses.toLocaleString('en-US', { maximumFractionDigits: 20 })} Solar masses`;
+    }
+    if (bd.earthMasses != null) { return `${bd.earthMasses} Earth masses`; }
+    if (bd.mass != null) { return `${bd.mass} Mt`; }
+    return '';
   }
+
+  /** This body's semi-major axis in km (stored in AU), or null. */
+  public getSemiMajorAxisKm(): number | null {
+    const au = this.body().bodyData.semiMajorAxis;
+    return au == null ? null : au * KM_PER_AU;
+  }
+
+  /** This body's distance-to-arrival in km (stored in light-seconds), or null. */
+  public getDistanceToArrivalKm(): number | null {
+    const ls = this.body().bodyData.distanceToArrival;
+    return ls == null ? null : ls * KM_PER_LIGHT_SECOND;
+  }
+
+  /** An ordinary star's radius in km (stored in solar radii), for the conversion dialog; null if absent. */
+  public getSolarRadiusKm(): number | null {
+    const solarRadius = this.body().bodyData.solarRadius;
+    return solarRadius == null ? null : solarRadius * KM_PER_SOLAR_RADIUS;
+  }
+
+  /**
+   * Physical radius in km for stars shown in km rather than solar radii: neutron stars,
+   * black holes (compact objects) and — per the display spec — white dwarfs. Null for
+   * ordinary stars, which keep solar radii. Kept distinct from {@link isBlackHoleOrNeutronStar}
+   * so the tangential-velocity gate stays compact-object-only.
+   */
+  public getStarRadiusKm(): number | null {
+    const compact = this.getCompactObjectRadiusKm();
+    if (compact !== null) { return compact; }
+    const bd = this.body().bodyData;
+    if (bd.subType?.startsWith('White Dwarf')) {
+      return this.stellarPhysics.radiusKm(bd.radius, bd.solarRadius);
+    }
+    return null;
+  }
+
 
 
   /**

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -32,10 +32,17 @@ import type { OnFootSafetyDialogData } from '../dialogs/on-foot-safety-dialog/on
 import { StellarAgeAssessment, assessStellarAge, isPlottableStarClass } from '../data/stellar-reference';
 import { ConvertIconComponent } from '../dialogs/unit-conversion-dialog/convert-icon.component';
 import {
+  dynamicAreaUnitLabel,
+  dynamicDistanceUnitLabel,
+  dynamicLengthUnitLabel,
+  dynamicMassUnitLabel,
   formatDynamicArea,
   formatDynamicDistanceLs,
   formatDynamicLength,
   formatDynamicMass,
+  formatLengthInUnit,
+  InlineLengthUnit,
+  pickInlineLengthUnit,
   KM_PER_AU,
   KM_PER_LIGHT_SECOND,
   KM_PER_SOLAR_RADIUS,
@@ -671,6 +678,53 @@ export class SystemBodyComponent implements OnChanges {
   public formatDistanceLs(ls: number): string { return formatDynamicDistanceLs(ls); }
   public formatMass(kg: number): string { return formatDynamicMass(kg); }
   public formatArea(km2: number): string { return formatDynamicArea(km2); }
+
+  // --- Conversion-dialog "shown in UI" unit labels (which dialog row to accent). ---
+  public lengthUnitLabel(km: number | null | undefined): string {
+    return km == null ? '' : dynamicLengthUnitLabel(km);
+  }
+  public distanceUnitLabel(km: number | null | undefined): string {
+    return km == null ? '' : dynamicDistanceUnitLabel(km);
+  }
+  public massUnitLabel(kg: number | null | undefined): string {
+    return kg == null ? '' : dynamicMassUnitLabel(kg);
+  }
+  public areaUnitLabel(km2: number | null | undefined): string {
+    return km2 == null ? '' : dynamicAreaUnitLabel(km2);
+  }
+  /** Dialog-row label for the inline duration unit chosen by {@link formatPeriodDays}. */
+  public durationUnitLabel(days: number | null | undefined): string {
+    if (days == null || !Number.isFinite(days)) { return ''; }
+    return this.periodParts(days).label;
+  }
+  /** Dialog-row label for the inline velocity unit chosen by {@link formatVelocityKms}. */
+  public velocityUnitLabel(kms: number | null | undefined): string {
+    if (kms == null || !Number.isFinite(kms)) { return ''; }
+    return this.isRelativistic(kms) ? 'c (fraction of light)' : 'km/s';
+  }
+  /** Native (journal/API) mass unit for this body, by which field carries it. */
+  public massSourceUnit(): string {
+    const bd = this.body().bodyData;
+    if (bd.solarMasses != null) { return 'Solar Masses'; }
+    if (bd.earthMasses != null) { return 'Earth Masses'; }
+    if (bd.mass != null) { return 'Megatonnes'; }
+    return '';
+  }
+
+  // --- Shared orbit-distance unit: semi-major axis, apoapsis and periapsis (#5). ---
+  /**
+   * One length unit shared by the semi-major-axis/apoapsis/periapsis trio, chosen from the
+   * semi-major axis (the orbit's representative scale; apoapsis ≤ 2a and periapsis ≥ 0 stay
+   * the same order of magnitude). Falls back to apoapsis then periapsis when absent.
+   */
+  public orbitDistanceUnit(): InlineLengthUnit {
+    const rep = this.getSemiMajorAxisKm() ?? (this.getApoapsis() || this.getPeriapsis() || 0);
+    return pickInlineLengthUnit(rep);
+  }
+  public formatOrbitDistance(km: number | null | undefined): string {
+    return km == null ? '' : formatLengthInUnit(km, this.orbitDistanceUnit());
+  }
+  public orbitDistanceUnitLabel(): string { return this.orbitDistanceUnit().label; }
 
   /** This body's mass in kilograms from whichever source field it carries, or null. */
   public getMassKg(): number | null {
@@ -1420,34 +1474,45 @@ export class SystemBodyComponent implements OnChanges {
     }
   }
 
+  /** True when a velocity is fast enough to read as a fraction of c rather than km/s. */
+  private isRelativistic(velocityKms: number): boolean {
+    return velocityKms / (SPEED_OF_LIGHT / 1000) >= 0.01;
+  }
+
   private formatVelocityKms(velocityKms: number): string {
-    const fractionOfC = velocityKms / (SPEED_OF_LIGHT / 1000);
-    if (fractionOfC >= 0.01) {
-      return `${fractionOfC.toFixed(3)}c`;
+    if (this.isRelativistic(velocityKms)) {
+      return `${(velocityKms / (SPEED_OF_LIGHT / 1000)).toFixed(3)}c`;
     }
     return `${velocityKms.toFixed(3)} km/s`;
   }
 
-  private formatPeriodDays(days: number): string {
+  /**
+   * The unit a period reads in at this magnitude: numeric value, inline abbreviation, and
+   * the matching conversion-dialog row label ('' for ms/s/decades/centuries, which have no
+   * dialog row). Single source for both {@link formatPeriodDays} and {@link durationUnitLabel}.
+   */
+  private periodParts(days: number): { value: number; unit: string; label: string } {
     const absDays = Math.abs(days);
     const seconds = absDays * 86400;
     const minutes = seconds / 60;
     const hours = minutes / 60;
     const weeks = absDays / 7;
     const years = absDays / 365.25;
-    const decades = years / 10;
-    const centuries = years / 100;
-    const sign = days < 0 ? '-' : '';
 
-    if (seconds < 1) return `${sign}${(seconds * 1000).toFixed(2)} ms`;
-    if (seconds < 60) return `${sign}${seconds.toFixed(2)} s`;
-    if (minutes < 60) return `${sign}${minutes.toFixed(2)} min`;
-    if (hours < 24) return `${sign}${hours.toFixed(2)} h`;
-    if (absDays < 7) return `${sign}${absDays.toFixed(2)} days`;
-    if (weeks < 52) return `${sign}${weeks.toFixed(2)} weeks`;
-    if (years < 10) return `${sign}${years.toFixed(2)} years`;
-    if (decades < 10) return `${sign}${decades.toFixed(2)} decades`;
-    return `${sign}${centuries.toFixed(2)} centuries`;
+    if (seconds < 1) return { value: seconds * 1000, unit: 'ms', label: '' };
+    if (seconds < 60) return { value: seconds, unit: 's', label: '' };
+    if (minutes < 60) return { value: minutes, unit: 'min', label: 'Minutes' };
+    if (hours < 24) return { value: hours, unit: 'h', label: 'Hours' };
+    if (absDays < 7) return { value: absDays, unit: 'days', label: 'Days' };
+    if (weeks < 52) return { value: weeks, unit: 'weeks', label: 'Weeks' };
+    if (years < 10) return { value: years, unit: 'years', label: 'Years' };
+    if (years / 10 < 10) return { value: years / 10, unit: 'decades', label: '' };
+    return { value: years / 100, unit: 'centuries', label: '' };
+  }
+
+  private formatPeriodDays(days: number): string {
+    const { value, unit } = this.periodParts(days);
+    return `${days < 0 ? '-' : ''}${value.toFixed(2)} ${unit}`;
   }
 
   public getRotationalPeriodDisplay(): string {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -211,8 +211,13 @@ hr {
   cursor: pointer;
 }
 
-/* Small "⇄" affordance after an attribute value that opens its unit-conversion dialog. */
+/* Small "⇄" affordance after an attribute value that opens its unit-conversion dialog.
+   A fixed-width box so the icons line up in a column and values without one can reserve
+   the exact same gutter (see .body-data-entry gutter rule in system-body.component.scss). */
 .convert-icon {
+  display: inline-block;
+  width: 14px;
+  text-align: center;
   margin-left: 6px;
   font-size: 0.8em;
   vertical-align: middle;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -215,9 +215,14 @@ hr {
    A fixed-width box so the icons line up in a column and values without one can reserve
    the exact same gutter (see .body-data-entry gutter rule in system-body.component.scss). */
 .convert-icon {
-  display: inline-block;
+  // inline-flex + a content-height box lets vertical-align: middle centre the glyph on the
+  // value text. (A plain inline-block leaves the FontAwesome svg's own vertical-align: -0.125em
+  // and the line-box strut in play, which drops the icon toward the value's baseline.)
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 14px;
-  text-align: center;
+  height: 1em;
   margin-left: 6px;
   font-size: 0.8em;
   vertical-align: middle;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -211,6 +211,22 @@ hr {
   cursor: pointer;
 }
 
+/* Small "⇄" affordance after an attribute value that opens its unit-conversion dialog. */
+.convert-icon {
+  margin-left: 6px;
+  font-size: 0.8em;
+  vertical-align: middle;
+  color: var(--color-text);
+  opacity: 0.6;
+  cursor: pointer;
+}
+
+.convert-icon:hover,
+.convert-icon:focus-visible {
+  opacity: 1;
+  color: var(--color-white);
+}
+
 .multiline-tooltip {
   white-space: pre-line;
 }


### PR DESCRIPTION
Adds a small "⇄" icon after each convertible body/star value that opens a dialog listing the value in every scale unit of its kind, each copyable by clicking it (mass also shows silly everyday-object comparisons). Inline units now adapt by magnitude where multiple units were requested.

- New pure module data/unit-conversions.ts: constants (single source of truth, now imported by body-physics/stellar-physics), buildConversions() table builder, buildMassComparisons(), and formatDynamic{Length,DistanceLs,Mass, Area} formatters. Units listed largest-unit-first.
- New UnitConversionDialogComponent (click a value to copy) and a reusable ConvertIconComponent affordance.
- system-body: convert icons on length/duration/mass/velocity/density/area/ pressure rows; dynamic inline display for distance (ls/ly), ring geometry, Roche/Hill and mass; density gains a Mt/cm³ tier.
- Relabel "Solar radius"→"Radius" and "Solar masses"→"Mass"; white dwarfs now show radius in km.
- Unit + e2e coverage for the module, dialog, icon and rendered rows.

<img width="1376" height="686" alt="image" src="https://github.com/user-attachments/assets/7ae66e43-d3c2-4b59-98ed-efb69d272db2" />
<img width="1050" height="680" alt="image" src="https://github.com/user-attachments/assets/9143beaf-f54e-41c9-a8b9-c0ff04274937" />

Closes #58

---

## Follow-up — UI/source unit highlighting, shared orbit unit, ring dynamics, alignment

- **Dialog "Value" header** is right-aligned to match the right-aligned values.
- **Dialog row highlighting:** the row whose unit is the one currently shown inline in the UI is **accented** (left bar + tint); the row whose unit is the value's **native game-journal unit** gets a small **"from journal"** badge. The accent is the UI indicator — the UI-unit row itself has no badge. (These can differ, e.g. Radius shows km in the UI but the game journal records it in **metres**, so the m row is badged.)
- **Inline alignment:** values that have no ⇄ icon reserve the same trailing gutter (via a `:has()` rule), so every value's text right-edge lines up in one column.
- **Shared orbit unit:** Semi-major axis, apoapsis and periapsis now pick **one** length unit together, chosen from the semi-major axis, so the trio always reads in the same unit.
- **Belts/rings Dynamics** rows gained ⇄ conversions (orbital period, min/max velocity, distance to neighbour, velocity difference).
- The inline-unit choice is single-sourced (`pickInline{Length,Mass,Area}Unit`, `periodParts`, `isRelativistic`) so the inline display and the dialog's accented row cannot drift apart.

Later polish (dialog UX + source-unit accuracy):
- Dialog **auto-sizes** to its content up to the shared max-height, and the ⇄ dialog is lazy-loaded like the other body dialogs.
- The ⇄ icon is vertically centred on the value; the value's own tooltip and the ⇄ "Show in other units" tooltip are separated so hovering one no longer shows the other.
- **"from journal" now names the real game-journal unit.** Body data reaches the app via the Canonn/Spansh API, which *pre-converts* most fields, but the badge is meant to name the unit the **game journal** records. Corrected accordingly (see the source column below): lengths → **m**, pressure → **Pa**, periods → **Seconds** (a Seconds row was added to the duration table). The badge tooltip now reads "The unit this value is recorded in by the game journal".

### Conversion categories (dialog unit tables)

| Category (`kind`) | Units listed (largest-first) |
| --- | --- |
| length | Light Years, AU, Solar Radii, Light seconds, km, m |
| duration | Years, Weeks, Days, Hours, Minutes, Seconds |
| mass | Solar Masses, Earth Masses, Megatonnes |
| velocity | c (fraction of light), km/s |
| density | Mt/cm³, g/cm³, kg/m³ |
| area | Ls², km² |
| pressure | atm, psi, kPa, Pa |

### Rows → category, inline units, and the game-journal source unit

The **source** column is the unit the value is recorded in by the game journal (badged "from journal"). The app receives these from the Canonn/Spansh API already converted (e.g. semi-major axis in AU, radius in km, periods in days), so the source unit is the journal's original, not the API's. Computed/derived values have **no** source unit (no badge).

| Row | Category | Inline unit(s) shown | Game-journal source unit |
| --- | --- | --- | --- |
| Orbital period | duration | dynamic (ms…centuries) | **Seconds** (`OrbitalPeriod`) |
| Semi-major axis | length | shared orbit unit (m/km/ls/ly) | **m** (`SemiMajorAxis`) |
| Apoapsis | length | shared orbit unit | — (computed) |
| Periapsis | length | shared orbit unit | — (computed) |
| Tangential velocity | velocity | km/s or c | — (computed) |
| Roche limit (rigid/fluid) | length | dynamic (m/km/ls/ly) | — (computed) |
| Hill sphere radius | length | dynamic | — (computed) |
| Radius (planet) | length | km | **m** (`Radius`) |
| Radius (compact star) | length | km | — (derived) |
| Radius (ordinary star) | length | R☉ | **m** (`Radius`) |
| Schwarzschild radius | length | km | — (computed) |
| Mass | mass | dynamic (Mt/Earth/Solar) | the field it arrives in — Solar Masses / Earth Masses / Megatonnes (`StellarMass`/`MassEM`/`MassMT`) |
| Density | density | dynamic (kg/m³, g/cm³, Mt/cm³) | — (computed) |
| Inner / Outer radius | length | dynamic | **m** (`InnerRad`/`OuterRad`) |
| Ring width | length | dynamic | — (computed) |
| Ring area | area | dynamic (km²/ls²) | — (computed) |
| Surface pressure | pressure | atm | **Pa** (`SurfacePressure`) |
| Rotational period | duration | dynamic | **Seconds** (`RotationPeriod`) |
| Distance to arrival | length | ls/ly | Light seconds (`DistanceFromArrivalLS`) |
| Ring/belt orbital period | duration | dynamic | — (computed) |
| Ring/belt min / max velocity | velocity | km/s or c | — (computed) |
| Ring/belt distance to neighbour | length | km | — (computed) |
| Ring/belt velocity difference | velocity | km/s or c | — (computed) |
