### PR TITLE
Flag neutron stars above the observed mass limit as anomalous

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,6 +12,12 @@ EXPOSE 4200 4201 4205 4206 9876
 # Switch to `root`.
 USER root
 
+# Extra runtime libraries Playwright's `--with-deps` doesn't pull on this base
+# image: recent Firefox builds link against libxslt at launch (libxslt.so.1).
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends libxslt1.1 \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install the Playwright browsers (Chromium + Firefox) and their system
 # dependencies for end-to-end tests. Keep the version in sync with the
 # `@playwright/test` dependency in package.json.

--- a/e2e/compact-object-limits.spec.ts
+++ b/e2e/compact-object-limits.spec.ts
@@ -9,7 +9,7 @@ import {
 /**
  * Deterministic tests for the degenerate-matter stability warnings (Chandrasekhar /
  * TOV) and the black-hole Schwarzschild radius, loaded from a fixture
- * (`fixtures/compact-object-limits.json`) holding five compact objects so each limit
+ * (`fixtures/compact-object-limits.json`) holding six compact objects so each limit
  * boundary is exercised in one offline page load.
  *
  * LAWD 96, Clooku BA-A f81, Jackson's Lighthouse and Sifoae WV-C d13-1 A carry their
@@ -26,14 +26,17 @@ const FIXTURE = {
 
 // Whitespace-normalised (the message's embedded newline is matched as a single space).
 const CHANDRASEKHAR_TOOLTIP =
-  'Exceeds Chandrasekhar limit (1.44 M☉). ' +
-  'Electron degeneracy pressure can no longer support the star against gravity, ' +
-  'leading to gravitational collapse or a Type Ia supernova.';
+  'Anomalous mass — exceeds the Chandrasekhar limit (1.44 M☉). ' +
+  'Electron degeneracy pressure is not expected to support a white dwarf this heavy, ' +
+  'which would normally trigger gravitational collapse or a Type Ia supernova.';
 
 const TOV_TOOLTIP =
-  'Exceeds Tolman–Oppenheimer–Volkoff limit. ' +
-  'Above the TOV limit (2.17 solar masses), neutron degeneracy pressure can no longer ' +
-  'support the star against gravity, and it collapses into a black hole.';
+  'Anomalous mass — exceeds the theoretical Tolman–Oppenheimer–Volkoff limit (2.17 M☉). ' +
+  'Beyond this, neutron degeneracy pressure is not expected to support the star.';
+
+const OBSERVED_MAX_TOOLTIP =
+  'Highly anomalous mass — exceeds the observed maximum neutron-star mass (2.51 M☉). ' +
+  'Beyond this point a star would normally be expected to collapse into a black hole.';
 
 test.describe('Compact-object stability limits (fixture)', () => {
   test.beforeEach(async ({ page }) => {
@@ -43,7 +46,7 @@ test.describe('Compact-object stability limits (fixture)', () => {
   test('white dwarf above the Chandrasekhar limit (1.45 M☉) shows the warning', async ({ page }) => {
     await ensureBodyExpanded(page, 0);
     await expect(bodyRowValue(page, 0, 'Solar masses')).toContainText('1.45');
-    await expectMassStabilityWarning(page, 0, { present: true, tooltip: CHANDRASEKHAR_TOOLTIP });
+    await expectMassStabilityWarning(page, 0, { present: true, tooltip: CHANDRASEKHAR_TOOLTIP, severity: 'danger' });
   });
 
   test('LAWD 96 — white dwarf below the Chandrasekhar limit (1.26 M☉) has no warning', async ({ page }) => {
@@ -60,15 +63,21 @@ test.describe('Compact-object stability limits (fixture)', () => {
     await expectMassStabilityWarning(page, 2, { present: false });
   });
 
-  test("Jackson's Lighthouse — neutron star above the TOV limit (13.48 M☉) shows the warning", async ({ page }) => {
+  test("Jackson's Lighthouse — neutron star above the observed maximum (13.48 M☉) shows the danger warning", async ({ page }) => {
     await ensureBodyExpanded(page, 3);
     await expect(bodyRowValue(page, 3, 'Solar masses')).toContainText('13.48');
-    await expectMassStabilityWarning(page, 3, { present: true, tooltip: TOV_TOOLTIP });
+    await expectMassStabilityWarning(page, 3, { present: true, tooltip: OBSERVED_MAX_TOOLTIP, severity: 'danger' });
   });
 
   test('Sifoae WV-C d13-1 — neutron star below the TOV limit (0.81 M☉) has no warning', async ({ page }) => {
     await ensureBodyExpanded(page, 4);
     await expect(bodyRowValue(page, 4, 'Solar masses')).toContainText('0.81');
     await expectMassStabilityWarning(page, 4, { present: false });
+  });
+
+  test('Super-TOV Neutron Star — between the theoretical and observed limits (2.35 M☉) shows the amber warning', async ({ page }) => {
+    await ensureBodyExpanded(page, 5);
+    await expect(bodyRowValue(page, 5, 'Solar masses')).toContainText('2.35');
+    await expectMassStabilityWarning(page, 5, { present: true, tooltip: TOV_TOOLTIP, severity: 'warning' });
   });
 });

--- a/e2e/fixtures/compact-object-limits.json
+++ b/e2e/fixtures/compact-object-limits.json
@@ -2,7 +2,7 @@
   "system": {
     "name": "Compact Object Limits",
     "id64": 9100000000001,
-    "bodyCount": 5,
+    "bodyCount": 6,
     "coords": {
       "x": 0,
       "y": 0,
@@ -92,6 +92,23 @@
         "distanceToArrival": 0,
         "surfaceTemperature": 4962653,
         "solarMasses": 0.808594,
+        "solarRadius": 1.55295201294033e-05,
+        "age": 3218,
+        "rotationalPeriod": 3.04077662037037e-05,
+        "axialTilt": 0.0,
+        "spectralClass": "N0",
+        "luminosity": "VII",
+        "updateTime": "2026-06-14 00:00:00+00"
+      },
+      {
+        "bodyId": 5,
+        "id64": 9100000000005,
+        "name": "Super-TOV Neutron Star",
+        "type": "Star",
+        "subType": "Neutron Star",
+        "distanceToArrival": 0,
+        "surfaceTemperature": 4962653,
+        "solarMasses": 2.35,
         "solarRadius": 1.55295201294033e-05,
         "age": 3218,
         "rotationalPeriod": 3.04077662037037e-05,

--- a/e2e/support/system-fixture.ts
+++ b/e2e/support/system-fixture.ts
@@ -136,15 +136,17 @@ export function bodyRowValue(page: Page, bodyId: number, label: string): Locator
 /**
  * Asserts the degeneracy-limit warning (⚠) on a star's "Solar masses" row is present
  * or absent, and — when present and an `tooltip` is given — that hovering it shows that
- * text. Tooltip comparison is whitespace-normalised, so the message's embedded newline
- * is matched as a single space.
+ * text. When a `severity` is given, also asserts the indicator carries the matching colour
+ * class (`status-warning` / `status-danger`). Tooltip comparison is whitespace-normalised,
+ * so the message's embedded newline is matched as a single space.
  */
 export async function expectMassStabilityWarning(
   page: Page,
   bodyId: number,
-  opts: { present: boolean; tooltip?: string },
+  opts: { present: boolean; tooltip?: string; severity?: 'warning' | 'danger' },
 ): Promise<void> {
-  const warning = bodyRowValue(page, bodyId, 'Solar masses').locator('.status-danger');
+  const selector = opts.severity ? `.status-${opts.severity}` : '.status-danger, .status-warning';
+  const warning = bodyRowValue(page, bodyId, 'Solar masses').locator(selector);
   await expect(warning, `#body-${bodyId} mass-stability warning presence`).toHaveCount(opts.present ? 1 : 0);
 
   if (opts.present && opts.tooltip) {

--- a/src/app/data/body-physics.service.spec.ts
+++ b/src/app/data/body-physics.service.spec.ts
@@ -128,7 +128,9 @@ describe('BodyPhysicsService', () => {
 
   describe('massStabilityAlert', () => {
     it('warns when a white dwarf exceeds the Chandrasekhar limit (1.44 M☉)', () => {
-      expect(service.massStabilityAlert('White Dwarf (DA)', 1.45)).toContain('Chandrasekhar');
+      const alert = service.massStabilityAlert('White Dwarf (DA)', 1.45);
+      expect(alert?.message).toContain('Chandrasekhar');
+      expect(alert?.severity).toBe('danger');
     });
 
     it('does not warn for a white dwarf just below the Chandrasekhar limit', () => {
@@ -136,8 +138,16 @@ describe('BodyPhysicsService', () => {
       expect(service.massStabilityAlert('White Dwarf (DA)', 1.42)).toBeNull();
     });
 
-    it('warns when a neutron star exceeds the TOV limit (2.17 M☉)', () => {
-      expect(service.massStabilityAlert('Neutron Star', 2.2)).toContain('Tolman');
+    it('warns (warning severity) when a neutron star exceeds the theoretical TOV limit (2.17 M☉)', () => {
+      const alert = service.massStabilityAlert('Neutron Star', 2.2);
+      expect(alert?.message).toContain('Tolman');
+      expect(alert?.severity).toBe('warning');
+    });
+
+    it('flags (danger severity) a neutron star above the observed maximum (2.51 M☉)', () => {
+      const alert = service.massStabilityAlert('Neutron Star', 2.6);
+      expect(alert?.message).toContain('observed maximum');
+      expect(alert?.severity).toBe('danger');
     });
 
     it('does not warn for a neutron star below the TOV limit', () => {

--- a/src/app/data/body-physics.service.ts
+++ b/src/app/data/body-physics.service.ts
@@ -20,8 +20,22 @@ const SPEED_OF_LIGHT = 299792458;
  * (TOV) limit caps a neutron star supported by neutron degeneracy pressure.
  */
 const CHANDRASEKHAR_LIMIT_SOLAR_MASSES = 1.44;
-// Modern maximum-mass estimate constrained by the GW170817 neutron-star merger.
+// Theoretical TOV maximum-mass estimate constrained by the GW170817 neutron-star merger.
 const TOV_LIMIT_SOLAR_MASSES = 2.17;
+// Observed upper bound: the heaviest neutron-star mass recorded in Elite Dangerous (not a
+// real-life measurement). A star above this is treated as a highly anomalous in-game body.
+const OBSERVED_NEUTRON_STAR_MAX_SOLAR_MASSES = 2.51;
+
+/**
+ * A degeneracy-pressure stability warning. `severity` is `'warning'` when a neutron star
+ * exceeds the theoretical TOV limit but stays within the observed mass range, and
+ * `'danger'` when a body exceeds a hard limit (Chandrasekhar, or the observed neutron-star
+ * maximum) and should already have collapsed.
+ */
+export interface MassStabilityAlert {
+  message: string;
+  severity: 'warning' | 'danger';
+}
 
 export interface PlanetaryDensity {
   value: number;
@@ -420,24 +434,41 @@ export class BodyPhysicsService {
 
   /**
    * Degeneracy-pressure stability warning when a body's mass exceeds the relevant limit:
-   * Chandrasekhar (1.44 M☉) for white dwarfs, TOV (~2.17 M☉) for neutron stars. Returns the
-   * tooltip message, or null when the body is stable / not a degenerate object. Black holes
-   * have already collapsed, so the "will collapse into a black hole" warning does not apply
-   * to them.
+   * Chandrasekhar (1.44 M☉) for white dwarfs, and for neutron stars the theoretical TOV
+   * limit (~2.17 M☉) and the observed maximum (~2.51 M☉). Returns the tooltip message and a
+   * severity, or null when the body is stable / not a degenerate object. A neutron star
+   * between the two limits is flagged as a `'warning'`; one above the observed maximum (or a
+   * super-Chandrasekhar white dwarf) is flagged as `'danger'`. Black holes have already
+   * collapsed, so the "will collapse into a black hole" warning does not apply to them.
    */
-  massStabilityAlert(subType: string | null | undefined, solarMasses: number | null | undefined): string | null {
+  massStabilityAlert(subType: string | null | undefined, solarMasses: number | null | undefined): MassStabilityAlert | null {
     if (solarMasses === null || solarMasses === undefined) { return null; }
 
     if (subType?.startsWith('White Dwarf') && solarMasses > CHANDRASEKHAR_LIMIT_SOLAR_MASSES) {
-      return 'Exceeds Chandrasekhar limit (1.44 M☉).\n'
-        + 'Electron degeneracy pressure can no longer support the star against gravity, '
-        + 'leading to gravitational collapse or a Type Ia supernova.';
+      return {
+        severity: 'danger',
+        message: 'Anomalous mass — exceeds the Chandrasekhar limit (1.44 M☉).\n'
+          + 'Electron degeneracy pressure is not expected to support a white dwarf this heavy, '
+          + 'which would normally trigger gravitational collapse or a Type Ia supernova.',
+      };
     }
 
-    if (subType === 'Neutron Star' && solarMasses > TOV_LIMIT_SOLAR_MASSES) {
-      return 'Exceeds Tolman–Oppenheimer–Volkoff limit.\n'
-        + 'Above the TOV limit (2.17 solar masses), neutron degeneracy pressure can no longer '
-        + 'support the star against gravity, and it collapses into a black hole.';
+    if (subType === 'Neutron Star') {
+      if (solarMasses > OBSERVED_NEUTRON_STAR_MAX_SOLAR_MASSES) {
+        return {
+          severity: 'danger',
+          message: 'Highly anomalous mass — exceeds the observed maximum neutron-star mass (2.51 M☉).\n'
+            + 'Beyond this point a star would normally be expected to collapse into a black hole.',
+        };
+      }
+
+      if (solarMasses > TOV_LIMIT_SOLAR_MASSES) {
+        return {
+          severity: 'warning',
+          message: 'Anomalous mass — exceeds the theoretical Tolman–Oppenheimer–Volkoff limit (2.17 M☉).\n'
+            + 'Beyond this, neutron degeneracy pressure is not expected to support the star.',
+        };
+      }
     }
 
     return null;

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -497,8 +497,9 @@
                 {{ formattedSolarMass?.display }}
               </span>
               @if (getMassStabilityAlert(); as massAlert) {
-              <span class="status-danger"
-                    [matTooltip]="massAlert"
+              <span [class.status-danger]="massAlert.severity === 'danger'"
+                    [class.status-warning]="massAlert.severity === 'warning'"
+                    [matTooltip]="massAlert.message"
                     matTooltipClass="multiline-tooltip">⚠</span>
               }
             </div>

--- a/src/app/system-body/system-body.component.scss
+++ b/src/app/system-body/system-body.component.scss
@@ -346,4 +346,5 @@
 
 /* Inline status indicators — tokenized (replaces former inline hex). */
 .status-danger { color: var(--color-danger) }
+.status-warning { color: var(--color-warning) }
 .status-success { color: var(--color-success) }

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -10,7 +10,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { DecimalPipe, DatePipe } from '@angular/common';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ClickableDirective } from '../clickable.directive';
-import { BodyPhysicsService, ShepherdingHillLimit, BodyRocheLimits, PlanetaryDensity } from '../data/body-physics.service';
+import { BodyPhysicsService, ShepherdingHillLimit, BodyRocheLimits, PlanetaryDensity, MassStabilityAlert } from '../data/body-physics.service';
 import { StellarPhysicsService } from '../data/stellar-physics.service';
 import { OrbitalRelationsService } from '../data/orbital-relations.service';
 import { RocheChartData, HillChartData } from '../data/chart-rendering.service';
@@ -130,7 +130,7 @@ export class SystemBodyComponent implements OnChanges {
   public readonly getTangentialVelocityTooltip = signal('');
   public readonly classifyNeutronStar = signal<string | null>(null);
   public readonly getSchwarzschildRadius = signal<number | null>(null);
-  public readonly getMassStabilityAlert = signal<string | null>(null);
+  public readonly getMassStabilityAlert = signal<MassStabilityAlert | null>(null);
   public getBodyDisplayName(bodyName: string): string {
     return this.appService.getBodyDisplayName(bodyName);
   }


### PR DESCRIPTION
## Summary

Neutron stars are now flagged against **two** mass limits with distinct colours, instead of only the theoretical TOV limit:

| Mass | Severity | Colour |
|------|----------|--------|
| > 2.17 M☉ (theoretical TOV limit) | warning | amber (`--color-warning`) |
| > 2.51 M☉ (observed in-game maximum) | danger | red (`--color-danger`) |

Super-Chandrasekhar white dwarfs stay `danger`/red.

The 2.51 M☉ value is the heaviest neutron-star mass recorded **in Elite Dangerous** (not a real-world measurement). Messages use an in-game "anomalous" framing rather than real-world "cannot exist / should have collapsed" wording.

<img width="669" height="315" alt="image" src="https://github.com/user-attachments/assets/84fb0282-c872-46f0-a115-80b687aa771b" />
<img width="669" height="315" alt="image" src="https://github.com/user-attachments/assets/7334bf53-1771-4bfb-aa63-b559341452b6" />

## Changes
- `body-physics.service.ts` — added the observed-maximum constant and a `MassStabilityAlert` interface; `massStabilityAlert()` now returns `{ message, severity }`, checking the observed maximum (danger) before the theoretical TOV limit (warning).
- `system-body.component.{ts,html}` — signal/template updated to bind `status-danger` / `status-warning` by severity and read `massAlert.message`.
- `system-body.component.scss` — added `.status-warning`.
- Tests — updated unit specs (severity + observed-maximum coverage), the e2e helper (`severity` option), the e2e spec (tooltips + danger/warning cases), and added a fixture body (`Super-TOV Neutron Star`, 2.35 M☉) covering the amber warning band.

## Verification
- Unit tests: **500 passed**
- e2e (`compact-object-limits`, chromium): **6 passed**
- Typecheck: clean

Closes #36 