### PR TITLE
fix: classify retrograde neutron stars by spin magnitude

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,15 +34,6 @@ pre-dates this branch.
   ([:52](src/app/data/stellar-physics.service.ts#L52)) to a negative km/s, which renders as
   e.g. "-12 km/s" or a negative fraction of c. Fix: use the magnitude of the period.
 
-- **`classifyNeutronStar` mislabels retrograde neutron stars as "Millisecond Pulsar"** —
-  [stellar-physics.service.ts:104](src/app/data/stellar-physics.service.ts#L104).
-  Same root cause: `period = rotationalPeriodDays * SECONDS_PER_DAY`
-  ([:115](src/app/data/stellar-physics.service.ts#L115)) has no `Math.abs`, so a negative
-  period satisfies the first branch `period < 0.01`
-  ([:118](src/app/data/stellar-physics.service.ts#L118)) — any retrograde neutron star,
-  however slowly it spins, is labelled "Millisecond Pulsar" (or "Hyper-Massive Millisecond
-  Pulsar"). Fix: take `Math.abs` of the period.
-
 - **`rocheExcess` compares against the semi-major axis, not periapsis** —
   [body-physics.service.ts:354](src/app/data/body-physics.service.ts#L354).
   A Roche breach is set by closest approach (periapsis), but `semiMajorAxisM`

--- a/src/app/data/stellar-physics.service.spec.ts
+++ b/src/app/data/stellar-physics.service.spec.ts
@@ -87,5 +87,14 @@ describe('StellarPhysicsService', () => {
     it('classifies a multi-hour rotator as an anomalous slow-rotator', () => {
       expect(service.classifyNeutronStar(1.5, 7200 / SEC, 8)).toBe('Anomalous Slow-Rotator');
     });
+
+    it('classifies retrograde (negative period) rotators by magnitude', () => {
+      // Elite stores retrograde rotation as a negative period; the sign must not
+      // collapse a slow rotator into the sub-10ms "Millisecond Pulsar" branch.
+      expect(service.classifyNeutronStar(1.5, -7200 / SEC, 8)).toBe('Anomalous Slow-Rotator');
+      expect(service.classifyNeutronStar(1.5, -10 / SEC, 8)).toBe('Slow-Period Pulsar');
+      // A genuinely fast retrograde spinner still classifies as a millisecond pulsar.
+      expect(service.classifyNeutronStar(1.5, -0.005 / SEC, 8)).toBe('Millisecond Pulsar');
+    });
   });
 });

--- a/src/app/data/stellar-physics.service.ts
+++ b/src/app/data/stellar-physics.service.ts
@@ -51,6 +51,8 @@ export class StellarPhysicsService {
    * Descriptive classification of a neutron star from its mass, rotation period and
    * absolute magnitude (period in days). Returns null when any required value is
    * missing, so callers can fall back to the generic "Neutron Star" label.
+   * The period is a spin rate, so its sign (Elite stores retrograde rotation as a
+   * negative `rotationalPeriod`) is ignored — only the magnitude classifies the body.
    */
   classifyNeutronStar(
     solarMasses: number | null | undefined,
@@ -63,7 +65,7 @@ export class StellarPhysicsService {
       return null;
     }
 
-    const period = rotationalPeriodDays * SECONDS_PER_DAY; // seconds
+    const period = Math.abs(rotationalPeriodDays) * SECONDS_PER_DAY; // seconds
     const isHighMass = solarMasses > 2.1;
 
     if (period < 0.01) {


### PR DESCRIPTION
## Summary

Addresses the fourth flagged physics item in `TODO.md`: `classifyNeutronStar` mislabelled retrograde neutron stars.

Elite stores retrograde rotation as a **negative** `rotationalPeriod`. `classifyNeutronStar` multiplied that straight into `period = rotationalPeriodDays * SECONDS_PER_DAY`, producing a negative `period`. A negative value satisfies the very first branch `period < 0.01`, so **any** retrograde neutron star — however slowly it actually spins — was labelled "Millisecond Pulsar" (or "Hyper-Massive Millisecond Pulsar").

Fix: take `Math.abs` of the period before classifying. A spin rate has no sign for this purpose, so only the magnitude matters. This matches the existing `Math.abs` convention already used in `tangentialVelocityKms`, `spinResonance`, and the solar-day code.

## Changes
- `stellar-physics.service.ts` — `Math.abs(rotationalPeriodDays)` in `classifyNeutronStar`, plus a doc note.
- `stellar-physics.service.spec.ts` — new test asserting retrograde rotators classify by magnitude (slow stays slow; a genuinely fast retrograde spinner still reads as a millisecond pulsar).
- `TODO.md` — removed the now-resolved item.

## Testing
- `ng test --watch=false` → 534 passed (36 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)