### PR TITLE
fix: compare periapsis, not semi-major axis, in rocheExcess

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,14 +21,3 @@ the `upgrade` branch. None are regressions — the logic was extracted verbatim 
   fix is `detectTrojanStatus` **plus** its spec pins. **Confirm against the game/an orrery
   first** (e.g. which body leads in Pro Eurl JF-A d88 B 2 / B 3) before flipping — this is
   flagged, not yet fixed.
-
-- **`rocheExcess` compares against the semi-major axis, not periapsis** —
-  [body-physics.service.ts:354](src/app/data/body-physics.service.ts#L354).
-  A Roche breach is set by closest approach (periapsis), but `semiMajorAxisM`
-  ([:385](src/app/data/body-physics.service.ts#L385)) is compared to `rocheLimitM`
-  ([:388-390](src/app/data/body-physics.service.ts#L388-L390)). A body on an eccentric orbit
-  can read "safe" here yet dip inside the rigid limit at periapsis. Inconsistent with
-  `calculateBodyRocheLimits` ([:202](src/app/data/body-physics.service.ts#L202)), which already
-  exposes `periapsis`/`apoapsis` ([:228-229](src/app/data/body-physics.service.ts#L228-L229))
-  for exactly this comparison. Fix: use periapsis. (The `1.26` coefficient = 2^(1/3) is the
-  correct rigid-body value.)

--- a/src/app/data/body-physics.service.extra.spec.ts
+++ b/src/app/data/body-physics.service.extra.spec.ts
@@ -193,6 +193,21 @@ describe('BodyPhysicsService (extended coverage)', () => {
       expect(excess!).toBeGreaterThan(0);
     });
 
+    it('breaches when an eccentric periapsis dips inside the limit despite a safe semi-major axis', () => {
+      const parent = node({ solarMasses: 1, solarRadius: 1 });
+      // Semi-major axis sits outside the rigid Roche limit, so a circular orbit reads safe...
+      const circular = node({ earthMasses: 1, radius: 6371, semiMajorAxis: 0.004 }, parent);
+      expect(service.rocheExcess(circular)).toBeNull();
+      // ...but a high-eccentricity orbit with the same semi-major axis swings inside at periapsis.
+      const eccentric = node(
+        { earthMasses: 1, radius: 6371, semiMajorAxis: 0.004, orbitalEccentricity: 0.6 },
+        parent,
+      );
+      const excess = service.rocheExcess(eccentric);
+      expect(excess).not.toBeNull();
+      expect(excess!).toBeGreaterThan(0);
+    });
+
     it('returns null when required mass/radius data is missing', () => {
       expect(service.rocheExcess(node({ semiMajorAxis: 1, radius: 1000 }))).toBeNull(); // no parent
       const parentNoMass = node({ radius: 50000 });

--- a/src/app/data/body-physics.service.ts
+++ b/src/app/data/body-physics.service.ts
@@ -753,12 +753,15 @@ export class BodyPhysicsService {
       return null;
     }
 
-    const semiMajorAxisM = body.bodyData.semiMajorAxis * KM_PER_AU * 1000;
+    // A Roche breach is set by closest approach (periapsis), not the mean distance, so an
+    // eccentric body can dip inside the rigid limit even when its semi-major axis is safe.
+    const eccentricity = body.bodyData.orbitalEccentricity || 0;
+    const periapsisM = body.bodyData.semiMajorAxis * KM_PER_AU * 1000 * (1 - eccentricity);
     const rhoParent = parentMassKg / this.sphereVolumeM3(parentRadiusM);
     const rhoSatellite = bodyMassKg / this.sphereVolumeM3(body.bodyData.radius * 1000);
     const rocheLimitM = 1.26 * parentRadiusM * Math.pow(rhoParent / rhoSatellite, 1 / 3);
 
-    return semiMajorAxisM < rocheLimitM ? (rocheLimitM - semiMajorAxisM) / 1000 : null;
+    return periapsisM < rocheLimitM ? (rocheLimitM - periapsisM) / 1000 : null;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes the fifth flagged item in `TODO.md`: **`rocheExcess` compares against the semi-major axis, not periapsis.**

A rigid Roche breach is set by the body's *closest approach* (periapsis), but [`rocheExcess`](src/app/data/body-physics.service.ts) compared the semi-major axis against the Roche limit. A body on an eccentric orbit could therefore read "safe" while actually dipping inside the rigid limit at periapsis.

The fix computes `periapsis = a·(1 − e)` and compares that against the limit — consistent with `calculateBodyRocheLimits`, which already exposes `periapsis`/`apoapsis` for exactly this purpose. The `1.26` coefficient (= 2^(1/3), the rigid-body value) is unchanged.

## Changes
- `body-physics.service.ts` — use periapsis instead of semi-major axis in `rocheExcess`.
- `body-physics.service.extra.spec.ts` — regression test: a body with the same semi-major axis reads safe when circular but breaches at high eccentricity.
- `TODO.md` — removed the now-fixed item.

## Verification
- `ng test` — 534 passed.
- `ng build` — clean (only the pre-existing bundle-budget warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)