### PR TITLE
fix: detect spin-orbit resonance for retrograde rotators

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,17 +17,6 @@ pre-dates this branch.
   near-zero, but the constant is wrong as named. Confirm the data source's unit for `mass`
   before changing.
 
-- **`spinResonance` silently fails for retrograde rotators** —
-  [stellar-physics.service.ts:29](src/app/data/stellar-physics.service.ts#L29).
-  Elite stores retrograde rotation as a negative `rotationalPeriod`, so
-  `rotationsPerOrbit = orbitalPeriod / rotationalPeriod`
-  ([:32](src/app/data/stellar-physics.service.ts#L32)) goes negative while every
-  `candidate = num / denom` ([:38](src/app/data/stellar-physics.service.ts#L38)) is strictly
-  positive — no match is ever found and the result is `'none'`, so a retrograde tidally-locked
-  (1:1) body is missed. The adjacent solar-day code at
-  [system-body.component.ts:1303-1306](src/app/system-body/system-body.component.ts#L1303-L1306)
-  already `Math.abs`-es both periods, so the two disagree. Fix: take `Math.abs` of both periods.
-
 - **`tangentialVelocityKms` returns a negative velocity for retrograde spinners** —
   [stellar-physics.service.ts:49](src/app/data/stellar-physics.service.ts#L49).
   Same root cause: a negative `rotationalPeriod` divides a positive circumference

--- a/src/app/data/stellar-physics.service.spec.ts
+++ b/src/app/data/stellar-physics.service.spec.ts
@@ -25,6 +25,13 @@ describe('StellarPhysicsService', () => {
     it('returns none for a non-simple ratio', () => {
       expect(service.spinResonance(1, 7.13)).toBe('none');
     });
+
+    it('detects resonance for retrograde rotators (negative rotationalPeriod)', () => {
+      // Elite stores retrograde rotation as a negative period; a retrograde
+      // tidally-locked body must still classify as 1:1, not silently 'none'.
+      expect(service.spinResonance(-10, 10)).toBe('1:1');
+      expect(service.spinResonance(-2, 3)).toBe('3:2');
+    });
   });
 
   describe('tangentialVelocityKms', () => {

--- a/src/app/data/stellar-physics.service.ts
+++ b/src/app/data/stellar-physics.service.ts
@@ -17,7 +17,10 @@ export class StellarPhysicsService {
   spinResonance(rotationalPeriod: number | null | undefined, orbitalPeriod: number | null | undefined): string {
     if (!rotationalPeriod || !orbitalPeriod) { return 'none'; }
 
-    const rotationsPerOrbit = orbitalPeriod / rotationalPeriod;
+    // Elite stores retrograde rotation as a negative rotationalPeriod; resonance is a
+    // ratio of magnitudes, so a retrograde tidally-locked body is still 1:1. Use the
+    // absolute periods (matching the solar-day code in SystemBodyComponent).
+    const rotationsPerOrbit = Math.abs(orbitalPeriod) / Math.abs(rotationalPeriod);
     const maxDenominator = 5;
     const tolerance = 0.01;
 


### PR DESCRIPTION
## Summary

Fixes a bug where `spinResonance` silently returned `'none'` for retrograde rotators (the second item on the physics/source TODO list).

Elite stores retrograde rotation as a **negative** `rotationalPeriod`, so `rotationsPerOrbit = orbitalPeriod / rotationalPeriod` went negative while every candidate ratio (`num/denom`) is strictly positive — no match ever fired. A retrograde tidally-locked (1:1) body was therefore missed and showed no resonance.

The fix computes the ratio from **absolute** periods (`Math.abs(orbitalPeriod) / Math.abs(rotationalPeriod)`), since resonance is a ratio of magnitudes. This also makes the service consistent with the solar-day code in `SystemBodyComponent` and the tidal-lock dialog, both of which already `Math.abs` both periods.

## Changes

- `src/app/data/stellar-physics.service.ts` — one-line fix + explanatory comment
- `src/app/data/stellar-physics.service.spec.ts` — regression test for negative-period rotators (`-10,10 → 1:1`; `-2,3 → 3:2`)
- `TODO.md` — removed the now-resolved entry

## Behavioural impact

The only observable change: retrograde tidally-locked bodies now display their correct `1:1` resonance badge/tooltip instead of `none`. The sole caller (`system-body.component.ts:1082`) passes args in the right order, and the tidal-lock dialog recomputes the ratio independently, so nothing downstream breaks.

## Verification

- Unit tests: **534 passed** (`ng test`)
- E2E: **354 passed** (`playwright test`)
- Code review (correctness + cross-file tracer): no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)