### PR TITLE
fix: tangential velocity negative for retrograde spinners

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,12 +28,6 @@ pre-dates this branch.
   [system-body.component.ts:1303-1306](src/app/system-body/system-body.component.ts#L1303-L1306)
   already `Math.abs`-es both periods, so the two disagree. Fix: take `Math.abs` of both periods.
 
-- **`tangentialVelocityKms` returns a negative velocity for retrograde spinners** —
-  [stellar-physics.service.ts:49](src/app/data/stellar-physics.service.ts#L49).
-  Same root cause: a negative `rotationalPeriod` divides a positive circumference
-  ([:52](src/app/data/stellar-physics.service.ts#L52)) to a negative km/s, which renders as
-  e.g. "-12 km/s" or a negative fraction of c. Fix: use the magnitude of the period.
-
 - **`classifyNeutronStar` mislabels retrograde neutron stars as "Millisecond Pulsar"** —
   [stellar-physics.service.ts:104](src/app/data/stellar-physics.service.ts#L104).
   Same root cause: `period = rotationalPeriodDays * SECONDS_PER_DAY`

--- a/src/app/data/stellar-physics.service.spec.ts
+++ b/src/app/data/stellar-physics.service.spec.ts
@@ -39,6 +39,14 @@ describe('StellarPhysicsService', () => {
       const v2 = service.tangentialVelocityKms(2, 100000);
       expect(v2).toBeCloseTo(v1 / 2, 9);
     });
+
+    it('returns a positive speed for a retrograde (negative period) spinner', () => {
+      // Elite stores retrograde rotation as a negative period; speed is a magnitude.
+      const prograde = service.tangentialVelocityKms(1, 100000);
+      const retrograde = service.tangentialVelocityKms(-1, 100000);
+      expect(retrograde).toBeGreaterThan(0);
+      expect(retrograde).toBeCloseTo(prograde, 9);
+    });
   });
 
   describe('radiusKm', () => {

--- a/src/app/data/stellar-physics.service.ts
+++ b/src/app/data/stellar-physics.service.ts
@@ -33,9 +33,14 @@ export class StellarPhysicsService {
     return 'none';
   }
 
-  /** Equatorial surface (tangential) velocity in km/s for a given rotation period (days) and radius (km). */
+  /**
+   * Equatorial surface (tangential) velocity in km/s for a given rotation period (days)
+   * and radius (km). Speed is a magnitude, so the period's sign (Elite stores retrograde
+   * rotation as a negative `rotationalPeriod`) is ignored — a retrograde spinner has the
+   * same surface speed as a prograde one.
+   */
   tangentialVelocityKms(rotationalPeriodDays: number, radiusKm: number): number {
-    const rotationalPeriodSeconds = rotationalPeriodDays * SECONDS_PER_DAY;
+    const rotationalPeriodSeconds = Math.abs(rotationalPeriodDays) * SECONDS_PER_DAY;
     const circumferenceM = 2 * Math.PI * radiusKm * 1000;
     return circumferenceM / rotationalPeriodSeconds / 1000;
   }


### PR DESCRIPTION
## Summary

Fixes the third flagged item in `TODO.md`: **`tangentialVelocityKms` returns a negative velocity for retrograde spinners**.

Elite stores retrograde rotation as a negative `rotationalPeriod`. `tangentialVelocityKms` divided a positive circumference by that negative period, yielding a negative km/s that rendered as e.g. `-12 km/s` or a negative fraction of c. Surface speed is a magnitude, so the fix takes `Math.abs` of the period — consistent with the existing `Math.abs` convention in `spinResonance` and the solar-day code at `system-body.component.ts:1303-1306`.

## Changes

- `stellar-physics.service.ts` — `Math.abs(rotationalPeriodDays)` in `tangentialVelocityKms`, plus a clarifying doc comment.
- `stellar-physics.service.spec.ts` — new test pinning that a negative (retrograde) period yields a positive speed equal to the prograde case.
- `TODO.md` — removed the addressed item.

## Verification

- `ng test` — 534 passed.
- `ng build` — passes (pre-existing bundle-budget warning unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)