### PR TITLE
feat: collision-candidate detection via 3D synodic analysis

### DIFF
--- a/.claude/skills/fetch-spansh/SKILL.md
+++ b/.claude/skills/fetch-spansh/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: fetch-spansh
+description: Fetch Elite Dangerous data from the Spansh API. Two modes — `fetch` pulls a whole system's body/station dump by name or id64 (to create/refresh an e2e fixture in e2e/fixtures/, inspect a body's real values when debugging the renderer, or check what Spansh serves); `search` finds individual bodies anywhere in the galaxy by their properties (subtype, gravity, temperature, mass, landability, …) ranked by distance from a reference system. Spansh dumps share the exact {"system":{...}} shape the app consumes and the fixtures store.
+---
+
+# Fetch Spansh data
+
+[fetch_spansh.py](fetch_spansh.py) talks to Spansh (`https://spansh.co.uk/api`), which
+ingests EDDN and is the upstream source behind the Canonn biostats endpoint the app calls.
+It has two modes: **`fetch`** (a whole system's dump) and **`search`** (find bodies by
+property). Stdlib Python only — no install. Paths below assume you run from the skill dir.
+
+## `fetch` — whole-system dump
+
+A system dump is in the same `{"system": {bodies, stations, coordinates, ...}}` shape as
+every `e2e/fixtures/*.json`, so `fetch` is both an inspection tool and the fixture generator.
+`fetch` is the default mode, so the system can be the first argument.
+
+```bash
+# Inspect a system on stdout, re-formatted to match the fixtures
+python3 fetch_spansh.py Sol
+
+# Already have the id64? Skip name resolution
+python3 fetch_spansh.py 10477373803
+
+# Save a new/refreshed e2e fixture (give a path relative to your cwd)
+python3 fetch_spansh.py "Alpha Centauri" --out e2e/fixtures/alpha-centauri.json
+
+# Pass through Spansh's exact bytes, unformatted
+python3 fetch_spansh.py Sol --raw
+```
+
+A bare name is resolved to an id64 via Spansh's typeahead, preferring an exact
+(case-insensitive) match; an ambiguous or missing name exits with candidates so you can
+retry with the right one or a numeric id64.
+
+## `search` — find bodies by property
+
+`search` is `POST /api/bodies/search`: it ranks bodies **by distance from a reference
+system** (`--near`, default Sol) and filters them by their properties. Each result carries
+`system_name` and `system_id64` (distinct from the body's own `id64`), so a hit feeds
+straight back into `fetch system_id64` — or `fetch "<system_name>"` — to get the dump.
+
+```bash
+# Nearest Earth-like worlds to Sol, within 100 ly
+python3 fetch_spansh.py search --type "Earth-like world" --within 100
+
+# Landable high-metal worlds under 0.3 g within 50 ly of Merope
+python3 fetch_spansh.py search --near Merope --type "High metal content world" \
+    --landable --range gravity 0 0.3
+
+# Very hot bodies (>1000 K) near Sol — '_' is an open upper bound — as raw JSON
+python3 fetch_spansh.py search --range surface_temperature 1000 _ --within 50 --json
+```
+
+| Flag | Filter |
+|------|--------|
+| `--near SYSTEM` | Reference system distances are measured from (default `Sol`). |
+| `--within LY` | Max distance in ly from `--near`. |
+| `--type SUBTYPE` | Body subtype, exact Spansh string. Repeatable (matches any). |
+| `--landable` | Landable bodies only. |
+| `--range FIELD MIN MAX` | Numeric field between MIN and MAX inclusive. `_` = open bound. Repeatable. |
+| `--size N` | Max results (default 15). |
+| `--farthest` | Rank by farthest instead of nearest. |
+| `--json` | Emit raw result objects instead of the summary table. |
+
+Filters combine with AND. By default it prints a distance-ranked summary table to stderr;
+`--json` emits the full result objects on stdout.
+
+**`--type` must match a real Spansh subtype string** (e.g. `Water world`, `Class III gas
+giant`, `K (Yellow-Orange) Star`). Get the full list — with galaxy-wide counts — from
+`GET /api/bodies/field_values/subtype`.
+
+**`--range FIELD` is validated against a whitelist** because Spansh *silently ignores* an
+unknown filter key and returns unconstrained results — so a typo (`temperature` for
+`surface_temperature`, `mass` for `earth_masses`) would otherwise look like it worked while
+returning the wrong bodies. The script errors and lists the valid fields instead. Each
+whitelisted field was verified to actually constrain results; searchable fields are:
+`earth_masses`, `gravity`, `surface_temperature`, `surface_pressure`, `radius`,
+`distance_to_arrival`, `signal_count`, `orbital_period`, `orbital_eccentricity`,
+`orbital_inclination`, `semi_major_axis`, `rotational_period`, `axis_tilt`,
+`arg_of_periapsis`, `estimated_scan_value`, `estimated_mapping_value`, and the star fields
+`solar_masses`, `solar_radius`, `age`. (`is_landable` is a boolean handled by `--landable`;
+its filter always means landable-only regardless of value.)
+
+## Creating an e2e fixture
+
+The deterministic Playwright specs stub the network and serve a saved dump from
+`e2e/fixtures/` (see [e2e/support/system-fixture.ts](../../../e2e/support/system-fixture.ts)).
+To add coverage for a real system:
+
+1. `python3 .claude/skills/fetch-spansh/fetch_spansh.py "<System Name>" --out e2e/fixtures/<slug>.json`
+   (run from the repo root so the `--out` path lands correctly).
+2. Point a spec at it via `loadFixtureSystem(page, { fixture: '<slug>.json', systemName, id64 })`.
+
+`--out` writes sorted keys, 2-space indent, and the trailing-space item separator Spansh's
+own serializer emits, so a generated fixture is byte-consistent with the existing ones and
+won't churn the diff. Don't hand-edit the JSON afterward unless you mean to.
+
+## Notes
+
+- A system that's too recently discovered may not be in Spansh yet — the script reports
+  this rather than writing an empty fixture. Try again later.
+- Endpoints used: `GET /api/systems/field_values/system_names?q=` (name→id64),
+  `GET /api/dump/{id64}` (the system dump), and `POST /api/bodies/search` (`search` mode).
+  `GET /api/bodies/field_values/subtype` gives the full set of body subtype strings (used by
+  [white-dwarf.spec.ts](../../../src/app/data/white-dwarf.spec.ts) and by `--type`).
+- `search` reports `count` capped at 10000; a `(capped)` note appears when the real total is
+  at or above that. Narrow with `--within` / `--range` to see a true count.

--- a/.claude/skills/fetch-spansh/fetch_spansh.py
+++ b/.claude/skills/fetch-spansh/fetch_spansh.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Fetch Elite Dangerous data from Spansh (https://spansh.co.uk).
+
+Two modes:
+
+  fetch   Download a whole system's dump by name or id64. Spansh ingests EDDN and
+          exposes a per-system "dump" in the same `{"system": {bodies, stations, ...}}`
+          shape this app receives from Canonn's biostats endpoint — the exact shape every
+          file in `e2e/fixtures/` is stored in. So `fetch ... --out e2e/fixtures/x.json`
+          is the fixture generator.
+
+  search  Find individual bodies anywhere in the galaxy by their properties (subtype,
+          gravity, temperature, mass, ...) ranked by distance from a reference system.
+          This is Spansh's `POST /api/bodies/search`. Every result carries its system
+          name + id64, so a hit can be fed straight back into `fetch` to get its dump.
+
+`fetch` is the default mode, so `fetch_spansh.py Sol` still works.
+Stdlib only (urllib + json); no install step.
+
+Examples:
+  # Whole-system dump on stdout (re-formatted to match the fixtures)
+  python3 fetch_spansh.py Sol
+
+  # Save a new e2e fixture (resolves the name to an id64 first)
+  python3 fetch_spansh.py "Alpha Centauri" --out e2e/fixtures/alpha-centauri.json
+
+  # Find the nearest Earth-like worlds to Sol
+  python3 fetch_spansh.py search --type "Earth-like world" --within 100
+
+  # Landable high-g rocky bodies near Merope, hot ones only, as JSON
+  python3 fetch_spansh.py search --near Merope --type "Rocky body" --landable \
+      --range gravity 2 _ --range surface_temperature 500 _ --json
+"""
+
+import argparse
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+API = "https://spansh.co.uk/api"
+TIMEOUT = 30
+
+# An open bound in `--range FIELD MIN MAX`: passes through as a value far outside any real
+# range, so Spansh's between-comparison effectively becomes one-sided (its own `<`/`>`
+# operators don't behave, but `<=>` against a huge bound does).
+OPEN = "_"
+NEG_INF, POS_INF = -1e30, 1e30
+
+# Numeric body fields Spansh actually filters on, each verified to constrain results (see
+# SKILL.md). This is a hard whitelist on purpose: Spansh *silently ignores* an unknown
+# filter key and returns unconstrained results, so a typo like `temperature` (it's
+# `surface_temperature`) or `mass` (`earth_masses`) would look like it worked but quietly
+# return the wrong bodies. Rejecting unknown fields up front turns that trap into an error.
+SEARCHABLE_NUMERIC = {
+    "earth_masses", "gravity", "surface_temperature", "surface_pressure", "radius",
+    "distance_to_arrival", "signal_count",
+    "orbital_period", "orbital_eccentricity", "orbital_inclination", "semi_major_axis",
+    "rotational_period", "axis_tilt", "arg_of_periapsis",
+    "estimated_scan_value", "estimated_mapping_value",
+    "solar_masses", "solar_radius", "age",  # stars
+}
+
+
+def _get(url: str):
+    req = urllib.request.Request(url, headers={"User-Agent": "canonn-signals/fetch-spansh"})
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+        return json.load(resp)
+
+
+def _post(path: str, payload: dict):
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"{API}/{path}",
+        data=body,
+        headers={"Content-Type": "application/json", "User-Agent": "canonn-signals/fetch-spansh"},
+    )
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+        return json.load(resp)
+
+
+# --------------------------------------------------------------------------- fetch mode
+
+def resolve_id64(name: str) -> int:
+    """Resolve a system name to its id64 via Spansh's typeahead, preferring an exact
+    (case-insensitive) name match and erroring with candidates when it's ambiguous."""
+    url = f"{API}/systems/field_values/system_names?q={urllib.parse.quote(name)}"
+    matches = _get(url).get("min_max", [])
+    if not matches:
+        sys.exit(f"No Spansh system matches '{name}'.")
+    exact = [m for m in matches if m["name"].lower() == name.lower()]
+    if len(exact) == 1:
+        return exact[0]["id64"]
+    if len(exact) > 1:
+        sys.exit(f"'{name}' is ambiguous on Spansh: {[m['id64'] for m in exact]}")
+    names = ", ".join(m["name"] for m in matches[:10])
+    sys.exit(f"No exact match for '{name}'. Did you mean one of: {names}?")
+
+
+def fetch_dump(id64: int):
+    dump = _get(f"{API}/dump/{id64}")
+    if not dump or not dump.get("system"):
+        sys.exit(f"Spansh has no dump for id64 {id64} (system may be too new — try again later).")
+    return dump
+
+
+def format_fixture(dump) -> str:
+    """Serialise exactly like the existing `e2e/fixtures/*.json` (sorted keys, 2-space
+    indent, the trailing-space item separator Spansh's own serializer emits)."""
+    return json.dumps(dump, indent=2, separators=(", ", ": "), sort_keys=True)
+
+
+def run_fetch(args) -> None:
+    id64 = int(args.system) if args.system.isdigit() else resolve_id64(args.system)
+    dump = fetch_dump(id64)
+    text = json.dumps(dump) if args.raw else format_fixture(dump)
+
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(text + "\n")
+        name = dump["system"].get("name", id64)
+        print(f"Wrote {name} (id64 {id64}) → {args.out}", file=sys.stderr)
+    else:
+        print(text)
+
+
+# -------------------------------------------------------------------------- search mode
+#
+# Filter grammar (each verified empirically against the live API — see SKILL.md):
+#   distance   {"min": "0", "max": "100"}            ly from reference_system
+#   enum/value {"value": ["Earth-like world", ...]}  exact string match, OR within the list
+#   numeric    {"comparison": "<=>", "value": [a,b]} between a and b inclusive
+#   landable   {"value": ["Y"]}                       presence ⇒ landable-only (value ignored)
+
+def build_filters(args) -> dict:
+    filters = {}
+    if args.within is not None:
+        filters["distance"] = {"min": "0", "max": str(args.within)}
+    if args.type:
+        filters["subtype"] = {"value": args.type}
+    if args.landable:
+        filters["is_landable"] = {"value": ["Y"]}
+    for field, lo, hi in args.range or []:
+        if field not in SEARCHABLE_NUMERIC:
+            sys.exit(
+                f"'{field}' isn't a searchable numeric field (Spansh would silently ignore it).\n"
+                f"Known fields: {', '.join(sorted(SEARCHABLE_NUMERIC))}"
+            )
+        lo_v = NEG_INF if lo == OPEN else float(lo)
+        hi_v = POS_INF if hi == OPEN else float(hi)
+        filters[field] = {"comparison": "<=>", "value": [lo_v, hi_v]}
+    return filters
+
+
+def run_search(args) -> None:
+    payload = {
+        "filters": build_filters(args),
+        "sort": [{"distance": {"direction": "desc" if args.farthest else "asc"}}],
+        "size": args.size,
+        "page": 0,
+        "reference_system": args.near,
+    }
+    resp = _post("bodies/search", payload)
+    if "error" in resp:
+        sys.exit(f"Spansh rejected the search: {resp['error']}. Filters: {payload['filters']}")
+    results = resp.get("results", [])
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+        return
+
+    ref = resp.get("reference", {}).get("name", args.near)
+    total = resp.get("count", len(results))
+    capped = " (capped)" if total >= 10000 else ""
+    print(f"{len(results)} of ~{total}{capped} bodies, by distance from {ref}:", file=sys.stderr)
+    if not results:
+        return
+    for b in results:
+        bits = [f"{b.get('distance', 0):8.1f} ly", f"{b.get('name', '?'):<28}", b.get("subtype", "?")]
+        if b.get("gravity") is not None:
+            bits.append(f"g={b['gravity']:.2f}")
+        if b.get("surface_temperature") is not None:
+            bits.append(f"{b['surface_temperature']:.0f}K")
+        if b.get("is_landable"):
+            bits.append("landable")
+        print("  " + "  ".join(bits))
+
+
+# --------------------------------------------------------------------------------- main
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Fetch Elite Dangerous data from Spansh.")
+    sub = ap.add_subparsers(dest="mode")
+
+    s = sub.add_parser("search", help="Find bodies by property, ranked by distance.")
+    s.add_argument("--near", default="Sol", help="Reference system to measure distance from (default: Sol).")
+    s.add_argument("--within", type=float, help="Max distance in ly from --near.")
+    s.add_argument("--type", action="append", metavar="SUBTYPE",
+                   help="Body subtype, e.g. 'Earth-like world'. Repeatable (matches any).")
+    s.add_argument("--landable", action="store_true", help="Landable bodies only.")
+    s.add_argument("--range", action="append", nargs=3, metavar=("FIELD", "MIN", "MAX"),
+                   help=f"Numeric field between MIN and MAX (e.g. gravity 0 1). Use '{OPEN}' for an open bound. Repeatable.")
+    s.add_argument("--size", type=int, default=15, help="Max results (default: 15).")
+    s.add_argument("--farthest", action="store_true", help="Sort by farthest instead of nearest.")
+    s.add_argument("--json", action="store_true", help="Emit raw result objects as JSON.")
+    s.set_defaults(func=run_search)
+
+    f = sub.add_parser("fetch", help="Download a whole system's dump.")
+    f.add_argument("system", help="System name (resolved via typeahead) or a numeric id64.")
+    f.add_argument("--out", help="Write to this file instead of stdout (e.g. e2e/fixtures/foo.json).")
+    f.add_argument("--raw", action="store_true", help="Emit Spansh's exact bytes, unformatted.")
+    f.set_defaults(func=run_fetch)
+
+    # `fetch` is the default mode: if the first token isn't a known subcommand, treat the
+    # invocation as `fetch <system> ...` so `fetch_spansh.py Sol` keeps working.
+    argv = sys.argv[1:]
+    if argv and argv[0] not in ("search", "fetch", "-h", "--help"):
+        argv = ["fetch"] + argv
+
+    args = ap.parse_args(argv)
+    if not getattr(args, "func", None):
+        ap.print_help()
+        sys.exit(2)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ Thumbs.db
 package-lock.json
 .pnpm-store/
 pnpm-lock.yaml
+
+# Python bytecode cache (from the .claude/skills helper scripts)
+__pycache__/
+*.pyc

--- a/src/app/data/orbital-relations.service.spec.ts
+++ b/src/app/data/orbital-relations.service.spec.ts
@@ -264,4 +264,195 @@ describe('OrbitalRelationsService', () => {
       expect(tip(peri.date)).toBe('2049-06-09 07:48');
     });
   });
+
+  describe('detectCollisionStatus', () => {
+    const now = Date.parse('2026-06-27T00:00:00Z');
+
+    it('flags two crossing-orbit siblings as collision candidates of each other', () => {
+      // Identical coplanar orbits, different periods, large radii → they collide at every
+      // conjunction. Aligned in longitude now, so the next contact is immediate.
+      const [a, b] = makeFamily([
+        { orbitalPeriod: 10, semiMajorAxis: 1, orbitalEccentricity: 0.1, orbitalInclination: 0,
+          radius: 60000, meanAnomaly: 0, argOfPeriapsis: 0, ascendingNode: 0,
+          timestamps: { meanAnomaly: '2026-06-27T00:00:00Z' } as any },
+        { orbitalPeriod: 11, semiMajorAxis: 1, orbitalEccentricity: 0.1, orbitalInclination: 0,
+          radius: 60000, meanAnomaly: 0, argOfPeriapsis: 0, ascendingNode: 0,
+          timestamps: { meanAnomaly: '2026-06-27T00:00:00Z' } as any },
+      ]);
+      const ra = service.detectCollisionStatus(a, now);
+      const rb = service.detectCollisionStatus(b, now);
+      expect(ra.isCandidate).toBe(true);
+      expect(rb.isCandidate).toBe(true);
+      expect(ra.partnerName).toBe('Child 2');
+      expect(rb.partnerName).toBe('Child 1');
+      // Synodic period = 1 / |1/10 − 1/11| = 110 days for both.
+      expect(ra.synodicPeriodDays).toBeCloseTo(110, 6);
+      expect(rb.synodicPeriodDays).toBeCloseTo(110, 6);
+      // Same orbit, same position now → contact essentially immediate.
+      expect(ra.nextCollision!.days).toBeLessThan(1);
+    });
+
+    it('does not flag co-orbital (equal-period) siblings — synodic period is infinite', () => {
+      const [a] = makeFamily([
+        { orbitalPeriod: 10, semiMajorAxis: 1, orbitalEccentricity: 0.1, argOfPeriapsis: 0, radius: 60000 },
+        { orbitalPeriod: 10, semiMajorAxis: 1, orbitalEccentricity: 0.1, argOfPeriapsis: 60, radius: 60000 },
+      ]);
+      expect(service.detectCollisionStatus(a, now).isCandidate).toBe(false);
+    });
+
+    it('does not flag well-separated orbits whose radial ranges cannot meet', () => {
+      const [a] = makeFamily([
+        { orbitalPeriod: 10, semiMajorAxis: 1, orbitalEccentricity: 0.01, radius: 6000 },
+        { orbitalPeriod: 20, semiMajorAxis: 5, orbitalEccentricity: 0.01, radius: 6000 },
+      ]);
+      expect(service.detectCollisionStatus(a, now).isCandidate).toBe(false);
+    });
+
+    it('does not flag radially-overlapping orbits that a relative tilt holds 3D-apart', () => {
+      // Same distance band, but one orbit is steeply inclined and offset in node so the two
+      // curves stay far apart in 3D despite the overlapping radial ranges. Small radii.
+      const [a] = makeFamily([
+        { orbitalPeriod: 10, semiMajorAxis: 1, orbitalEccentricity: 0.001, radius: 3000,
+          orbitalInclination: 0, ascendingNode: 0, argOfPeriapsis: 0 },
+        { orbitalPeriod: 11, semiMajorAxis: 1, orbitalEccentricity: 0.001, radius: 3000,
+          orbitalInclination: 60, ascendingNode: 90, argOfPeriapsis: 0 },
+      ]);
+      expect(service.detectCollisionStatus(a, now).isCandidate).toBe(false);
+    });
+
+    it('flags the real Grae Eaec AA-A h0 D 2 c / d pair and dates the contact in 3D', () => {
+      // Razor-thin nearly-circular orbits ~1825 km apart radially; the ~2700 km moons sit
+      // closer than their radii sum, so they truly collide. A full 3D Kepler propagation
+      // (verified independently) puts the next contact on 2026-10-18.
+      const [c, d] = makeFamily([
+        { name: 'D 2 c', orbitalPeriod: 1.90164928358796, semiMajorAxis: 0.0128560641816413,
+          orbitalEccentricity: 8.4e-5, orbitalInclination: -0.727422, radius: 2780.05725,
+          argOfPeriapsis: 201.101444, ascendingNode: -128.723473, meanAnomaly: 18.25511,
+          timestamps: { meanAnomaly: '2022-05-21T02:21:30Z' } as any },
+        { name: 'D 2 d', orbitalPeriod: 1.90435777659722, semiMajorAxis: 0.0128682681673058,
+          orbitalEccentricity: 2.8e-5, orbitalInclination: -0.020247, radius: 2715.17175,
+          argOfPeriapsis: 100.379093, ascendingNode: 25.401207, meanAnomaly: 38.691326,
+          timestamps: { meanAnomaly: '2022-05-21T02:21:30Z' } as any },
+      ]);
+      const r = service.detectCollisionStatus(c, now);
+      expect(r.isCandidate).toBe(true);
+      expect(r.partnerName).toBe('D 2 d');
+      expect(r.synodicPeriodDays).toBeCloseTo(1337, 0);
+      expect(r.nextCollision).not.toBeNull();
+      // Within a day of the independently computed 3D contact time.
+      expect(r.nextCollision!.start.toISOString().slice(0, 10)).toBe('2026-10-18');
+    });
+
+    it('skips off-node near-miss conjunctions and dates the first true 3D contact', () => {
+      // Two tilted orbits whose longitude conjunctions precess across the mutual node. The
+      // next two conjunctions (≈2026-06-29 and ≈2026-08-27) pass 15000+ km apart — far wider
+      // than the 6000 km contact distance — so they are NOT collisions. A naive
+      // same-longitude model would wrongly report the imminent one; the 3D search skips both
+      // and reports the first conjunction that actually lands on the node. An independent
+      // brute-force propagation puts that first real contact on 2027-05-03.
+      const [a] = makeFamily([
+        { name: 'A', orbitalPeriod: 2.0, semiMajorAxis: 0.01, orbitalEccentricity: 0.001,
+          orbitalInclination: 0, ascendingNode: 0, argOfPeriapsis: 0, meanAnomaly: 0, radius: 3000,
+          timestamps: { meanAnomaly: '2026-01-01T00:00:00Z' } as any },
+        { name: 'B', orbitalPeriod: 2.07, semiMajorAxis: 0.01, orbitalEccentricity: 0.001,
+          orbitalInclination: 1, ascendingNode: 0, argOfPeriapsis: 0, meanAnomaly: 90, radius: 3000,
+          timestamps: { meanAnomaly: '2026-01-01T00:00:00Z' } as any },
+      ]);
+      const r = service.detectCollisionStatus(a, now);
+      expect(r.isCandidate).toBe(true);
+      expect(r.nextCollision).not.toBeNull();
+      // The reported contact is the real on-node one, ~10 months out — not the imminent
+      // near-miss conjunction a naive model would have flagged days from now.
+      expect(r.nextCollision!.days).toBeGreaterThan(180);
+      expect(r.nextCollision!.start.toISOString().slice(0, 10)).toBe('2027-05-03');
+    });
+
+    it('catches a grazing contact whose minimum falls between coarse time samples', () => {
+      // The bodies pass ~17949 km apart — just inside the 18000 km contact distance — at a
+      // moment between the coarse scan steps. The contact time must be found by refining the
+      // window minimum before the contact test, not judged against an over-wide coarse sample.
+      const [a] = makeFamily([
+        { name: 'A', orbitalPeriod: 10, semiMajorAxis: 0.01, orbitalEccentricity: 0,
+          orbitalInclination: 0, ascendingNode: 0, argOfPeriapsis: 0, meanAnomaly: 0, radius: 9000,
+          timestamps: { meanAnomaly: '2026-06-27T00:00:00Z' } as any },
+        { name: 'B', orbitalPeriod: 11, semiMajorAxis: 0.01, orbitalEccentricity: 0,
+          orbitalInclination: 5, ascendingNode: 0, argOfPeriapsis: 0, meanAnomaly: 50, radius: 9000,
+          timestamps: { meanAnomaly: '2026-06-27T00:00:00Z' } as any },
+      ]);
+      const r = service.detectCollisionStatus(a, now);
+      expect(r.isCandidate).toBe(true);
+      expect(r.nextCollision).not.toBeNull();
+      expect(r.nextCollision!.days).toBeGreaterThan(0);
+      expect(r.nextCollision!.days).toBeLessThan(30);
+    });
+
+    it('flags the real Dryio Hypue RY-A e0 A 6 a / b pair (sharp minimum, multi-basin)', () => {
+      // These moons' closest orbital approach (~3000 km, inside the ~3909 km radii sum) sits
+      // in a narrow valley whose basin a coarse single-best grid search misses — it must be
+      // found by the finer grid + multi-basin refinement. Brute-force 3D contact: 2028-08-10.
+      const [a] = makeFamily([
+        { name: 'A 6 a', orbitalPeriod: 2.04546135608796, semiMajorAxis: 0.0128871889270589,
+          orbitalEccentricity: 0.000555, orbitalInclination: 0.025846, argOfPeriapsis: 107.388455,
+          ascendingNode: 82.705832, meanAnomaly: 183.01898, radius: 2097.79225,
+          timestamps: { meanAnomaly: '2023-04-07T20:50:46Z' } as any },
+        { name: 'A 6 b', orbitalPeriod: 2.05459880332176, semiMajorAxis: 0.0129255400416571,
+          orbitalEccentricity: 0.000999, orbitalInclination: 0.006466, argOfPeriapsis: 25.373948,
+          ascendingNode: 21.680711, meanAnomaly: 53.449845, radius: 1811.117375,
+          timestamps: { meanAnomaly: '2023-04-07T20:50:43Z' } as any },
+      ]);
+      const r = service.detectCollisionStatus(a, now);
+      expect(r.isCandidate).toBe(true);
+      expect(r.partnerName).toBe('A 6 b');
+      expect(r.nextCollision).not.toBeNull();
+      expect(r.nextCollision!.start.toISOString().slice(0, 10)).toBe('2028-08-10');
+    });
+
+    it('reports the contact window (start/end) for the real Braireau AA-A h761 1 b / c pair', () => {
+      // A collision is an interval, not an instant. An independent brute-force 3D Kepler
+      // propagation (combined radii 6509.6 km) puts the contact window on 2028-06-19:
+      // START ≈ 07:52:57 UTC, minimum separation (≈2929 km) at 08:33:52, END ≈ 09:14:49 UTC
+      // — a duration of ≈82 minutes.
+      const [b1, c1] = makeFamily([
+        { name: '1 b', orbitalPeriod: 3.12638586318287, semiMajorAxis: 0.0154507028533318,
+          orbitalEccentricity: 0.011564, orbitalInclination: -2.461662, argOfPeriapsis: 219.533956,
+          ascendingNode: -179.142714, meanAnomaly: 272.605583, radius: 3445.79375,
+          timestamps: { meanAnomaly: '2023-03-19T22:33:44Z' } as any },
+        { name: '1 c', orbitalPeriod: 3.17091274040509, semiMajorAxis: 0.015597059041845,
+          orbitalEccentricity: 5.6e-5, orbitalInclination: -0.160679, argOfPeriapsis: 305.081614,
+          ascendingNode: -78.606663, meanAnomaly: 309.399786, radius: 3063.84525,
+          timestamps: { meanAnomaly: '2023-03-19T22:33:52Z' } as any },
+      ]);
+      const r = service.detectCollisionStatus(b1, now);
+      expect(r.isCandidate).toBe(true);
+      expect(r.partnerName).toBe('1 c');
+      expect(r.nextCollision).not.toBeNull();
+      // Contact window starts on 2028-06-19 around 07:5x UTC.
+      expect(r.nextCollision!.start.toISOString().slice(0, 10)).toBe('2028-06-19');
+      // The window is a genuine interval: end follows start…
+      expect(r.nextCollision!.end.getTime()).toBeGreaterThan(r.nextCollision!.start.getTime());
+      // …and lasts on the order of an hour and a half (≈82 minutes here).
+      const durationMin = (r.nextCollision!.end.getTime() - r.nextCollision!.start.getTime()) / 60000;
+      expect(durationMin).toBeGreaterThan(60);
+      expect(durationMin).toBeLessThan(100);
+    });
+
+    it('treats an unbound (e ≥ 1) sibling as a non-recurring, non-candidate orbit', () => {
+      const [a] = makeFamily([
+        { orbitalPeriod: 10, semiMajorAxis: 1, orbitalEccentricity: 0.1, radius: 60000 },
+        { orbitalPeriod: 11, semiMajorAxis: 1, orbitalEccentricity: 1.5, radius: 60000 },
+      ]);
+      expect(service.detectCollisionStatus(a, now).isCandidate).toBe(false);
+    });
+
+    it('still flags a geometric candidate when timing data is missing (no date)', () => {
+      const [a] = makeFamily([
+        { orbitalPeriod: 10, semiMajorAxis: 1, orbitalEccentricity: 0.1, orbitalInclination: 0, radius: 60000 },
+        { orbitalPeriod: 11, semiMajorAxis: 1, orbitalEccentricity: 0.1, orbitalInclination: 0, radius: 60000 },
+      ]);
+      const r = service.detectCollisionStatus(a, now);
+      expect(r.isCandidate).toBe(true);
+      expect(r.synodicPeriodDays).toBeCloseTo(110, 6);
+      expect(r.nextCollision).toBeNull();
+    });
+  });
 });

--- a/src/app/data/orbital-relations.service.spec.ts
+++ b/src/app/data/orbital-relations.service.spec.ts
@@ -341,6 +341,11 @@ describe('OrbitalRelationsService', () => {
       expect(r.nextCollision).not.toBeNull();
       // Within a day of the independently computed 3D contact time.
       expect(r.nextCollision!.start.toISOString().slice(0, 10)).toBe('2026-10-18');
+      // Enriched fields for the collision dialog: combined radii (the contact threshold) and the
+      // closest-approach separation, which must sit at or inside that threshold (it IS a contact).
+      expect(r.combinedRadiiKm).toBeCloseTo(2780.05725 + 2715.17175, 3);
+      expect(r.nextCollision!.minSeparationKm).toBeGreaterThan(0);
+      expect(r.nextCollision!.minSeparationKm).toBeLessThanOrEqual(r.combinedRadiiKm!);
     });
 
     it('skips off-node near-miss conjunctions and dates the first true 3D contact', () => {
@@ -407,6 +412,30 @@ describe('OrbitalRelationsService', () => {
       expect(r.nextCollision!.start.toISOString().slice(0, 10)).toBe('2028-08-10');
     });
 
+    it('flags the real Dryooe Flyou PS-U f2-1857 1 b / c pair (tightly-nested, sub-degree valley)', () => {
+      // Two moons on near-coplanar orbits nested only ~4255 km apart radially (semiMajorAxis
+      // 2,935,367 vs 2,939,622 km). Their true closest 3D approach is ~722 km — well inside the
+      // 3459.8 km radii sum — but it lives in a valley < 0.1° wide. The historical fixed-1°
+      // grid stepped over it and reported ~7798 km, wrongly rejecting the pair (isCandidate
+      // false). The adaptive step + line-of-nodes seed must now find it. Brute-force 3D contact
+      // (synodic ≈ 1309 d, so contacts are sparse): 2033-06-15.
+      const [b1] = makeFamily([
+        { name: '1 b', orbitalPeriod: 2.84128111821759, semiMajorAxis: 0.0196217139777391,
+          orbitalEccentricity: 0.001403, orbitalInclination: -0.148447, argOfPeriapsis: 46.239216,
+          ascendingNode: -83.383117, meanAnomaly: 170.83725, radius: 1751.312875,
+          timestamps: { meanAnomaly: '2023-04-07T20:50:43Z' } as any },
+        { name: '1 c', orbitalPeriod: 2.84746178873843, semiMajorAxis: 0.0196501568743971,
+          orbitalEccentricity: 0.000402, orbitalInclination: 0.117054, argOfPeriapsis: 209.510865,
+          ascendingNode: -94.95314, meanAnomaly: 322.88133, radius: 1708.5065,
+          timestamps: { meanAnomaly: '2023-04-07T20:50:43Z' } as any },
+      ]);
+      const r = service.detectCollisionStatus(b1, now);
+      expect(r.isCandidate).toBe(true);
+      expect(r.partnerName).toBe('1 c');
+      expect(r.nextCollision).not.toBeNull();
+      expect(r.nextCollision!.start.toISOString().slice(0, 10)).toBe('2033-06-15');
+    });
+
     it('reports the contact window (start/end) for the real Braireau AA-A h761 1 b / c pair', () => {
       // A collision is an interval, not an instant. An independent brute-force 3D Kepler
       // propagation (combined radii 6509.6 km) puts the contact window on 2028-06-19:
@@ -441,7 +470,10 @@ describe('OrbitalRelationsService', () => {
         { orbitalPeriod: 10, semiMajorAxis: 1, orbitalEccentricity: 0.1, radius: 60000 },
         { orbitalPeriod: 11, semiMajorAxis: 1, orbitalEccentricity: 1.5, radius: 60000 },
       ]);
-      expect(service.detectCollisionStatus(a, now).isCandidate).toBe(false);
+      const r = service.detectCollisionStatus(a, now);
+      expect(r.isCandidate).toBe(false);
+      // A non-candidate carries no contact threshold.
+      expect(r.combinedRadiiKm).toBeNull();
     });
 
     it('still flags a geometric candidate when timing data is missing (no date)', () => {
@@ -453,6 +485,8 @@ describe('OrbitalRelationsService', () => {
       expect(r.isCandidate).toBe(true);
       expect(r.synodicPeriodDays).toBeCloseTo(110, 6);
       expect(r.nextCollision).toBeNull();
+      // Combined radii is known even without a contact date (geometry alone).
+      expect(r.combinedRadiiKm).toBeCloseTo(120000, 6);
     });
   });
 });

--- a/src/app/data/orbital-relations.service.ts
+++ b/src/app/data/orbital-relations.service.ts
@@ -39,6 +39,8 @@ export interface CollisionStatus {
   synodicPeriodDays: number | null;
   /** Next contact window (when the bodies are within combined radii), or null when timing data is missing. */
   nextCollision: CollisionWindow | null;
+  /** Up to 10 upcoming contact windows in chronological order; empty when timing data is missing. */
+  upcomingCollisions: CollisionWindow[];
   /** Sum of the two bodies' radii (km) — the contact threshold; null when not a candidate. */
   combinedRadiiKm: number | null;
 }
@@ -320,10 +322,12 @@ export class OrbitalRelationsService {
     }
 
     // Position in the orbital plane (periapsis along +x), then standard 3-1-3 rotation.
+    // The ED/Spansh data uses the opposite sign convention from the standard astronomical
+    // frame, so both angles must be negated before the rotation is applied.
     const xo = a * (Math.cos(E) - e);
     const yo = a * Math.sqrt(1 - e * e) * Math.sin(E);
-    const node = (bd.ascendingNode ?? 0) * DEG_TO_RAD;
-    const argp = (bd.argOfPeriapsis ?? 0) * DEG_TO_RAD;
+    const node = -(bd.ascendingNode ?? 0) * DEG_TO_RAD;
+    const argp = -(bd.argOfPeriapsis ?? 0) * DEG_TO_RAD;
     const incl = (bd.orbitalInclination ?? 0) * DEG_TO_RAD;
     const cO = Math.cos(node), sO = Math.sin(node);
     const cw = Math.cos(argp), sw = Math.sin(argp);
@@ -478,7 +482,9 @@ export class OrbitalRelationsService {
       if (bd.meanAnomaly == null || !bd.orbitalPeriod || !bd.timestamps?.meanAnomaly) { return null; }
       const M = this.meanAnomalyNow(bd.meanAnomaly, bd.orbitalPeriod, bd.timestamps.meanAnomaly, now);
       if (!Number.isFinite(M)) { return null; }
-      return ((((bd.ascendingNode ?? 0) + (bd.argOfPeriapsis ?? 0) + M) % 360) + 360) % 360;
+      // Angles are negated to match the sign convention used in orbitalStateVector.
+      // Mean longitude = M - Ω - ω (negated Ω and ω relative to the raw ED values).
+      return (((M - (bd.ascendingNode ?? 0) - (bd.argOfPeriapsis ?? 0)) % 360) + 360) % 360;
     };
     const lonA = lon(a), lonB = lon(b);
     if (lonA == null || lonB == null || !Number.isFinite(synodicDays)) { return null; }
@@ -499,9 +505,14 @@ export class OrbitalRelationsService {
    * for the true minimum separation (separation oscillates at the orbital period, not just
    * the synodic one), and report the first anchor whose closest approach is within contact.
    */
-  private nextContact(a: CanonnBiostatsBody, b: CanonnBiostatsBody, contactKm: number, synodicDays: number, now: number): CollisionWindow | null {
+  /**
+   * Returns up to `count` upcoming contact windows between two bodies, searching consecutive
+   * synodic-period conjunctions for genuine 3D contacts (separation ≤ combinedRadiiKm).
+   * De-duplicates windows so a single prolonged contact episode is only reported once.
+   */
+  private nextContacts(a: CanonnBiostatsBody, b: CanonnBiostatsBody, contactKm: number, synodicDays: number, now: number, count: number): CollisionWindow[] {
     const firstDays = this.nextConjunctionDays(a, b, synodicDays, now);
-    if (firstDays == null || !Number.isFinite(synodicDays)) { return null; }
+    if (firstDays == null || !Number.isFinite(synodicDays)) { return []; }
 
     // Cheap repeated propagation: precompute each body's epoch so we avoid re-parsing the
     // timestamp string on every one of the many separation evaluations below.
@@ -518,8 +529,15 @@ export class OrbitalRelationsService {
 
     const windowDays = 2 * Math.max(a.orbitalPeriod!, b.orbitalPeriod!);
     const stepDays = Math.min(a.orbitalPeriod!, b.orbitalPeriod!) / 40;
-    for (let k = 0; k < MAX_CONJUNCTIONS_SCANNED; k++) {
+    const stepMs = (30 / 86400) * MS_PER_DAY; // 30-second probe steps for bisection
+    const maxSpanMs = windowDays * MS_PER_DAY;  // ≈ 2 × the longer orbital period
+    const results: CollisionWindow[] = [];
+
+    for (let k = 0; k < MAX_CONJUNCTIONS_SCANNED && results.length < count; k++) {
       const centerMs = now + (firstDays + k * synodicDays) * MS_PER_DAY;
+      // Skip conjunction windows that fall inside an already-found contact episode.
+      if (results.length > 0 && centerMs < results[results.length - 1].end.getTime()) { continue; }
+
       let bestT = -1, bestSep = Infinity;
       for (let t = centerMs - windowDays * MS_PER_DAY; t <= centerMs + windowDays * MS_PER_DAY; t += stepDays * MS_PER_DAY) {
         if (t < now) { continue; }
@@ -538,45 +556,40 @@ export class OrbitalRelationsService {
         const s = sep(t);
         if (s < bestSep) { bestSep = s; bestT = t; }
       }
-      if (bestSep <= contactKm) {
-        // `bestT` is a confirmed in-contact instant (the minimum-separation time). The contact
-        // is an interval, so root-find the two times where sep(t) === contactKm bracketing it:
-        // step outward in small increments until separation rises back above contactKm, then
-        // bisect for precision. Bound the outward walk to ~2 orbital periods either way.
-        const stepMs = (30 / 86400) * MS_PER_DAY; // 30-second probe steps
-        const maxSpanMs = windowDays * MS_PER_DAY; // ≈ 2 × the longer orbital period
 
-        // START: walk backward to bracket the down-crossing, then bisect.
-        let lo = bestT;
-        let hi = bestT - stepMs;
-        while (bestT - hi <= maxSpanMs && sep(hi) <= contactKm) {
-          lo = hi;
-          hi -= stepMs;
-        }
-        // [hi, lo] now brackets the crossing (sep(hi) > contactKm ≥ sep(lo)); bisect.
-        for (let i = 0; i < 40; i++) {
-          const mid = (hi + lo) / 2;
-          if (sep(mid) > contactKm) { hi = mid; } else { lo = mid; }
-        }
-        const startMs = lo;
+      if (bestSep > contactKm) { continue; }
 
-        // END: symmetric, walk forward to bracket the up-crossing, then bisect.
-        let elo = bestT;
-        let ehi = bestT + stepMs;
-        while (ehi - bestT <= maxSpanMs && sep(ehi) <= contactKm) {
-          elo = ehi;
-          ehi += stepMs;
-        }
-        for (let i = 0; i < 40; i++) {
-          const mid = (elo + ehi) / 2;
-          if (sep(mid) > contactKm) { ehi = mid; } else { elo = mid; }
-        }
-        const endMs = elo;
+      // `bestT` is a confirmed in-contact instant (the minimum-separation time). The contact
+      // is an interval, so root-find the two times where sep(t) === contactKm bracketing it:
+      // step outward in small increments until separation rises back above contactKm, then
+      // bisect for precision. Bound the outward walk to ~2 orbital periods either way.
 
-        return { start: new Date(startMs), end: new Date(endMs), days: (startMs - now) / MS_PER_DAY, minSeparationKm: bestSep };
+      // START: walk backward to bracket the down-crossing, then bisect.
+      let lo = bestT;
+      let hi = bestT - stepMs;
+      while (bestT - hi <= maxSpanMs && sep(hi) <= contactKm) { lo = hi; hi -= stepMs; }
+      for (let i = 0; i < 40; i++) {
+        const mid = (hi + lo) / 2;
+        if (sep(mid) > contactKm) { hi = mid; } else { lo = mid; }
       }
+      const startMs = lo;
+
+      // De-duplicate: skip if this window is part of a contact episode already recorded.
+      if (results.length > 0 && startMs <= results[results.length - 1].end.getTime()) { continue; }
+
+      // END: walk forward to bracket the up-crossing, then bisect.
+      let elo = bestT;
+      let ehi = bestT + stepMs;
+      while (ehi - bestT <= maxSpanMs && sep(ehi) <= contactKm) { elo = ehi; ehi += stepMs; }
+      for (let i = 0; i < 40; i++) {
+        const mid = (elo + ehi) / 2;
+        if (sep(mid) > contactKm) { ehi = mid; } else { elo = mid; }
+      }
+      const endMs = elo;
+
+      results.push({ start: new Date(startMs), end: new Date(endMs), days: (startMs - now) / MS_PER_DAY, minSeparationKm: bestSep });
     }
-    return null;
+    return results;
   }
 
   /**
@@ -594,13 +607,13 @@ export class OrbitalRelationsService {
    */
   detectCollisionStatus(body: SystemBody, now: number = Date.now()): CollisionStatus {
     const none: CollisionStatus = {
-      isCandidate: false, partnerName: null, synodicPeriodDays: null, nextCollision: null, combinedRadiiKm: null,
+      isCandidate: false, partnerName: null, synodicPeriodDays: null, nextCollision: null, upcomingCollisions: [], combinedRadiiKm: null,
     };
     const bd = body.bodyData;
     const range = this.orbitalRadialRange(bd);
     if (!body.parent || !bd.orbitalPeriod || !range) { return none; }
 
-    let best: { partner: SystemBody; synodic: number; event: CollisionWindow | null; contactKm: number } | null = null;
+    let best: { partner: SystemBody; synodic: number; events: CollisionWindow[]; contactKm: number } | null = null;
     for (const sibling of body.parent.subBodies) {
       if (sibling === body) { continue; }
       const sd = sibling.bodyData;
@@ -620,20 +633,26 @@ export class OrbitalRelationsService {
       if (this.minOrbitDistanceKm(bd, sd, contactKm) > contactKm) { continue; }
 
       const synodic = 1 / Math.abs(1 / bd.orbitalPeriod - 1 / sd.orbitalPeriod);
-      const event = this.nextContact(bd, sd, contactKm, synodic, now);
+      // Fetch the first contact only for partner selection; the winning partner gets the full 10.
+      const events = this.nextContacts(bd, sd, contactKm, synodic, now, 1);
+      const first = events[0] ?? null;
       // Prefer the partner with the soonest predicted collision; keep any geometric
       // candidate as a fallback when timing data is unavailable for an earlier one.
-      if (!best || (event && (!best.event || event.days < best.event.days))) {
-        best = { partner: sibling, synodic, event, contactKm };
+      if (!best || (first && (!best.events[0] || first.days < best.events[0].days))) {
+        best = { partner: sibling, synodic, events, contactKm };
       }
     }
 
     if (!best) { return none; }
+
+    // Expand the winning partner to the full upcoming-collisions list.
+    const upcoming = this.nextContacts(bd, best.partner.bodyData, best.contactKm, best.synodic, now, 10);
     return {
       isCandidate: true,
       partnerName: best.partner.bodyData.name,
       synodicPeriodDays: best.synodic,
-      nextCollision: best.event,
+      nextCollision: upcoming[0] ?? null,
+      upcomingCollisions: upcoming,
       combinedRadiiKm: best.contactKm,
     };
   }

--- a/src/app/data/orbital-relations.service.ts
+++ b/src/app/data/orbital-relations.service.ts
@@ -25,6 +25,8 @@ export interface CollisionWindow {
   start: Date;
   end: Date;
   days: number;
+  /** Centre-to-centre separation (km) at closest approach within the window — the deepest point of contact. */
+  minSeparationKm: number;
 }
 
 /** Result of collision-candidate analysis for a body relative to a crossing-orbit sibling. */
@@ -37,6 +39,8 @@ export interface CollisionStatus {
   synodicPeriodDays: number | null;
   /** Next contact window (when the bodies are within combined radii), or null when timing data is missing. */
   nextCollision: CollisionWindow | null;
+  /** Sum of the two bodies' radii (km) — the contact threshold; null when not a candidate. */
+  combinedRadiiKm: number | null;
 }
 
 /** Milliseconds per day, used to convert orbital periods (days) to wall-clock time. */
@@ -46,8 +50,15 @@ const MS_PER_DAY = 1000 * 60 * 60 * 24;
 const KM_PER_AU = 149597870.7;
 /** Radians per degree, for the 3D Keplerian position maths. */
 const DEG_TO_RAD = Math.PI / 180;
-/** Step (degrees of mean anomaly) for the coarse orbit-curve sampling in the proximity test. */
-const ORBIT_SAMPLE_STEP_DEG = 1;
+/**
+ * Coarse orbit-curve sampling step (degrees of mean anomaly) for the proximity test is
+ * adaptive: a fixed step that resolves a wide pair would step right over the narrow close-
+ * approach valley of two tightly-nested orbits and report a wildly inflated minimum. We scale
+ * the step so adjacent samples sit ~one contact-distance apart in arc length, clamped between
+ * these bounds (fine for nested pairs, coarse — the historical 1° — for well-separated ones).
+ */
+const ORBIT_MIN_STEP_DEG = 0.05;
+const ORBIT_MAX_STEP_DEG = 1;
 /** How many of the closest coarse cells to refine from (covers multiple close-approach basins). */
 const ORBIT_REFINE_TOPK = 6;
 /** Half-grid size (per axis) for each zoom pass refining the orbit-to-orbit minimum. */
@@ -331,16 +342,27 @@ export class OrbitalRelationsService {
    * apart — so the pair is not a collision candidate at all.
    *
    * Two near-circular orbits a few km apart approach within a sliver around their mutual
-   * node, far narrower than a uniform sweep can resolve, so a coarse grid alone reports a
-   * wildly inflated minimum. We therefore locate the closest sampled pair on a coarse grid,
-   * then iteratively zoom the (mean-anomaly-A, mean-anomaly-B) window around it to converge
-   * on the true minimum.
+   * node, far narrower than a uniform sweep can resolve, so a fixed coarse grid alone reports
+   * a wildly inflated minimum. We defend against that two ways: the coarse step is scaled to
+   * the geometry (`contactKm` is the resolution we care about, so adjacent samples sit ~one
+   * contact-distance apart in arc length), and we additionally seed the refinement on the
+   * orbits' mutual line of nodes — where a relative tilt brings near-coplanar orbits closest.
+   * We then refine from each seed and take the overall minimum.
    */
-  private minOrbitDistanceKm(a: CanonnBiostatsBody, b: CanonnBiostatsBody): number {
+  private minOrbitDistanceKm(a: CanonnBiostatsBody, b: CanonnBiostatsBody, contactKm: number): number {
+    // Resolve the close-approach valley: step so the arc between samples on the larger orbit
+    // is roughly the contact distance. clamp keeps it cheap for wide pairs (1°, as before) and
+    // fine enough for tightly-nested ones without an unbounded grid.
+    const aMaxKm = Math.max(a.semiMajorAxis!, b.semiMajorAxis!) * KM_PER_AU;
+    const stepDeg = Math.min(
+      Math.max((contactKm / aMaxKm) * (180 / Math.PI), ORBIT_MIN_STEP_DEG),
+      ORBIT_MAX_STEP_DEG,
+    );
+
     // Positions are computed once per sampled angle (per axis) and reused across the cross
     // product, so an N×N grid costs 2N state-vector evaluations, not N².
     const coarse: number[] = [];
-    for (let deg = 0; deg < 360; deg += ORBIT_SAMPLE_STEP_DEG) { coarse.push(deg); }
+    for (let deg = 0; deg < 360; deg += stepDeg) { coarse.push(deg); }
     const posA = coarse.map(d => this.orbitalStateVector(a, d));
     const posB = coarse.map(d => this.orbitalStateVector(b, d));
 
@@ -363,20 +385,67 @@ export class OrbitalRelationsService {
       }
     }
 
+    // Refinement seeds: the K closest grid cells, plus the two ends of the mutual line of
+    // nodes (the line where the orbital planes intersect). For near-coplanar nested orbits the
+    // true minimum sits on that line — the grid can step over it, but the node seed cannot.
+    const seeds: [number, number][] = topK.map(cell => [coarse[cell.i], coarse[cell.j]]);
+    for (const seed of this.lineOfNodeSeeds(posA, posB, coarse)) { seeds.push(seed); }
+
     let best = Infinity;
-    for (const cell of topK) {
-      best = Math.min(best, this.refineOrbitMinimum(a, b, coarse[cell.i], coarse[cell.j]));
+    for (const [startA, startB] of seeds) {
+      best = Math.min(best, this.refineOrbitMinimum(a, b, startA, startB, stepDeg));
     }
     return best;
   }
 
   /**
+   * Mean-anomaly seeds at the two ends of the orbits' mutual line of nodes (the intersection
+   * of the two orbital planes), one (mean-anomaly-A, mean-anomaly-B) pair per end. For
+   * near-coplanar nested orbits the closest 3D approach lies on this line, where the relative
+   * tilt's vertical separation vanishes — a valley a uniform grid can step over. Returns []
+   * for effectively coplanar orbits: their planes are parallel, there is no distinct node
+   * line, and without a vertical valley the coarse grid already resolves the minimum.
+   */
+  private lineOfNodeSeeds(posA: Vec3[], posB: Vec3[], coarse: number[]): [number, number][] {
+    // Two position vectors from the focus span each orbital plane; their cross product is the
+    // plane normal. Use samples ~90° apart so they are well separated.
+    const quarter = Math.floor(coarse.length / 4);
+    const normalA = this.cross(posA[0], posA[quarter]);
+    const normalB = this.cross(posB[0], posB[quarter]);
+    const nodeLine = this.cross(normalA, normalB);
+    if (this.norm(nodeLine) <= 1e-6 * this.norm(normalA) * this.norm(normalB)) { return []; }
+
+    const seeds: [number, number][] = [];
+    for (const sign of [1, -1]) {
+      const dir: Vec3 = { x: sign * nodeLine.x, y: sign * nodeLine.y, z: sign * nodeLine.z };
+      seeds.push([this.mostAligned(posA, coarse, dir), this.mostAligned(posB, coarse, dir)]);
+    }
+    return seeds;
+  }
+
+  /** Mean anomaly of the sampled position whose direction (from the focus) best aligns with `dir`. */
+  private mostAligned(pos: Vec3[], coarse: number[], dir: Vec3): number {
+    let bestCos = -Infinity, bestIndex = 0;
+    for (let i = 0; i < pos.length; i++) {
+      const cos = this.dot(pos[i], dir) / this.norm(pos[i]);
+      if (cos > bestCos) { bestCos = cos; bestIndex = i; }
+    }
+    return coarse[bestIndex];
+  }
+
+  private cross(p: Vec3, q: Vec3): Vec3 {
+    return { x: p.y * q.z - p.z * q.y, y: p.z * q.x - p.x * q.z, z: p.x * q.y - p.y * q.x };
+  }
+  private dot(p: Vec3, q: Vec3): number { return p.x * q.x + p.y * q.y + p.z * q.z; }
+  private norm(p: Vec3): number { return Math.sqrt(this.dot(p, p)); }
+
+  /**
    * Refines the orbit-to-orbit minimum distance starting from a coarse (mean-anomaly-A,
    * mean-anomaly-B) cell, by repeatedly sampling a shrinking window around the running best.
    */
-  private refineOrbitMinimum(a: CanonnBiostatsBody, b: CanonnBiostatsBody, startA: number, startB: number): number {
+  private refineOrbitMinimum(a: CanonnBiostatsBody, b: CanonnBiostatsBody, startA: number, startB: number, stepDeg: number): number {
     let aDeg = startA, bDeg = startB, best = Infinity;
-    let half = ORBIT_SAMPLE_STEP_DEG;
+    let half = stepDeg;
     for (let iter = 0; iter < ORBIT_REFINE_ITERATIONS; iter++) {
       const degsA: number[] = [], degsB: number[] = [];
       for (let k = -ORBIT_REFINE_GRID; k <= ORBIT_REFINE_GRID; k++) {
@@ -504,7 +573,7 @@ export class OrbitalRelationsService {
         }
         const endMs = elo;
 
-        return { start: new Date(startMs), end: new Date(endMs), days: (startMs - now) / MS_PER_DAY };
+        return { start: new Date(startMs), end: new Date(endMs), days: (startMs - now) / MS_PER_DAY, minSeparationKm: bestSep };
       }
     }
     return null;
@@ -525,13 +594,13 @@ export class OrbitalRelationsService {
    */
   detectCollisionStatus(body: SystemBody, now: number = Date.now()): CollisionStatus {
     const none: CollisionStatus = {
-      isCandidate: false, partnerName: null, synodicPeriodDays: null, nextCollision: null,
+      isCandidate: false, partnerName: null, synodicPeriodDays: null, nextCollision: null, combinedRadiiKm: null,
     };
     const bd = body.bodyData;
     const range = this.orbitalRadialRange(bd);
     if (!body.parent || !bd.orbitalPeriod || !range) { return none; }
 
-    let best: { partner: SystemBody; synodic: number; event: CollisionWindow | null } | null = null;
+    let best: { partner: SystemBody; synodic: number; event: CollisionWindow | null; contactKm: number } | null = null;
     for (const sibling of body.parent.subBodies) {
       if (sibling === body) { continue; }
       const sd = sibling.bodyData;
@@ -548,14 +617,14 @@ export class OrbitalRelationsService {
 
       // Exact 3D candidacy: do the orbit curves themselves come within contact distance? A
       // relative tilt can keep radially-overlapping orbits permanently apart.
-      if (this.minOrbitDistanceKm(bd, sd) > contactKm) { continue; }
+      if (this.minOrbitDistanceKm(bd, sd, contactKm) > contactKm) { continue; }
 
       const synodic = 1 / Math.abs(1 / bd.orbitalPeriod - 1 / sd.orbitalPeriod);
       const event = this.nextContact(bd, sd, contactKm, synodic, now);
       // Prefer the partner with the soonest predicted collision; keep any geometric
       // candidate as a fallback when timing data is unavailable for an earlier one.
       if (!best || (event && (!best.event || event.days < best.event.days))) {
-        best = { partner: sibling, synodic, event };
+        best = { partner: sibling, synodic, event, contactKm };
       }
     }
 
@@ -565,6 +634,7 @@ export class OrbitalRelationsService {
       partnerName: best.partner.bodyData.name,
       synodicPeriodDays: best.synodic,
       nextCollision: best.event,
+      combinedRadiiKm: best.contactKm,
     };
   }
 }

--- a/src/app/data/orbital-relations.service.ts
+++ b/src/app/data/orbital-relations.service.ts
@@ -15,8 +15,47 @@ export interface OrbitalEvent {
   days: number;
 }
 
+/**
+ * The contact *window* of a collision: a collision is an interval, not an instant. `start`
+ * is when the bodies' separation first drops below the sum of their radii and `end` is when
+ * it rises back above; `days` is the number of days from `now` until `start` (it can be
+ * slightly negative when contact is already in progress at `now`).
+ */
+export interface CollisionWindow {
+  start: Date;
+  end: Date;
+  days: number;
+}
+
+/** Result of collision-candidate analysis for a body relative to a crossing-orbit sibling. */
+export interface CollisionStatus {
+  /** True when this body shares its parent with a sibling on a crossing, near-coplanar orbit. */
+  isCandidate: boolean;
+  /** Name of the sibling whose orbit crosses this body's, or null when none. */
+  partnerName: string | null;
+  /** Synodic period (days) between the pair — the interval between successive conjunctions. */
+  synodicPeriodDays: number | null;
+  /** Next contact window (when the bodies are within combined radii), or null when timing data is missing. */
+  nextCollision: CollisionWindow | null;
+}
+
 /** Milliseconds per day, used to convert orbital periods (days) to wall-clock time. */
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/** Kilometres per astronomical unit, to compare body radii against orbital distances. */
+const KM_PER_AU = 149597870.7;
+/** Radians per degree, for the 3D Keplerian position maths. */
+const DEG_TO_RAD = Math.PI / 180;
+/** Step (degrees of mean anomaly) for the coarse orbit-curve sampling in the proximity test. */
+const ORBIT_SAMPLE_STEP_DEG = 1;
+/** How many of the closest coarse cells to refine from (covers multiple close-approach basins). */
+const ORBIT_REFINE_TOPK = 6;
+/** Half-grid size (per axis) for each zoom pass refining the orbit-to-orbit minimum. */
+const ORBIT_REFINE_GRID = 4;
+/** Number of zoom passes refining the orbit-to-orbit minimum distance. */
+const ORBIT_REFINE_ITERATIONS = 10;
+/** Upper bound on conjunctions examined before giving up on finding a collision date. */
+const MAX_CONJUNCTIONS_SCANNED = 300;
 
 /** Angular tolerance (degrees) for matching a Lagrange geometry. */
 const ANGLE_TOLERANCE_DEG = 1;
@@ -24,6 +63,9 @@ const ANGLE_TOLERANCE_DEG = 1;
 const ALIGNMENT_TOLERANCE_DEG = 5;
 /** Tolerance (degrees) for equal rosette spacing. */
 const ROSETTE_TOLERANCE_DEG = 5;
+
+/** A 3D position in the system's shared frame (kilometres). */
+interface Vec3 { x: number; y: number; z: number; }
 
 /**
  * Detects co-orbital configurations (Trojan/Lagrange points and rosettes) by comparing
@@ -230,5 +272,299 @@ export class OrbitalRelationsService {
       return null;
     }
     return { date: new Date(now + days * MS_PER_DAY), days };
+  }
+
+  /**
+   * Orbital radial range [periapsis, apoapsis] in AU, or null for an orbit that isn't a
+   * bound, recurring ellipse: a missing/non-positive semi-major axis, or an eccentricity
+   * ≥ 1 (parabolic/hyperbolic escape trajectory, which has no apoapsis and never returns,
+   * so it can't be a recurring collision partner). The `> 0` check is deliberate — a
+   * falsy/`!` test would let a negative semi-major axis (the convention for hyperbolic
+   * orbits, or corrupt external data) through and produce an inverted range.
+   */
+  private orbitalRadialRange(bd: CanonnBiostatsBody): { peri: number; apo: number } | null {
+    if (!(bd.semiMajorAxis! > 0)) { return null; }
+    const e = bd.orbitalEccentricity ?? 0;
+    if (!(e >= 0) || e >= 1) { return null; }
+    return { peri: bd.semiMajorAxis! * (1 - e), apo: bd.semiMajorAxis! * (1 + e) };
+  }
+
+  /**
+   * Parent-centric position (km) of a body at the given mean anomaly, from its Keplerian
+   * elements. Solves Kepler's equation for the eccentric anomaly, places the body in its
+   * orbital plane, then rotates by argument-of-periapsis, inclination and ascending node
+   * into the shared 3D frame. This is the geometry both the orbit-proximity test and the
+   * time-stepped collision search build on.
+   */
+  private orbitalStateVector(bd: CanonnBiostatsBody, meanAnomalyDeg: number): Vec3 {
+    const a = bd.semiMajorAxis! * KM_PER_AU;
+    const e = Math.min(Math.max(bd.orbitalEccentricity ?? 0, 0), 0.999);
+    const M = (((meanAnomalyDeg % 360) + 360) % 360) * DEG_TO_RAD;
+
+    let E = e < 0.8 ? M : Math.PI;
+    for (let i = 0; i < 12; i++) {
+      const delta = (E - e * Math.sin(E) - M) / (1 - e * Math.cos(E));
+      E -= delta;
+      if (Math.abs(delta) < 1e-12) { break; }
+    }
+
+    // Position in the orbital plane (periapsis along +x), then standard 3-1-3 rotation.
+    const xo = a * (Math.cos(E) - e);
+    const yo = a * Math.sqrt(1 - e * e) * Math.sin(E);
+    const node = (bd.ascendingNode ?? 0) * DEG_TO_RAD;
+    const argp = (bd.argOfPeriapsis ?? 0) * DEG_TO_RAD;
+    const incl = (bd.orbitalInclination ?? 0) * DEG_TO_RAD;
+    const cO = Math.cos(node), sO = Math.sin(node);
+    const cw = Math.cos(argp), sw = Math.sin(argp);
+    const ci = Math.cos(incl), si = Math.sin(incl);
+    return {
+      x: xo * (cO * cw - sO * sw * ci) - yo * (cO * sw + sO * cw * ci),
+      y: xo * (sO * cw + cO * sw * ci) - yo * (sO * sw - cO * cw * ci),
+      z: xo * (sw * si) + yo * (cw * si),
+    };
+  }
+
+  /**
+   * Minimum distance (km) between the two orbit *curves*, independent of where each body
+   * currently is. When this exceeds the sum of the bodies' radii the orbits never touch in
+   * 3D — even if their radial ranges overlap, a relative tilt can hold the paths permanently
+   * apart — so the pair is not a collision candidate at all.
+   *
+   * Two near-circular orbits a few km apart approach within a sliver around their mutual
+   * node, far narrower than a uniform sweep can resolve, so a coarse grid alone reports a
+   * wildly inflated minimum. We therefore locate the closest sampled pair on a coarse grid,
+   * then iteratively zoom the (mean-anomaly-A, mean-anomaly-B) window around it to converge
+   * on the true minimum.
+   */
+  private minOrbitDistanceKm(a: CanonnBiostatsBody, b: CanonnBiostatsBody): number {
+    // Positions are computed once per sampled angle (per axis) and reused across the cross
+    // product, so an N×N grid costs 2N state-vector evaluations, not N².
+    const coarse: number[] = [];
+    for (let deg = 0; deg < 360; deg += ORBIT_SAMPLE_STEP_DEG) { coarse.push(deg); }
+    const posA = coarse.map(d => this.orbitalStateVector(a, d));
+    const posB = coarse.map(d => this.orbitalStateVector(b, d));
+
+    // Keep the K closest coarse cells, not just the single closest. The closest approach of
+    // two near-coincident orbits lies in a narrow valley; the single best coarse sample can
+    // sit on a shallower stretch of that valley while the true minimum hides in a different
+    // cell, so we refine from several basins and take the overall minimum.
+    const topK: { d2: number; i: number; j: number }[] = [];
+    for (let i = 0; i < posA.length; i++) {
+      for (let j = 0; j < posB.length; j++) {
+        const dx = posA[i].x - posB[j].x, dy = posA[i].y - posB[j].y, dz = posA[i].z - posB[j].z;
+        const d2 = dx * dx + dy * dy + dz * dz;
+        if (topK.length < ORBIT_REFINE_TOPK) {
+          topK.push({ d2, i, j });
+          topK.sort((p, q) => q.d2 - p.d2); // worst first
+        } else if (d2 < topK[0].d2) {
+          topK[0] = { d2, i, j };
+          topK.sort((p, q) => q.d2 - p.d2);
+        }
+      }
+    }
+
+    let best = Infinity;
+    for (const cell of topK) {
+      best = Math.min(best, this.refineOrbitMinimum(a, b, coarse[cell.i], coarse[cell.j]));
+    }
+    return best;
+  }
+
+  /**
+   * Refines the orbit-to-orbit minimum distance starting from a coarse (mean-anomaly-A,
+   * mean-anomaly-B) cell, by repeatedly sampling a shrinking window around the running best.
+   */
+  private refineOrbitMinimum(a: CanonnBiostatsBody, b: CanonnBiostatsBody, startA: number, startB: number): number {
+    let aDeg = startA, bDeg = startB, best = Infinity;
+    let half = ORBIT_SAMPLE_STEP_DEG;
+    for (let iter = 0; iter < ORBIT_REFINE_ITERATIONS; iter++) {
+      const degsA: number[] = [], degsB: number[] = [];
+      for (let k = -ORBIT_REFINE_GRID; k <= ORBIT_REFINE_GRID; k++) {
+        degsA.push(aDeg + (k / ORBIT_REFINE_GRID) * half);
+        degsB.push(bDeg + (k / ORBIT_REFINE_GRID) * half);
+      }
+      const posA = degsA.map(d => this.orbitalStateVector(a, d));
+      const posB = degsB.map(d => this.orbitalStateVector(b, d));
+      let cA = aDeg, cB = bDeg;
+      for (let i = 0; i < posA.length; i++) {
+        for (let j = 0; j < posB.length; j++) {
+          const dx = posA[i].x - posB[j].x, dy = posA[i].y - posB[j].y, dz = posA[i].z - posB[j].z;
+          const d = Math.sqrt(dx * dx + dy * dy + dz * dz);
+          if (d < best) { best = d; cA = degsA[i]; cB = degsB[j]; }
+        }
+      }
+      aDeg = cA; bDeg = cB;
+      half /= ORBIT_REFINE_GRID; // next window spans the previous grid spacing
+    }
+    return best;
+  }
+
+  /**
+   * Days from `now` until the two bodies' mean longitudes next coincide (conjunction), used
+   * only to anchor the collision search near the once-per-synodic-period close approach.
+   * Null when either body lacks the elements to propagate its position to `now`.
+   */
+  private nextConjunctionDays(a: CanonnBiostatsBody, b: CanonnBiostatsBody, synodicDays: number, now: number): number | null {
+    const lon = (bd: CanonnBiostatsBody): number | null => {
+      if (bd.meanAnomaly == null || !bd.orbitalPeriod || !bd.timestamps?.meanAnomaly) { return null; }
+      const M = this.meanAnomalyNow(bd.meanAnomaly, bd.orbitalPeriod, bd.timestamps.meanAnomaly, now);
+      if (!Number.isFinite(M)) { return null; }
+      return ((((bd.ascendingNode ?? 0) + (bd.argOfPeriapsis ?? 0) + M) % 360) + 360) % 360;
+    };
+    const lonA = lon(a), lonB = lon(b);
+    if (lonA == null || lonB == null || !Number.isFinite(synodicDays)) { return null; }
+    const aFaster = a.orbitalPeriod! < b.orbitalPeriod!;
+    const lead = aFaster ? lonA : lonB;
+    const lag = aFaster ? lonB : lonA;
+    let gap = (lag - lead) % 360;
+    if (gap < 0) { gap += 360; }
+    return (gap / 360) * synodicDays;
+  }
+
+  /**
+   * Next time the two bodies actually pass within `contactKm` of each other in 3D, or null
+   * if no contact occurs within the search horizon. A longitude conjunction recurs once per
+   * synodic period but is a genuine collision only when it lands near the orbits' mutual
+   * intersection — an off-node conjunction sails past with kilometres of vertical clearance.
+   * So we anchor on each successive conjunction, finely scan a few orbital periods around it
+   * for the true minimum separation (separation oscillates at the orbital period, not just
+   * the synodic one), and report the first anchor whose closest approach is within contact.
+   */
+  private nextContact(a: CanonnBiostatsBody, b: CanonnBiostatsBody, contactKm: number, synodicDays: number, now: number): CollisionWindow | null {
+    const firstDays = this.nextConjunctionDays(a, b, synodicDays, now);
+    if (firstDays == null || !Number.isFinite(synodicDays)) { return null; }
+
+    // Cheap repeated propagation: precompute each body's epoch so we avoid re-parsing the
+    // timestamp string on every one of the many separation evaluations below.
+    const epochA = Date.parse(a.timestamps!.meanAnomaly!);
+    const epochB = Date.parse(b.timestamps!.meanAnomaly!);
+    const sep = (tMs: number): number => {
+      const Ma = a.meanAnomaly! + ((tMs - epochA) / MS_PER_DAY / a.orbitalPeriod!) * 360;
+      const Mb = b.meanAnomaly! + ((tMs - epochB) / MS_PER_DAY / b.orbitalPeriod!) * 360;
+      const pa = this.orbitalStateVector(a, Ma);
+      const pb = this.orbitalStateVector(b, Mb);
+      const dx = pa.x - pb.x, dy = pa.y - pb.y, dz = pa.z - pb.z;
+      return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    };
+
+    const windowDays = 2 * Math.max(a.orbitalPeriod!, b.orbitalPeriod!);
+    const stepDays = Math.min(a.orbitalPeriod!, b.orbitalPeriod!) / 40;
+    for (let k = 0; k < MAX_CONJUNCTIONS_SCANNED; k++) {
+      const centerMs = now + (firstDays + k * synodicDays) * MS_PER_DAY;
+      let bestT = -1, bestSep = Infinity;
+      for (let t = centerMs - windowDays * MS_PER_DAY; t <= centerMs + windowDays * MS_PER_DAY; t += stepDays * MS_PER_DAY) {
+        if (t < now) { continue; }
+        const s = sep(t);
+        if (s < bestSep) { bestSep = s; bestT = t; }
+      }
+      if (bestT < now) { continue; }
+
+      // Refine around the coarse minimum *before* testing contact: the coarse step is too
+      // wide to resolve a narrow separation dip, so a grazing contact whose true minimum
+      // falls between two coarse samples would otherwise be judged against an over-estimated
+      // shoulder value and missed entirely.
+      const fine = stepDays / 20;
+      for (let t = bestT - stepDays * MS_PER_DAY; t <= bestT + stepDays * MS_PER_DAY; t += fine * MS_PER_DAY) {
+        if (t < now) { continue; }
+        const s = sep(t);
+        if (s < bestSep) { bestSep = s; bestT = t; }
+      }
+      if (bestSep <= contactKm) {
+        // `bestT` is a confirmed in-contact instant (the minimum-separation time). The contact
+        // is an interval, so root-find the two times where sep(t) === contactKm bracketing it:
+        // step outward in small increments until separation rises back above contactKm, then
+        // bisect for precision. Bound the outward walk to ~2 orbital periods either way.
+        const stepMs = (30 / 86400) * MS_PER_DAY; // 30-second probe steps
+        const maxSpanMs = windowDays * MS_PER_DAY; // ≈ 2 × the longer orbital period
+
+        // START: walk backward to bracket the down-crossing, then bisect.
+        let lo = bestT;
+        let hi = bestT - stepMs;
+        while (bestT - hi <= maxSpanMs && sep(hi) <= contactKm) {
+          lo = hi;
+          hi -= stepMs;
+        }
+        // [hi, lo] now brackets the crossing (sep(hi) > contactKm ≥ sep(lo)); bisect.
+        for (let i = 0; i < 40; i++) {
+          const mid = (hi + lo) / 2;
+          if (sep(mid) > contactKm) { hi = mid; } else { lo = mid; }
+        }
+        const startMs = lo;
+
+        // END: symmetric, walk forward to bracket the up-crossing, then bisect.
+        let elo = bestT;
+        let ehi = bestT + stepMs;
+        while (ehi - bestT <= maxSpanMs && sep(ehi) <= contactKm) {
+          elo = ehi;
+          ehi += stepMs;
+        }
+        for (let i = 0; i < 40; i++) {
+          const mid = (elo + ehi) / 2;
+          if (sep(mid) > contactKm) { ehi = mid; } else { elo = mid; }
+        }
+        const endMs = elo;
+
+        return { start: new Date(startMs), end: new Date(endMs), days: (startMs - now) / MS_PER_DAY };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Flags a body as a collision candidate when a sibling under the same parent is on a
+   * crossing orbit whose path comes within the sum of the two bodies' radii. The reported
+   * next-collision date is the next time the bodies are actually that close in 3D — not
+   * merely at the same longitude, since most conjunctions pass clear of the orbits' mutual
+   * intersection. Same-period co-orbital bodies (Trojans/rosettes) are excluded: they never
+   * lap each other (infinite synodic period) and are handled by the Trojan/rosette detectors.
+   *
+   * Note: this deliberately goes beyond the Canonn reference spreadsheet's 2D method (radial
+   * apo/periapsis-band overlap + synodic period, ignoring inclination, ascending node, and
+   * phase). The two agree for near-coplanar pairs but diverge on inclined pairs, where the 3D
+   * model defers the collision to the next conjunction that actually falls on the mutual node.
+   */
+  detectCollisionStatus(body: SystemBody, now: number = Date.now()): CollisionStatus {
+    const none: CollisionStatus = {
+      isCandidate: false, partnerName: null, synodicPeriodDays: null, nextCollision: null,
+    };
+    const bd = body.bodyData;
+    const range = this.orbitalRadialRange(bd);
+    if (!body.parent || !bd.orbitalPeriod || !range) { return none; }
+
+    let best: { partner: SystemBody; synodic: number; event: CollisionWindow | null } | null = null;
+    for (const sibling of body.parent.subBodies) {
+      if (sibling === body) { continue; }
+      const sd = sibling.bodyData;
+      const sRange = this.orbitalRadialRange(sd);
+      if (!sd.orbitalPeriod || !sRange) { continue; }
+      // Equal periods never lap (synodic period → ∞): these are stable co-orbital pairs.
+      if (sd.orbitalPeriod === bd.orbitalPeriod) { continue; }
+
+      // Cheap radial pre-filter: if the orbits' distance bands can't approach within the
+      // bodies' combined radius, they can never touch — skip the costly 3D work below.
+      const contactKm = (bd.radius ?? 0) + (sd.radius ?? 0);
+      const radialGapAu = Math.max(range.peri, sRange.peri) - Math.min(range.apo, sRange.apo);
+      if (radialGapAu > contactKm / KM_PER_AU) { continue; }
+
+      // Exact 3D candidacy: do the orbit curves themselves come within contact distance? A
+      // relative tilt can keep radially-overlapping orbits permanently apart.
+      if (this.minOrbitDistanceKm(bd, sd) > contactKm) { continue; }
+
+      const synodic = 1 / Math.abs(1 / bd.orbitalPeriod - 1 / sd.orbitalPeriod);
+      const event = this.nextContact(bd, sd, contactKm, synodic, now);
+      // Prefer the partner with the soonest predicted collision; keep any geometric
+      // candidate as a fallback when timing data is unavailable for an earlier one.
+      if (!best || (event && (!best.event || event.days < best.event.days))) {
+        best = { partner: sibling, synodic, event };
+      }
+    }
+
+    if (!best) { return none; }
+    return {
+      isCandidate: true,
+      partnerName: best.partner.bodyData.name,
+      synodicPeriodDays: best.synodic,
+      nextCollision: best.event,
+    };
   }
 }

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.html
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.html
@@ -49,6 +49,39 @@
       </ul>
     </div>
 
+    @if (data.upcomingCollisions.length > 0) {
+    <div class="upcoming-collisions">
+      <h3>Upcoming collisions</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Contact start (UTC)</th>
+            <th>Days until</th>
+            <th>Duration</th>
+            <th>Overlap</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (w of data.upcomingCollisions; track w.start.getTime(); let i = $index) {
+          <tr>
+            <td class="num">{{ i + 1 }}</td>
+            <td class="date">{{ w.start | date:'yyyy-MM-dd HH:mm':'UTC' }} UTC</td>
+            <td class="num">
+              {{ w.days | number:'1.0-0' }}
+              @if (yearsUntilFor(w) >= 1) {<span class="hint">({{ yearsUntilFor(w) | number:'1.1-1' }} yr)</span>}
+            </td>
+            <td>{{ formatDuration(w) }}</td>
+            <td class="num">
+              @if (overlapPercentFor(w); as pct) { {{ pct | number:'1.0-1' }}% }
+            </td>
+          </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+    }
+
     <div class="explanation">
       <p><strong>What does this mean?</strong></p>
       <p>

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.html
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.html
@@ -1,0 +1,67 @@
+<app-dialog-shell [heading]="heading">
+  <div class="collision-dialog">
+    <div class="values">
+      <ul>
+        <li><strong>Bodies:</strong> {{ data.bodyName }}
+          @if (data.partnerName) { &amp; {{ data.partnerName }} }
+        </li>
+        @if (data.synodicPeriodDays !== null) {
+        <li><strong>Synodic period:</strong>
+          {{ data.synodicPeriodDays | number:'1.0-0' }} days
+          @if (synodicPeriodYears !== null && synodicPeriodYears >= 1) {
+          ({{ synodicPeriodYears | number:'1.1-1' }} years)
+          }
+          <span class="hint">— the interval between successive close approaches</span>
+        </li>
+        }
+
+        @if (data.nextCollision; as c) {
+        <li><strong>Next collision in:</strong>
+          {{ c.days | number:'1.0-0' }} days
+          @if (yearsUntil !== null && yearsUntil >= 1) { ({{ yearsUntil | number:'1.1-1' }} years) }
+        </li>
+        <li><strong>Contact starts:</strong><br>
+          <span class="time">{{ c.start | date:'yyyy-MM-dd HH:mm:ss' }} <span class="tz">{{ c.start | date:'zzzz' }} (your time)</span></span><br>
+          <span class="time">{{ c.start | date:'yyyy-MM-dd HH:mm:ss':'UTC' }} <span class="tz">UTC</span></span>
+        </li>
+        <li><strong>Contact ends:</strong><br>
+          <span class="time">{{ c.end | date:'yyyy-MM-dd HH:mm:ss' }} <span class="tz">{{ c.end | date:'zzzz' }} (your time)</span></span><br>
+          <span class="time">{{ c.end | date:'yyyy-MM-dd HH:mm:ss':'UTC' }} <span class="tz">UTC</span></span>
+        </li>
+        @if (durationMinutes !== null) {
+        <li><strong>Duration:</strong> {{ durationMinutes | number:'1.0-1' }} minutes</li>
+        }
+        <li><strong>Closest approach:</strong> {{ c.minSeparationKm | number:'1.0-0' }} km centre-to-centre</li>
+        @if (data.combinedRadiiKm !== null) {
+        <li><strong>Combined radii (contact threshold):</strong> {{ data.combinedRadiiKm | number:'1.0-0' }} km</li>
+        }
+        @if (overlapPercent !== null) {
+        <li><strong>Overlap:</strong> {{ overlapPercent | number:'1.0-1' }}%
+          @if (overlapLabel) { <span class="hint">— {{ overlapLabel }}</span> }
+        </li>
+        }
+        } @else {
+        <li><strong>Status:</strong> crossing-orbit candidate
+          <span class="hint">— the orbits pass within the combined radii, but a contact date can't be
+            computed without the bodies' mean-anomaly (phase) data.</span>
+        </li>
+        }
+      </ul>
+    </div>
+
+    <div class="explanation">
+      <p><strong>What does this mean?</strong></p>
+      <p>
+        These aren't real physics events. The stellar forge is programmed to prevent collisions, but a few
+        slip through. When two objects are on a collision course, they simply pass straight through each
+        other and carry on in their orbits. It's not supported by the engine — what happens is the two
+        bodies intersect and create a non-game experience of meshes. Any permanent change (a real explosion
+        or new asteroid field) only happens when Frontier manually writes it into a server update.
+      </p>
+      <p>
+        Overlap is the depth of the intersection at closest approach, as a percentage of the bodies'
+        combined radii: 0% means the surfaces merely graze, 100% means the centres pass through one another.
+      </p>
+    </div>
+  </div>
+</app-dialog-shell>

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.scss
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.scss
@@ -1,0 +1,30 @@
+.collision-dialog {
+    .values ul {
+        list-style: none;
+        padding-left: 0;
+        margin: 0 0 20px;
+    }
+
+    .values ul li {
+        padding: 4px 0;
+        line-height: 1.5;
+    }
+
+    .time {
+        font-variant-numeric: tabular-nums;
+    }
+
+    .tz {
+        opacity: 0.7;
+        font-size: 0.9em;
+    }
+
+    .hint {
+        opacity: 0.7;
+        font-style: italic;
+    }
+
+    .explanation {
+        line-height: 1.6;
+    }
+}

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.scss
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.scss
@@ -27,4 +27,47 @@
     .explanation {
         line-height: 1.6;
     }
+
+    .upcoming-collisions {
+        margin-bottom: 20px;
+
+        h3 {
+            margin: 0 0 10px;
+            font-size: 1em;
+            font-weight: 600;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9em;
+
+            th, td {
+                padding: 5px 10px;
+                text-align: left;
+                border-bottom: 1px solid var(--color-surface-border, rgba(255, 255, 255, 0.12));
+            }
+
+            th {
+                font-weight: 600;
+                opacity: 0.8;
+                white-space: nowrap;
+            }
+
+            td.num {
+                text-align: right;
+                font-variant-numeric: tabular-nums;
+                white-space: nowrap;
+            }
+
+            td.date {
+                font-variant-numeric: tabular-nums;
+                white-space: nowrap;
+            }
+
+            tbody tr:hover {
+                background: var(--color-surface-hover, rgba(255, 255, 255, 0.05));
+            }
+        }
+    }
 }

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.spec.ts
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.spec.ts
@@ -1,0 +1,74 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+import { CollisionDialogComponent, CollisionDialogData } from './collision-dialog.component';
+
+function setup(data: CollisionDialogData): ComponentFixture<CollisionDialogComponent> {
+  TestBed.configureTestingModule({
+    imports: [CollisionDialogComponent],
+    providers: [provideZonelessChangeDetection(), { provide: MAT_DIALOG_DATA, useValue: data }],
+  });
+  const fixture = TestBed.createComponent(CollisionDialogComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('CollisionDialogComponent', () => {
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('shows the predicted-collision heading, both UTC and local times, and the caveat', () => {
+    const fixture = setup({
+      bodyName: 'Test 1 b',
+      partnerName: 'Test 1 c',
+      synodicPeriodDays: 400,
+      combinedRadiiKm: 5000,
+      nextCollision: {
+        start: new Date('2026-12-15T14:00:00Z'),
+        end: new Date('2026-12-15T15:30:00Z'),
+        days: 170,
+        minSeparationKm: 1000,
+      },
+    });
+    expect(fixture.componentInstance.heading).toBe('Predicted Collision');
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('Test 1 c');
+    // Both a UTC and a local rendering of the start time are present.
+    expect(el.textContent).toContain('UTC');
+    expect(el.textContent).toContain('your time');
+    // The caveat text must be shown verbatim-ish.
+    expect(el.textContent).toContain('pass straight through each other');
+    expect(el.textContent).toContain('Frontier manually writes it into a server update');
+  });
+
+  it('computes overlap depth and its severity label from separation and combined radii', () => {
+    const fixture = setup({
+      bodyName: 'A', partnerName: 'B', synodicPeriodDays: 10, combinedRadiiKm: 1000,
+      nextCollision: { start: new Date(), end: new Date(), days: 1, minSeparationKm: 100 },
+    });
+    const c = fixture.componentInstance;
+    // 100 km apart with 1000 km combined radii → 90% overlap → "Major impact".
+    expect(c.overlapPercent).toBeCloseTo(90, 6);
+    expect(c.overlapLabel).toBe('Major impact');
+  });
+
+  it('clamps overlap at 0% when the bodies merely graze (separation ≥ combined radii)', () => {
+    const fixture = setup({
+      bodyName: 'A', partnerName: 'B', synodicPeriodDays: 10, combinedRadiiKm: 1000,
+      nextCollision: { start: new Date(), end: new Date(), days: 1, minSeparationKm: 1000 },
+    });
+    expect(fixture.componentInstance.overlapPercent).toBeCloseTo(0, 6);
+    expect(fixture.componentInstance.overlapLabel).toBe('Glancing blow');
+  });
+
+  it('shows the candidate heading and an explanatory note when timing data is missing', () => {
+    const fixture = setup({
+      bodyName: 'A', partnerName: 'B', synodicPeriodDays: 10, combinedRadiiKm: 1000, nextCollision: null,
+    });
+    expect(fixture.componentInstance.heading).toBe('Collision Candidate');
+    expect(fixture.componentInstance.overlapPercent).toBeNull();
+    expect(fixture.componentInstance.durationMinutes).toBeNull();
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain("can't be");
+  });
+});

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.ts
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.ts
@@ -10,6 +10,8 @@ export interface CollisionDialogData {
   partnerName: string | null;
   synodicPeriodDays: number | null;
   nextCollision: CollisionWindow | null;
+  /** Up to 10 upcoming contact windows in chronological order. */
+  upcomingCollisions: CollisionWindow[];
   /** Sum of the two bodies' radii (km) — the contact threshold. */
   combinedRadiiKm: number | null;
 }
@@ -69,5 +71,34 @@ export class CollisionDialogComponent {
   /** Synodic period expressed in years (for context alongside the day count). */
   public get synodicPeriodYears(): number | null {
     return this.data.synodicPeriodDays === null ? null : this.data.synodicPeriodDays / DAYS_PER_YEAR;
+  }
+
+  /**
+   * Contact-window duration as a human-readable string: e.g. "2 days 4 hours and 5 minutes".
+   * Any unit whose value is zero is omitted entirely.
+   */
+  public formatDuration(w: CollisionWindow): string {
+    const totalMinutes = Math.round((w.end.getTime() - w.start.getTime()) / 60000);
+    const days = Math.floor(totalMinutes / 1440);
+    const hours = Math.floor((totalMinutes % 1440) / 60);
+    const minutes = totalMinutes % 60;
+    const parts: string[] = [];
+    if (days > 0) { parts.push(`${days} day${days !== 1 ? 's' : ''}`); }
+    if (hours > 0) { parts.push(`${hours} hour${hours !== 1 ? 's' : ''}`); }
+    if (minutes > 0) { parts.push(`${minutes} minute${minutes !== 1 ? 's' : ''}`); }
+    if (parts.length === 0) { return 'less than 1 minute'; }
+    if (parts.length === 1) { return parts[0]; }
+    return parts.slice(0, -1).join(', ') + ' and ' + parts[parts.length - 1];
+  }
+
+  /** Overlap percentage for a given contact window (0% = grazing, 100% = dead-on). */
+  public overlapPercentFor(w: CollisionWindow): number | null {
+    if (!this.data.combinedRadiiKm) { return null; }
+    return Math.max(0, (1 - w.minSeparationKm / this.data.combinedRadiiKm) * 100);
+  }
+
+  /** Years until the start of a contact window (for display alongside day counts). */
+  public yearsUntilFor(w: CollisionWindow): number {
+    return w.days / DAYS_PER_YEAR;
   }
 }

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.ts
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.ts
@@ -1,0 +1,73 @@
+import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { DatePipe, DecimalPipe } from '@angular/common';
+import { DialogShellComponent } from '../dialog-shell/dialog-shell.component';
+import { CollisionWindow } from '../../data/orbital-relations.service';
+
+/** Data passed to the collision dialog when it is opened from a body's "Collision" badge. */
+export interface CollisionDialogData {
+  bodyName: string;
+  partnerName: string | null;
+  synodicPeriodDays: number | null;
+  nextCollision: CollisionWindow | null;
+  /** Sum of the two bodies' radii (km) — the contact threshold. */
+  combinedRadiiKm: number | null;
+}
+
+/** Days in a Julian year, used to express long intervals (synodic period, time-to-collision) in years. */
+const DAYS_PER_YEAR = 365.25;
+
+/**
+ * Details of a predicted collision between two sibling bodies: when the contact window opens
+ * and closes (local time and UTC), how deeply the bodies overlap, the synodic period, and the
+ * caveats about what these "collisions" actually are in-game.
+ */
+@Component({
+  selector: 'app-collision-dialog',
+  templateUrl: './collision-dialog.component.html',
+  styleUrls: ['./collision-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DialogShellComponent, DatePipe, DecimalPipe],
+})
+export class CollisionDialogComponent {
+  public readonly data = inject<CollisionDialogData>(MAT_DIALOG_DATA);
+
+  public readonly heading = this.data.nextCollision ? 'Predicted Collision' : 'Collision Candidate';
+
+  /** Contact-window duration in minutes (start → end), or null when there is no timed window. */
+  public get durationMinutes(): number | null {
+    const c = this.data.nextCollision;
+    return c ? (c.end.getTime() - c.start.getTime()) / 60000 : null;
+  }
+
+  /**
+   * How deeply the bodies interpenetrate at closest approach, as a percentage of their combined
+   * radii: 0% = surfaces just grazing, 100% = centres coincident (a dead-on hit). Null when the
+   * separation or combined radii are unavailable.
+   */
+  public get overlapPercent(): number | null {
+    const c = this.data.nextCollision;
+    if (!c || !this.data.combinedRadiiKm) { return null; }
+    return Math.max(0, (1 - c.minSeparationKm / this.data.combinedRadiiKm) * 100);
+  }
+
+  /** Plain-language severity for the overlap, mirroring the Canonn collision-table wording. */
+  public get overlapLabel(): string | null {
+    const pct = this.overlapPercent;
+    if (pct === null) { return null; }
+    if (pct < 2) { return 'Glancing blow'; }
+    if (pct < 50) { return 'Minor impact'; }
+    if (pct < 98) { return 'Major impact'; }
+    return 'Head-on collision';
+  }
+
+  /** Time from now until the contact window opens, expressed in years. */
+  public get yearsUntil(): number | null {
+    return this.data.nextCollision ? this.data.nextCollision.days / DAYS_PER_YEAR : null;
+  }
+
+  /** Synodic period expressed in years (for context alongside the day count). */
+  public get synodicPeriodYears(): number | null {
+    return this.data.synodicPeriodDays === null ? null : this.data.synodicPeriodDays / DAYS_PER_YEAR;
+  }
+}

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -283,6 +283,40 @@ describe('SystemBodyComponent (extended coverage)', () => {
     });
   });
 
+  describe('collision dialog', () => {
+    it('opens the collision dialog with this body name and the candidate details', () => {
+      render(makeBody({ name: 'X 1 b' }));
+      component.collisionStatus = {
+        isCandidate: true, partnerName: 'X 1 c', synodicPeriodDays: 8, combinedRadiiKm: 5000,
+        nextCollision: {
+          start: new Date('2026-12-15T14:00:00Z'), end: new Date('2026-12-15T15:30:00Z'),
+          days: 170, minSeparationKm: 1000,
+        },
+      };
+      component.showCollisionDialog();
+      expect(lastDialogData().bodyName).toBe('X 1 b');
+      expect(lastDialogData().partnerName).toBe('X 1 c');
+      expect(lastDialogData().combinedRadiiKm).toBe(5000);
+      expect(lastDialogData().nextCollision.minSeparationKm).toBe(1000);
+    });
+
+    it('does nothing when the body is not a collision candidate', () => {
+      render(makeBody({}));
+      component.collisionStatus = null;
+      const before = dialogOpenCalls;
+      component.showCollisionDialog();
+      expect(dialogOpenCalls).toBe(before);
+    });
+
+    it('formats the badge countdown in days, adding years past a year, and flags in-progress', () => {
+      render(makeBody({}));
+      expect(component.formatCollisionCountdown(-1)).toBe('in progress now');
+      expect(component.formatCollisionCountdown(0.5)).toBe('less than a day');
+      expect(component.formatCollisionCountdown(45)).toBe('45 days');
+      expect(component.formatCollisionCountdown(800)).toContain('years');
+    });
+  });
+
   describe('stellar physics display helpers', () => {
     it('computes spin resonance, tooltip and tangential velocity for a neutron star', () => {
       render(makeBody({

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -92,13 +92,13 @@
         rosetteStatus }}</span>
       }
       @if (collisionStatus?.isCandidate) {
-      <span class="badge badge-red"
+      <span class="badge badge-red clickable"
             [matTooltip]="collisionStatus!.nextCollision
-              ? ('Collision candidate: collides with ' + collisionStatus!.partnerName
-                 + ' on ' + (collisionStatus!.nextCollision!.start | date:'yyyy-MM-dd HH:mm:ss')
-                 + ' until ' + (collisionStatus!.nextCollision!.end | date:'HH:mm:ss')
-                 + ' (synodic period ' + (collisionStatus!.synodicPeriodDays | number:'1.0-0') + ' days)')
-              : ('Collision candidate: crossing orbit with ' + collisionStatus!.partnerName)">Collision</span>
+              ? ('Collides with ' + collisionStatus!.partnerName
+                 + ' in ' + formatCollisionCountdown(collisionStatus!.nextCollision!.days)
+                 + ' — click for details')
+              : ('Crossing orbit with ' + collisionStatus!.partnerName + ' — click for details')"
+            (click)="showCollisionDialog()">Collision</span>
       }
       @if (getRocheExcess() !== null) {
       <span class="badge badge-red"

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -91,6 +91,15 @@
             [matTooltip]="'Klemperer ' + rosetteStatus">{{
         rosetteStatus }}</span>
       }
+      @if (collisionStatus?.isCandidate) {
+      <span class="badge badge-red"
+            [matTooltip]="collisionStatus!.nextCollision
+              ? ('Collision candidate: collides with ' + collisionStatus!.partnerName
+                 + ' on ' + (collisionStatus!.nextCollision!.start | date:'yyyy-MM-dd HH:mm:ss')
+                 + ' until ' + (collisionStatus!.nextCollision!.end | date:'HH:mm:ss')
+                 + ' (synodic period ' + (collisionStatus!.synodicPeriodDays | number:'1.0-0') + ' days)')
+              : ('Collision candidate: crossing orbit with ' + collisionStatus!.partnerName)">Collision</span>
+      }
       @if (getRocheExcess() !== null) {
       <span class="badge badge-red"
             [matTooltip]="'Roche limit exceeded by ' + (getRocheExcess()! | number:'0.0-0') + ' km'">

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -26,6 +26,7 @@ import { HillLimitDialogComponent } from '../dialogs/hill-limit-dialog/hill-limi
 import { RocheLimitDialogComponent } from '../dialogs/roche-limit-dialog/roche-limit-dialog.component';
 import { InvisibleRingDialogComponent, InvisibleRingDialogData } from '../dialogs/invisible-ring-dialog/invisible-ring-dialog.component';
 import { ApoPeriDialogComponent, ApoPeriDialogData } from '../dialogs/apo-peri-dialog/apo-peri-dialog.component';
+import { CollisionDialogComponent, CollisionDialogData } from '../dialogs/collision-dialog/collision-dialog.component';
 import { JetAngleDialogComponent } from '../dialogs/jet-angle-dialog/jet-angle-dialog.component';
 import { JsonDialogComponent, JsonDialogData, formatBodyJson } from '../dialogs/json-dialog/json-dialog.component';
 import { OnFootSafetyDialogComponent, OnFootSafetyDialogData } from '../dialogs/on-foot-safety-dialog/on-foot-safety-dialog.component';
@@ -967,6 +968,37 @@ export class SystemBodyComponent implements OnChanges {
         degreesToEvent
       } satisfies ApoPeriDialogData,
     });
+  }
+
+  /** Opens the collision dialog with this body's collision-candidate details. */
+  public showCollisionDialog(): void {
+    const status = this.collisionStatus;
+    if (!status?.isCandidate) { return; }
+    this.dialog.open(CollisionDialogComponent, {
+      width: '900px',
+      maxWidth: '95vw',
+      autoFocus: 'first-heading',
+      hasBackdrop: true,
+      backdropClass: 'cdk-overlay-dark-backdrop',
+      data: {
+        bodyName: this.body().bodyData.name,
+        partnerName: status.partnerName,
+        synodicPeriodDays: status.synodicPeriodDays,
+        nextCollision: status.nextCollision,
+        combinedRadiiKm: status.combinedRadiiKm,
+      } satisfies CollisionDialogData,
+    });
+  }
+
+  /**
+   * Human-readable time-until for the collision badge tooltip: days, with years in parentheses
+   * once the wait reaches a year. Negative means contact is already in progress.
+   */
+  public formatCollisionCountdown(days: number): string {
+    if (days < 0) { return 'in progress now'; }
+    if (days < 1) { return 'less than a day'; }
+    const dayLabel = `${Math.round(days).toLocaleString()} days`;
+    return days >= 365.25 ? `${dayLabel} (${(days / 365.25).toFixed(1)} years)` : dayLabel;
   }
 
   public showShepherdingHillLimitChart(): void {

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -12,7 +12,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ClickableDirective } from '../clickable.directive';
 import { BodyPhysicsService, ShepherdingHillLimit, BodyRocheLimits, PlanetaryDensity, MassStabilityAlert } from '../data/body-physics.service';
 import { StellarPhysicsService } from '../data/stellar-physics.service';
-import { OrbitalRelationsService } from '../data/orbital-relations.service';
+import { OrbitalRelationsService, CollisionStatus } from '../data/orbital-relations.service';
 import { RocheChartData, HillChartData } from '../data/chart-rendering.service';
 import { BODY_TYPE } from '../data/body-types';
 import { WHITE_DWARF_CLASSES, whiteDwarfSpectralCode, whiteDwarfSpectralTypeKey } from '../data/white-dwarf';
@@ -171,6 +171,13 @@ export class SystemBodyComponent implements OnChanges {
     this.trojanStatus = trojan.lagrangePoint;
     this.trojanHostStatus = trojan.isHost;
     this.rosetteStatus = this.orbitalRelations.detectRosetteStatus(body);
+    // Collision detection runs a costly 3D orbital search, so only redo it when the body
+    // itself changes — not on the many ngOnChanges re-fires from unrelated input flips or
+    // the async codex effect, which leave the orbital geometry untouched.
+    if (this.collisionBody !== body) {
+      this.collisionBody = body;
+      this.collisionStatus = this.orbitalRelations.detectCollisionStatus(body);
+    }
     this.getNextPeriapsis.set(this.calculateNextPeriapsis());
     this.getNextApoapsis.set(this.calculateNextApoapsis());
     this.getRocheExcess.set(this.calculateRocheExcess());
@@ -1187,6 +1194,9 @@ export class SystemBodyComponent implements OnChanges {
   public trojanStatus: string | null = null;
   public trojanHostStatus: boolean = false;
   public rosetteStatus: string | null = null;
+  public collisionStatus: CollisionStatus | null = null;
+  /** The body `collisionStatus` was last computed for, to skip recompute on unrelated re-renders. */
+  private collisionBody: SystemBody | null = null;
   public readonly getEstimatedTempRange = signal<{ min: number; max: number } | null>(null);
   public readonly getLandableBadgeClass = signal('badge-gray');
   public readonly getLandableTooltip = signal('');

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -985,6 +985,7 @@ export class SystemBodyComponent implements OnChanges {
         partnerName: status.partnerName,
         synodicPeriodDays: status.synodicPeriodDays,
         nextCollision: status.nextCollision,
+        upcomingCollisions: status.upcomingCollisions,
         combinedRadiiKm: status.combinedRadiiKm,
       } satisfies CollisionDialogData,
     });


### PR DESCRIPTION
## Summary

Adds collision-candidate detection for orbiting bodies. Sibling bodies under the same parent whose orbits bring them within the sum of their radii are flagged with a red **Collision** badge in the system-body view; the tooltip names the partner, the synodic period, and the **next contact window** (start until end).

## How it works

All logic lives in `OrbitalRelationsService` (`src/app/data/orbital-relations.service.ts`) and runs a full **3D Kepler propagation**:

- **`orbitalStateVector`** — parent-centric 3D position from a body's Keplerian elements.
- **`minOrbitDistanceKm`** — phase-independent minimum distance between the two orbit *curves* (1° coarse grid + multi-basin zoom refinement). Decides candidacy: do the orbits ever come within the combined radii in 3D?
- **`nextContact`** — anchors on successive conjunctions (once per synodic period), finds the first that actually passes within the combined radii, then root-finds the contact window's start/end (the times separation crosses the sum of radii).
- **`detectCollisionStatus`** — orchestrates the above; reports `CollisionWindow { start, end, days }`.

Excluded: same-period co-orbital pairs (Trojans/rosettes — infinite synodic period, handled by existing detectors) and unbound (`e ≥ 1`) orbits. The expensive scan is memoized per body so it doesn't re-run on unrelated `ngOnChanges` fires.

## Why 3D (vs the Canonn 2D reference)

The Canonn reference computes collisions with a 2D radial-band-overlap + synodic method that ignores inclination, ascending node, and phase. This PR deliberately goes further with full 3D. The two **agree for near-coplanar pairs** but **diverge for inclined pairs**, where the 3D model defers the collision to the next conjunction that lands on the orbits' mutual node.

Validated against an independent brute-force 3D propagation:
- Grae Eaec AA-A h0 D 2 c/d → 2026-10-18
- Dryio Hypue RY-A e0 A 6 a/b → 2028-08-10 (sharp-minimum / multi-basin case)
- Braireau AA-A h761 1 b/c → contact window 2028-06-19 07:52:57 → 09:14:49 (inclined pair)

> Note: exact dates are hypersensitive to the live Spansh `meanAnomaly` + epoch (propagating hundreds of orbits), so a stale data dump won't reproduce live-app dates.

## Testing

- `npx ng test --no-watch` → 511 passing (regression tests for each validated pair, plus off-node-skip, grazing-contact, tilted-apart-non-candidate, and unbound-orbit cases).
- `npx ng build --configuration=production` → succeeds (pre-existing bundle-budget warning only).

Closes #17 