### PR TITLE
Lagrange-points dialog with real-body diagram

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,19 +19,6 @@ pre-dates this branch.
   for exactly this comparison. Fix: use periapsis. (The `1.26` coefficient = 2^(1/3) is the
   correct rigid-body value.)
 
-## Approximations (document, not necessarily fix)
-
-- **Trojan/Lagrange detection keys off `argOfPeriapsis` alone** —
-  [orbital-relations.service.ts:56](src/app/data/orbital-relations.service.ts#L56).
-  `detectTrojanStatus` computes its ±60°/180° geometry purely from `argOfPeriapsis`
-  differences ([:73](src/app/data/orbital-relations.service.ts#L73),
-  [:83](src/app/data/orbital-relations.service.ts#L83),
-  [:87](src/app/data/orbital-relations.service.ts#L87)). The true angular position of a
-  co-orbital body is its mean longitude λ = Ω + ω + M, so ω alone is only correct when the
-  siblings also share the ascending node Ω and mean anomaly M. A reasonable heuristic for
-  ED's largely coplanar, near-circular pairs, but an approximation — worth a clarifying code
-  comment so it isn't mistaken for an exact L4/L5 test.
-
 ## pgnames (vendored procedural-generation code)
 
 - **`tryParse` rejects all `…AB-C d<n1>-<n2>` names** —

--- a/e2e/fixtures/cloomoo-il-y-e1.json
+++ b/e2e/fixtures/cloomoo-il-y-e1.json
@@ -1,0 +1,545 @@
+{
+  "system": {
+    "allegiance": null, 
+    "bodies": [
+      {
+        "argOfPeriapsis": 193.963046, 
+        "ascendingNode": -120.818875, 
+        "bodyId": 1, 
+        "id64": 36028803052480908, 
+        "meanAnomaly": 340.244734, 
+        "name": "Cloomoo IL-Y e1 barycentre 1", 
+        "orbitalEccentricity": 0.125718, 
+        "orbitalInclination": -35.004933, 
+        "orbitalPeriod": 47204.2771677176, 
+        "semiMajorAxis": 9.30357918004369, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-06-29T01:39:12Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-06-29 01:39:12+00"
+      }, 
+      {
+        "argOfPeriapsis": 55.802533, 
+        "ascendingNode": -114.252201, 
+        "bodyId": 2, 
+        "id64": 72057600071444876, 
+        "meanAnomaly": 306.844262, 
+        "name": "Cloomoo IL-Y e1 barycentre 2", 
+        "orbitalEccentricity": 0.301272, 
+        "orbitalInclination": 10.330291, 
+        "orbitalPeriod": 49.628642284213, 
+        "semiMajorAxis": 0.209175995544458, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-06-29T01:39:12Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-06-29 01:39:12+00"
+      }, 
+      {
+        "absoluteMagnitude": -0.613342, 
+        "age": 312, 
+        "argOfPeriapsis": 294.916777, 
+        "ascendingNode": -133.33131, 
+        "axialTilt": 0.0, 
+        "bodyId": 3, 
+        "distanceToArrival": 0.0, 
+        "id64": 108086397090408844, 
+        "luminosity": "IVab", 
+        "mainStar": true, 
+        "meanAnomaly": 192.304069, 
+        "name": "Cloomoo IL-Y e1 A", 
+        "orbitalEccentricity": 0.024102, 
+        "orbitalInclination": 24.075428, 
+        "orbitalPeriod": 0.615566430821759, 
+        "parents": [
+          {
+            "Null": 2
+          }, 
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.645732390844907, 
+        "semiMajorAxis": 0.00807582555072967, 
+        "solarMasses": 3.941406, 
+        "solarRadius": 2.15167227030913, 
+        "spectralClass": "B8", 
+        "stations": [], 
+        "subType": "B (Blue-White) Star", 
+        "surfaceTemperature": 13791.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-06-29T01:39:13Z", 
+          "meanAnomaly": "2026-06-29T01:39:13Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-06-29 01:39:13+00"
+      }, 
+      {
+        "absoluteMagnitude": 2.646088, 
+        "age": 312, 
+        "argOfPeriapsis": 114.916782, 
+        "ascendingNode": -133.33131, 
+        "axialTilt": 0.0, 
+        "bodyId": 4, 
+        "distanceToArrival": 12.980196, 
+        "id64": 144115194109372812, 
+        "luminosity": "Vb", 
+        "meanAnomaly": 192.2963, 
+        "name": "Cloomoo IL-Y e1 B", 
+        "orbitalEccentricity": 0.024102, 
+        "orbitalInclination": 24.075428, 
+        "orbitalPeriod": 0.615566430821759, 
+        "parents": [
+          {
+            "Null": 2
+          }, 
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.69357198568287, 
+        "semiMajorAxis": 0.0173372513753918, 
+        "solarMasses": 1.835938, 
+        "solarRadius": 1.40463252336449, 
+        "spectralClass": "A7", 
+        "stations": [], 
+        "subType": "A (Blue-White) Star", 
+        "surfaceTemperature": 8060.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-06-29T01:39:12Z", 
+          "meanAnomaly": "2026-06-29T01:39:12Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-06-29 01:39:12+00"
+      }, 
+      {
+        "argOfPeriapsis": 235.802507, 
+        "ascendingNode": -114.252201, 
+        "bodyId": 5, 
+        "id64": 180143991128336780, 
+        "meanAnomaly": 306.844358, 
+        "name": "Cloomoo IL-Y e1 barycentre 5", 
+        "orbitalEccentricity": 0.301272, 
+        "orbitalInclination": 10.330291, 
+        "orbitalPeriod": 49.628642284213, 
+        "semiMajorAxis": 0.346052830828272, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-06-29T01:39:13Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-06-29 01:39:13+00"
+      }, 
+      {
+        "absoluteMagnitude": 2.666824, 
+        "age": 312, 
+        "argOfPeriapsis": 201.543965, 
+        "ascendingNode": 47.365904, 
+        "axialTilt": 0.0, 
+        "bodyId": 6, 
+        "distanceToArrival": 243.06794, 
+        "id64": 216172788147300748, 
+        "luminosity": "Vb", 
+        "meanAnomaly": 37.303036, 
+        "name": "Cloomoo IL-Y e1 C", 
+        "orbitalEccentricity": 0.011917, 
+        "orbitalInclination": 16.025465, 
+        "orbitalPeriod": 0.569169995960648, 
+        "parents": [
+          {
+            "Null": 5
+          }, 
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.83162723287037, 
+        "semiMajorAxis": 0.0101967507608476, 
+        "solarMasses": 1.746094, 
+        "solarRadius": 1.48104852336449, 
+        "spectralClass": "A8", 
+        "stations": [], 
+        "subType": "A (Blue-White) Star", 
+        "surfaceTemperature": 7812.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-06-29T01:39:13Z", 
+          "meanAnomaly": "2026-06-29T01:39:13Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-06-29 01:39:13+00"
+      }, 
+      {
+        "absoluteMagnitude": 2.853394, 
+        "age": 312, 
+        "argOfPeriapsis": 21.543971, 
+        "ascendingNode": 47.365904, 
+        "axialTilt": 0.0, 
+        "bodyId": 7, 
+        "distanceToArrival": 248.910991, 
+        "id64": 252201585166264716, 
+        "luminosity": "Vb", 
+        "meanAnomaly": 37.303036, 
+        "name": "Cloomoo IL-Y e1 D", 
+        "orbitalEccentricity": 0.011917, 
+        "orbitalInclination": 16.025465, 
+        "orbitalPeriod": 0.569169995960648, 
+        "parents": [
+          {
+            "Null": 5
+          }, 
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.606214906701389, 
+        "semiMajorAxis": 0.0101967507608476, 
+        "solarMasses": 1.746094, 
+        "solarRadius": 1.4084472178289, 
+        "spectralClass": "A9", 
+        "stations": [], 
+        "subType": "A (Blue-White) Star", 
+        "surfaceTemperature": 7674.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-06-29T01:39:13Z", 
+          "meanAnomaly": "2026-06-29T01:39:13Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-06-29 01:39:13+00"
+      }, 
+      {
+        "absoluteMagnitude": 1.886566, 
+        "age": 312, 
+        "argOfPeriapsis": 13.963051, 
+        "ascendingNode": -120.818875, 
+        "axialTilt": 0.0, 
+        "bodyId": 8, 
+        "distanceToArrival": 25225.030867, 
+        "id64": 288230382185228684, 
+        "luminosity": "VI", 
+        "meanAnomaly": 340.244734, 
+        "name": "Cloomoo IL-Y e1 E", 
+        "orbitalEccentricity": 0.125718, 
+        "orbitalInclination": -35.004933, 
+        "orbitalPeriod": 47204.2771677176, 
+        "parents": [
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.920351252118055, 
+        "semiMajorAxis": 47.683232697072, 
+        "solarMasses": 1.808594, 
+        "solarRadius": 1.5621946340762, 
+        "spectralClass": "A3", 
+        "stations": [], 
+        "subType": "A (Blue-White) Star", 
+        "surfaceTemperature": 9103.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-06-29T01:39:13Z", 
+          "meanAnomaly": "2026-06-29T01:39:13Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-06-29 01:39:13+00"
+      }, 
+      {
+        "argOfPeriapsis": 202.150452, 
+        "ascendingNode": 156.646912, 
+        "atmosphereType": null, 
+        "axialTilt": -0.188921, 
+        "bodyId": 9, 
+        "distanceToArrival": 621.88193, 
+        "earthMasses": 0.400998, 
+        "gravity": 0.768258998674416, 
+        "id64": 324259179204192652, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 12.639412, 
+          "Chromium": 9.576516, 
+          "Germanium": 4.432872, 
+          "Iron": 21.293772, 
+          "Manganese": 8.794109, 
+          "Molybdenum": 1.390471, 
+          "Nickel": 16.105715, 
+          "Phosphorus": 8.091969, 
+          "Sulphur": 15.03088, 
+          "Tin": 1.372425, 
+          "Yttrium": 1.271851
+        }, 
+        "meanAnomaly": 185.676258, 
+        "name": "Cloomoo IL-Y e1 ABCD 1", 
+        "orbitalEccentricity": 0.000642, 
+        "orbitalInclination": 0.043947, 
+        "orbitalPeriod": 164.90149277228, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 4605.7885, 
+        "rotationalPeriod": 1.67431649658565, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 1.2363278555988, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 33.0836, 
+          "Rock": 66.9164
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 879.072998, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-29T01:41:31Z", 
+          "meanAnomaly": "2026-06-29T01:41:31Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-29 01:41:31+00"
+      }, 
+      {
+        "argOfPeriapsis": 230.052372, 
+        "ascendingNode": 72.952708, 
+        "atmosphereType": null, 
+        "axialTilt": 0.291987, 
+        "bodyId": 10, 
+        "distanceToArrival": 909.519298, 
+        "earthMasses": 0.496783, 
+        "gravity": 0.834213215050474, 
+        "id64": 360287976223156620, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 13.305812, 
+          "Chromium": 10.081427, 
+          "Iron": 22.41646, 
+          "Molybdenum": 1.463782, 
+          "Nickel": 16.954868, 
+          "Niobium": 1.532045, 
+          "Phosphorus": 8.518609, 
+          "Sulphur": 15.823366, 
+          "Tellurium": 1.208656, 
+          "Zinc": 6.091955, 
+          "Zirconium": 2.603013
+        }, 
+        "meanAnomaly": 83.185021, 
+        "name": "Cloomoo IL-Y e1 ABCD 2", 
+        "orbitalEccentricity": 0.001617, 
+        "orbitalInclination": 0.001562, 
+        "orbitalPeriod": 263.138246481065, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 4919.6165, 
+        "rotationalPeriod": 0.825066230162037, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 1.68826244214677, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 33.0836, 
+          "Rock": 66.9164
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 761.678101, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-29T01:41:18Z", 
+          "meanAnomaly": "2026-06-29T01:41:18Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-29 01:41:18+00"
+      }, 
+      {
+        "argOfPeriapsis": 276.04562, 
+        "ascendingNode": 3.886808, 
+        "atmosphereComposition": {
+          "Sulphur dioxide": 100.0
+        }, 
+        "atmosphereType": "Hot Sulphur dioxide", 
+        "axialTilt": 0.433028, 
+        "bodyId": 11, 
+        "distanceToArrival": 1991.168658, 
+        "earthMasses": 0.333164, 
+        "gravity": 0.715938615274804, 
+        "id64": 396316773242120588, 
+        "isLandable": false, 
+        "meanAnomaly": 123.137312, 
+        "name": "Cloomoo IL-Y e1 ABCD 3", 
+        "orbitalEccentricity": 0.00451, 
+        "orbitalInclination": 0.338992, 
+        "orbitalPeriod": 971.80565612184, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 4348.8845, 
+        "rotationalPeriod": 0.860892748368056, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 4.03369951167537, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 33.0851, 
+          "Rock": 66.9149
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.687271851102887, 
+        "surfaceTemperature": 539.619629, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-29T01:41:36Z", 
+          "meanAnomaly": "2026-06-29T01:41:36Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-29 01:41:36+00"
+      }, 
+      {
+        "argOfPeriapsis": 191.194665, 
+        "ascendingNode": -96.315001, 
+        "atmosphereComposition": {
+          "Sulphur dioxide": 100.0
+        }, 
+        "atmosphereType": "Sulphur dioxide", 
+        "axialTilt": 0.335701, 
+        "bodyId": 15, 
+        "distanceToArrival": 3024.081798, 
+        "earthMasses": 0.228536, 
+        "gravity": 0.62139971448965, 
+        "id64": 540431961317976460, 
+        "isLandable": false, 
+        "meanAnomaly": 355.147407, 
+        "name": "Cloomoo IL-Y e1 ABCD 6", 
+        "orbitalEccentricity": 0.075326, 
+        "orbitalInclination": -28.56074, 
+        "orbitalPeriod": 2100.23823159712, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 3866.1475, 
+        "rotationalPeriod": 0.4566248896875, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 6.74263474458214, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 33.0853, 
+          "Rock": 66.9147
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.41741657414261, 
+        "surfaceTemperature": 428.836304, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-29T01:41:56Z", 
+          "meanAnomaly": "2026-06-29T01:41:56Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-29 01:41:56+00"
+      }, 
+      {
+        "argOfPeriapsis": 208.73262, 
+        "ascendingNode": 30.345304, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 97.921028, 
+          "Nitrogen": 1.099532, 
+          "Sulphur dioxide": 0.97921
+        }, 
+        "atmosphereType": "Hot thick Carbon dioxide", 
+        "axialTilt": 0.148944, 
+        "bodyId": 19, 
+        "distanceToArrival": 26255.737869, 
+        "earthMasses": 1.966716, 
+        "gravity": 1.45196777811767, 
+        "id64": 684547149393832332, 
+        "isLandable": false, 
+        "meanAnomaly": 269.118195, 
+        "name": "Cloomoo IL-Y e1 E 1", 
+        "orbitalEccentricity": 0.181614, 
+        "orbitalInclination": -124.553544, 
+        "orbitalPeriod": 1194.97833980455, 
+        "parents": [
+          {
+            "Star": 8
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 7419.5745, 
+        "rotationalPeriod": 0.537327226539352, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 2.68525416172284, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 32.7491, 
+          "Rock": 67.2509
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 293.371862817666, 
+        "surfaceTemperature": 1388.382935, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-29T01:41:02Z", 
+          "meanAnomaly": "2026-06-29T01:41:02Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-29 01:41:02+00", 
+        "volcanismType": "Minor Metallic Magma"
+      }
+    ], 
+    "bodyCount": 14, 
+    "coords": {
+      "x": 16363.65625, 
+      "y": 216.3125, 
+      "z": 24774.4375
+    }, 
+    "date": "2026-06-29 01:39:13+00", 
+    "government": "None", 
+    "id64": 6033516940, 
+    "name": "Cloomoo IL-Y e1", 
+    "population": 0, 
+    "primaryEconomy": "None", 
+    "region": {
+      "name": "Norma Expanse", 
+      "region": 10
+    }, 
+    "secondaryEconomy": "None", 
+    "security": "Anarchy", 
+    "stations": []
+  }
+}

--- a/e2e/fixtures/eorld-byio-aa-a-h539.json
+++ b/e2e/fixtures/eorld-byio-aa-a-h539.json
@@ -1,0 +1,1465 @@
+{
+  "system": {
+    "allegiance": null, 
+    "bodies": [
+      {
+        "absoluteMagnitude": 7.025696, 
+        "age": 2, 
+        "argOfPeriapsis": 178.34768, 
+        "ascendingNode": 33.174061, 
+        "axialTilt": 0.0, 
+        "belts": [
+          {
+            "innerRadius": 626940000.0, 
+            "mass": 2173100000000000.0, 
+            "name": "Eorld Byio AA-A h539 A A Belt", 
+            "outerRadius": 8352900000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "bodyId": 1, 
+        "distanceToArrival": 0.0, 
+        "id64": 36028801543339351, 
+        "luminosity": "VI", 
+        "mainStar": true, 
+        "meanAnomaly": 96.415855, 
+        "name": "Eorld Byio AA-A h539 A", 
+        "orbitalEccentricity": 0.203984, 
+        "orbitalInclination": -18.989309, 
+        "orbitalPeriod": 1784.10154249933, 
+        "parents": [
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.165947049918981, 
+        "semiMajorAxis": 4.87010992883075, 
+        "solarMasses": 41.476563, 
+        "solarRadius": 0.487701348670022, 
+        "spectralClass": "AeBe1", 
+        "stations": [], 
+        "subType": "Herbig Ae/Be Star", 
+        "surfaceTemperature": 4991.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:10:48Z", 
+          "meanAnomaly": "2026-03-06T20:10:48Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-03-06 20:10:48+00"
+      }, 
+      {
+        "argOfPeriapsis": 358.347675, 
+        "ascendingNode": 33.174061, 
+        "bodyId": 2, 
+        "id64": 72057598562303319, 
+        "meanAnomaly": 96.415856, 
+        "name": "Eorld Byio AA-A h539 barycentre 2", 
+        "orbitalEccentricity": 0.203984, 
+        "orbitalInclination": -18.989309, 
+        "orbitalPeriod": 1784.10154249933, 
+        "semiMajorAxis": 7.0291351614226, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-03-06T20:10:48Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-03-06 20:10:48+00"
+      }, 
+      {
+        "absoluteMagnitude": -6.723648, 
+        "age": 2, 
+        "argOfPeriapsis": 122.74522, 
+        "ascendingNode": 113.172454, 
+        "axialTilt": 0.0, 
+        "bodyId": 3, 
+        "distanceToArrival": 6299.206565, 
+        "id64": 108086395581267287, 
+        "luminosity": "Vz", 
+        "mainStar": false, 
+        "meanAnomaly": 94.538782, 
+        "name": "Eorld Byio AA-A h539 B", 
+        "orbitalEccentricity": 0.004026, 
+        "orbitalInclination": -53.528667, 
+        "orbitalPeriod": 1.24039714811343, 
+        "parents": [
+          {
+            "Null": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 2.40849376584491, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0240235135076417, 
+        "solarMasses": 18.882813, 
+        "solarRadius": 5.98629737455068, 
+        "spectralClass": "O0", 
+        "stations": [], 
+        "subType": "O (Blue-White) Star", 
+        "surfaceTemperature": 33751.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:10:48Z", 
+          "meanAnomaly": "2026-03-06T20:10:48Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-03-06 20:10:48+00"
+      }, 
+      {
+        "absoluteMagnitude": -4.136719, 
+        "age": 2, 
+        "argOfPeriapsis": 302.745215, 
+        "ascendingNode": 113.172454, 
+        "axialTilt": 0.0, 
+        "bodyId": 4, 
+        "distanceToArrival": 6310.741566, 
+        "id64": 144115192600231255, 
+        "luminosity": "Vz", 
+        "mainStar": false, 
+        "meanAnomaly": 94.538782, 
+        "name": "Eorld Byio AA-A h539 C", 
+        "orbitalEccentricity": 0.004026, 
+        "orbitalInclination": -53.528667, 
+        "orbitalPeriod": 1.24039714811343, 
+        "parents": [
+          {
+            "Null": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 1.51657711134259, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0453100758459223, 
+        "solarMasses": 10.011719, 
+        "solarRadius": 3.91583231631919, 
+        "spectralClass": "B0", 
+        "stations": [], 
+        "subType": "B (Blue-White) Star", 
+        "surfaceTemperature": 23005.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:10:48Z", 
+          "meanAnomaly": "2026-03-06T20:10:48Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-03-06 20:10:48+00"
+      }, 
+      {
+        "argOfPeriapsis": 268.625507, 
+        "ascendingNode": -28.103592, 
+        "atmosphereComposition": {
+          "Silicates": 100.0
+        }, 
+        "atmosphereType": "Hot thin Silicate vapour", 
+        "axialTilt": -0.078213, 
+        "bodyId": 14, 
+        "distanceToArrival": 64.57055, 
+        "earthMasses": 0.958881, 
+        "gravity": 1.57774059345366, 
+        "id64": 504403162789870935, 
+        "isLandable": false, 
+        "meanAnomaly": 176.95025, 
+        "name": "Eorld Byio AA-A h539 A 1", 
+        "orbitalEccentricity": 0.000479, 
+        "orbitalInclination": -0.236219, 
+        "orbitalPeriod": 2.63046528453704, 
+        "parents": [
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 4969.9395, 
+        "rotationalPeriod": 2.6377587553588, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.129336828054516, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 98.9858, 
+          "Rock": 0.0
+        }, 
+        "stations": [], 
+        "subType": "Metal-rich body", 
+        "surfacePressure": 0.00326079682210708, 
+        "surfaceTemperature": 1481.246826, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:12:03Z", 
+          "meanAnomaly": "2026-03-06T20:12:03Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:12:03+00", 
+        "volcanismType": "Major Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 129.039246, 
+        "ascendingNode": -168.087687, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 0.321688, 
+          "Silicates": 99.665924
+        }, 
+        "atmosphereType": "Hot thick Silicate vapour", 
+        "axialTilt": 0.074333, 
+        "bodyId": 15, 
+        "distanceToArrival": 86.631233, 
+        "earthMasses": 5.372301, 
+        "gravity": 2.20270898337922, 
+        "id64": 540431959808834903, 
+        "isLandable": false, 
+        "meanAnomaly": 100.560703, 
+        "name": "Eorld Byio AA-A h539 A 2", 
+        "orbitalEccentricity": 0.000347, 
+        "orbitalInclination": -0.092369, 
+        "orbitalPeriod": 4.09036992048611, 
+        "parents": [
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 9956.076, 
+        "rotationalPeriod": 4.10171070072917, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.173596974653819, 
+        "solidComposition": {
+          "Ice": 0.0044, 
+          "Metal": 32.9466, 
+          "Rock": 66.3855
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 53813.5622995312, 
+        "surfaceTemperature": 4642.165039, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:12:19Z", 
+          "meanAnomaly": "2026-03-06T20:12:19Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:12:19+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 132.137885, 
+        "ascendingNode": -179.940371, 
+        "bodyId": 16, 
+        "id64": 576460756827798871, 
+        "meanAnomaly": 284.92253, 
+        "name": "Eorld Byio AA-A h539 barycentre 16", 
+        "orbitalEccentricity": 0.00011, 
+        "orbitalInclination": -0.042571, 
+        "orbitalPeriod": 5.12783891625, 
+        "semiMajorAxis": 0.201831985201485, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-03-06T20:12:35Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-03-06 20:12:35+00"
+      }, 
+      {
+        "argOfPeriapsis": 117.039478, 
+        "ascendingNode": -48.508284, 
+        "atmosphereComposition": {
+          "Iron": 1.47592, 
+          "Silicates": 98.507355
+        }, 
+        "atmosphereType": "Hot thick Silicate vapour", 
+        "axialTilt": -1.196857, 
+        "bodyId": 17, 
+        "distanceToArrival": 100.722016, 
+        "earthMasses": 14.902105, 
+        "gravity": 3.52887355970225, 
+        "id64": 612489553846762839, 
+        "isLandable": false, 
+        "meanAnomaly": 285.066653, 
+        "name": "Eorld Byio AA-A h539 A 3", 
+        "orbitalEccentricity": 0.077644, 
+        "orbitalInclination": -0.277049, 
+        "orbitalPeriod": 1.14130926215278, 
+        "parents": [
+          {
+            "Null": 16
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 13100.635, 
+        "rotationalPeriod": 1.93923601467593, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 8.89012185180454e-05, 
+        "solidComposition": {
+          "Ice": 0.0096, 
+          "Metal": 32.69, 
+          "Rock": 65.8686
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 9159039.70818653, 
+        "surfaceTemperature": 6735.407227, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:12:35Z", 
+          "meanAnomaly": "2026-03-06T20:12:35Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:12:35+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 297.039473, 
+        "ascendingNode": -48.508284, 
+        "atmosphereComposition": {
+          "Silicates": 0.207135, 
+          "Sulphur dioxide": 99.792877
+        }, 
+        "atmosphereType": "Hot Sulphur dioxide", 
+        "axialTilt": 0.018734, 
+        "bodyId": 18, 
+        "distanceToArrival": 100.636159, 
+        "earthMasses": 1.890519, 
+        "gravity": 1.60260885082084, 
+        "id64": 648518350865726807, 
+        "isLandable": false, 
+        "meanAnomaly": 285.079645, 
+        "name": "Eorld Byio AA-A h539 A 4", 
+        "orbitalEccentricity": 0.077644, 
+        "orbitalInclination": -0.277049, 
+        "orbitalPeriod": 1.14130926215278, 
+        "parents": [
+          {
+            "Null": 16
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 6924.101, 
+        "rotationalPeriod": 1.21154336685185, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.000700768037134542, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 57.1802, 
+          "Rock": 42.1557
+        }, 
+        "stations": [], 
+        "subType": "Metal-rich body", 
+        "surfacePressure": 2.19833795953615, 
+        "surfaceTemperature": 1507.299805, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:12:38Z", 
+          "meanAnomaly": "2026-03-06T20:12:38Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:12:38+00", 
+        "volcanismType": "Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 163.542794, 
+        "ascendingNode": -85.409931, 
+        "atmosphereComposition": {
+          "Iron": 1.47598, 
+          "Silicates": 98.511383
+        }, 
+        "atmosphereType": "Hot thick Silicate vapour", 
+        "axialTilt": 0.808363, 
+        "bodyId": 19, 
+        "distanceToArrival": 121.341956, 
+        "earthMasses": 12.87923, 
+        "gravity": 3.48562791883349, 
+        "id64": 684547147884690775, 
+        "isLandable": false, 
+        "meanAnomaly": 65.059133, 
+        "name": "Eorld Byio AA-A h539 A 5", 
+        "orbitalEccentricity": 0.001642, 
+        "orbitalInclination": -0.000694, 
+        "orbitalPeriod": 6.78826171767361, 
+        "parents": [
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 12254.372, 
+        "rotationalPeriod": 6.80708184586806, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.243335867814152, 
+        "solidComposition": {
+          "Ice": 0.0089, 
+          "Metal": 33.7888, 
+          "Rock": 65.9522
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 8946915.86210708, 
+        "surfaceTemperature": 6460.387207, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:12:31Z", 
+          "meanAnomaly": "2026-03-06T20:12:31Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:12:31+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 161.414261, 
+        "ascendingNode": 8.680061, 
+        "atmosphereComposition": {
+          "Helium": 25.992887, 
+          "Hydrogen": 74.007118
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 0.155585, 
+        "bodyId": 20, 
+        "distanceToArrival": 158.065307, 
+        "earthMasses": 46.881561, 
+        "gravity": 1.43074558988478, 
+        "id64": 720575944903654743, 
+        "isLandable": false, 
+        "meanAnomaly": 76.940716, 
+        "name": "Eorld Byio AA-A h539 A 6", 
+        "orbitalEccentricity": 0.00135, 
+        "orbitalInclination": 0.002979, 
+        "orbitalPeriod": 10.086600082338, 
+        "parents": [
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 36492.736, 
+        "rotationalPeriod": 10.1145643858449, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.316857235524533, 
+        "stations": [], 
+        "subType": "Class IV gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 1312.931519, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:11:52Z", 
+          "meanAnomaly": "2026-03-06T20:11:52Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:11:52+00"
+      }, 
+      {
+        "argOfPeriapsis": 277.231177, 
+        "ascendingNode": 167.057592, 
+        "atmosphereType": null, 
+        "axialTilt": 0.101368, 
+        "bodyId": 21, 
+        "distanceToArrival": 158.26851, 
+        "earthMasses": 0.078535, 
+        "gravity": 0.649567247884164, 
+        "id64": 756604741922618711, 
+        "isLandable": true, 
+        "materials": {
+          "Iron": 37.313633, 
+          "Manganese": 15.410151, 
+          "Molybdenum": 2.436559, 
+          "Nickel": 28.222469, 
+          "Niobium": 2.550188, 
+          "Ruthenium": 2.304355, 
+          "Selenium": 2.599716, 
+          "Vanadium": 9.16293
+        }, 
+        "meanAnomaly": 98.224608, 
+        "name": "Eorld Byio AA-A h539 A 6 a", 
+        "orbitalEccentricity": 0.0, 
+        "orbitalInclination": -71.99071, 
+        "orbitalPeriod": 0.879404935300926, 
+        "parents": [
+          {
+            "Planet": 20
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 2216.69075, 
+        "rotationalPeriod": 0.880141213136574, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.000935058823158243, 
+        "signals": {
+          "biology": [
+            "Prasinum Bioluminescent Anemone"
+          ], 
+          "genuses": [
+            "$Codex_Ent_Sphere_Name;"
+          ], 
+          "signals": {
+            "$SAA_SignalType_Biological;": 1, 
+            "$SAA_SignalType_Geological;": 2
+          }, 
+          "updateTime": "2026-03-06 20:18:29+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 100.0, 
+          "Rock": 0.0
+        }, 
+        "stations": [], 
+        "subType": "Metal-rich body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 1329.059692, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:18:30Z", 
+          "meanAnomaly": "2026-03-06T20:18:30Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:18:30+00", 
+        "volcanismType": "Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 64.904388, 
+        "ascendingNode": -170.235608, 
+        "bodyId": 22, 
+        "id64": 792633538941582679, 
+        "meanAnomaly": 295.751482, 
+        "name": "Eorld Byio AA-A h539 barycentre 22", 
+        "orbitalEccentricity": 0.00025, 
+        "orbitalInclination": 0.017173, 
+        "orbitalPeriod": 12.9442662000694, 
+        "semiMajorAxis": 0.37418415331752, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-03-06T20:12:25Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-03-06 20:12:25+00"
+      }, 
+      {
+        "argOfPeriapsis": 185.401131, 
+        "ascendingNode": 18.659766, 
+        "atmosphereComposition": {
+          "Iron": 1.475827, 
+          "Silicates": 98.501129
+        }, 
+        "atmosphereType": "Hot thick Silicate vapour", 
+        "axialTilt": 0.74839, 
+        "bodyId": 23, 
+        "distanceToArrival": 186.609089, 
+        "earthMasses": 24.8232, 
+        "gravity": 3.59012888752932, 
+        "id64": 828662335960546647, 
+        "isLandable": false, 
+        "meanAnomaly": 344.404102, 
+        "name": "Eorld Byio AA-A h539 A 7", 
+        "orbitalEccentricity": 0.081612, 
+        "orbitalInclination": 3.206312, 
+        "orbitalPeriod": 1.6191091250463, 
+        "parents": [
+          {
+            "Null": 22
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 16763.338, 
+        "rotationalPeriod": 3.87367703145833, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.000211531826959346, 
+        "solidComposition": {
+          "Ice": 0.0551, 
+          "Metal": 31.1183, 
+          "Rock": 61.6899
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 8878939.52331606, 
+        "surfaceTemperature": 6412.671387, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:12:26Z", 
+          "meanAnomaly": "2026-03-06T20:12:26Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:12:26+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 5.401136, 
+        "ascendingNode": 18.659766, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 0.721859, 
+          "Silicates": 99.270164
+        }, 
+        "atmosphereType": "Hot thick Silicate vapour", 
+        "axialTilt": -0.188899, 
+        "bodyId": 24, 
+        "distanceToArrival": 187.126006, 
+        "earthMasses": 5.254774, 
+        "gravity": 2.11439879677781, 
+        "id64": 864691132979510615, 
+        "isLandable": false, 
+        "meanAnomaly": 344.399985, 
+        "name": "Eorld Byio AA-A h539 A 8", 
+        "orbitalEccentricity": 0.081612, 
+        "orbitalInclination": 3.206312, 
+        "orbitalPeriod": 1.6191091250463, 
+        "parents": [
+          {
+            "Null": 22
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 10050.095, 
+        "rotationalPeriod": 1.78226199576389, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.000999262425899956, 
+        "solidComposition": {
+          "Ice": 0.0085, 
+          "Metal": 32.7422, 
+          "Rock": 65.9739
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 78084.9191413768, 
+        "surfaceTemperature": 4858.674805, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:12:25Z", 
+          "meanAnomaly": "2026-03-06T20:12:25Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:12:25+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 157.940198, 
+        "ascendingNode": 119.653067, 
+        "bodyId": 25, 
+        "id64": 900719929998474583, 
+        "meanAnomaly": 259.925957, 
+        "name": "Eorld Byio AA-A h539 barycentre 25", 
+        "orbitalEccentricity": 0.005445, 
+        "orbitalInclination": 0.053229, 
+        "orbitalPeriod": 17.295342490625, 
+        "semiMajorAxis": 0.453927541632996, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-03-06T20:11:19Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-03-06 20:11:19+00"
+      }, 
+      {
+        "argOfPeriapsis": 99.362221, 
+        "ascendingNode": -73.553221, 
+        "atmosphereComposition": {
+          "Helium": 25.992882, 
+          "Hydrogen": 74.007111
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -0.227222, 
+        "bodyId": 26, 
+        "distanceToArrival": 226.635301, 
+        "earthMasses": 49.455814, 
+        "gravity": 1.78588814112369, 
+        "id64": 936748727017438551, 
+        "isLandable": false, 
+        "meanAnomaly": 169.956865, 
+        "name": "Eorld Byio AA-A h539 A 9", 
+        "orbitalEccentricity": 0.108991, 
+        "orbitalInclination": -2.064032, 
+        "orbitalPeriod": 6.22059618709491, 
+        "parents": [
+          {
+            "Null": 25
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 33548.12, 
+        "rotationalPeriod": 17.6671835573843, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.000454207364720559, 
+        "stations": [], 
+        "subType": "Class IV gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 1268.963623, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:11:19Z", 
+          "meanAnomaly": "2026-03-06T20:11:19Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:11:19+00"
+      }, 
+      {
+        "argOfPeriapsis": 279.362216, 
+        "ascendingNode": -73.553221, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 0.841768, 
+          "Silicates": 99.149704
+        }, 
+        "atmosphereType": "Hot thick Silicate vapour", 
+        "axialTilt": -0.390091, 
+        "bodyId": 27, 
+        "distanceToArrival": 227.440073, 
+        "earthMasses": 6.998897, 
+        "gravity": 2.11694208218619, 
+        "id64": 972777524036402519, 
+        "isLandable": false, 
+        "meanAnomaly": 169.958539, 
+        "name": "Eorld Byio AA-A h539 A 10", 
+        "orbitalEccentricity": 0.108991, 
+        "orbitalInclination": -2.064032, 
+        "orbitalPeriod": 6.22059618709491, 
+        "parents": [
+          {
+            "Null": 25
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 11591.694, 
+        "rotationalPeriod": 6.64620038480324, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00320953383982324, 
+        "solidComposition": {
+          "Ice": 0.0275, 
+          "Metal": 31.7951, 
+          "Rock": 64.0656
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 77589.8417962003, 
+        "surfaceTemperature": 4851.617188, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:11:22Z", 
+          "meanAnomaly": "2026-03-06T20:11:22Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:11:22+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 322.382316, 
+        "ascendingNode": -52.847417, 
+        "bodyId": 28, 
+        "id64": 1008806321055366487, 
+        "meanAnomaly": 61.725751, 
+        "name": "Eorld Byio AA-A h539 barycentre 28", 
+        "orbitalEccentricity": 0.003237, 
+        "orbitalInclination": 0.134686, 
+        "orbitalPeriod": 24.9546676598264, 
+        "semiMajorAxis": 0.579608847666105, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-03-06T20:12:14Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-03-06 20:12:14+00"
+      }, 
+      {
+        "argOfPeriapsis": 191.945767, 
+        "ascendingNode": 69.491776, 
+        "atmosphereType": null, 
+        "axialTilt": -2.030487, 
+        "bodyId": 29, 
+        "distanceToArrival": 288.633132, 
+        "earthMasses": 13.179326, 
+        "gravity": 5.89151748750892, 
+        "id64": 1044835118074330455, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 2.561601, 
+          "Chromium": 14.835414, 
+          "Iron": 32.987144, 
+          "Manganese": 13.623354, 
+          "Nickel": 24.950092, 
+          "Niobium": 2.254495, 
+          "Tellurium": 0.687405, 
+          "Vanadium": 8.100494
+        }, 
+        "meanAnomaly": 102.962002, 
+        "name": "Eorld Byio AA-A h539 A 11", 
+        "orbitalEccentricity": 0.113247, 
+        "orbitalInclination": 5.509088, 
+        "orbitalPeriod": 9.06689333971065, 
+        "parents": [
+          {
+            "Null": 28
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 9534.976, 
+        "rotationalPeriod": -14.8993363498148, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.000338133237012537, 
+        "signals": {
+          "genuses": [
+            "$Codex_Ent_Sphere_Name;"
+          ], 
+          "signals": {
+            "$SAA_SignalType_Biological;": 1, 
+            "$SAA_SignalType_Geological;": 2, 
+            "$SAA_SignalType_Human;": 1
+          }, 
+          "updateTime": "2026-03-06 20:12:16+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 100.0, 
+          "Rock": 0.0
+        }, 
+        "stations": [], 
+        "subType": "Metal-rich body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 1258.068848, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:12:17Z", 
+          "meanAnomaly": "2026-03-06T20:12:17Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:12:17+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 11.945772, 
+        "ascendingNode": 69.491776, 
+        "atmosphereType": null, 
+        "axialTilt": -0.407185, 
+        "bodyId": 30, 
+        "distanceToArrival": 290.002575, 
+        "earthMasses": 1.663364, 
+        "gravity": 2.14636830835118, 
+        "id64": 1080863915093294423, 
+        "isLandable": false, 
+        "meanAnomaly": 102.960999, 
+        "name": "Eorld Byio AA-A h539 A 12", 
+        "orbitalEccentricity": 0.113247, 
+        "orbitalInclination": 5.509088, 
+        "orbitalPeriod": 9.06689333971065, 
+        "parents": [
+          {
+            "Null": 28
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 5612.135, 
+        "rotationalPeriod": 9.62206323679398, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00267913017541982, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 100.0, 
+          "Rock": 0.0
+        }, 
+        "stations": [], 
+        "subType": "Metal-rich body", 
+        "surfacePressure": 3.75554305452751e-05, 
+        "surfaceTemperature": 1258.216919, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:12:14Z", 
+          "meanAnomaly": "2026-03-06T20:12:14Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:12:14+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 119.167332, 
+        "ascendingNode": -109.742681, 
+        "atmosphereComposition": {
+          "Sulphur dioxide": 99.985878
+        }, 
+        "atmosphereType": "Hot Sulphur dioxide", 
+        "axialTilt": 0.200297, 
+        "bodyId": 31, 
+        "distanceToArrival": 350.223731, 
+        "earthMasses": 0.806202, 
+        "gravity": 1.41938890588355, 
+        "id64": 1116892712112258391, 
+        "isLandable": false, 
+        "meanAnomaly": 171.492254, 
+        "name": "Eorld Byio AA-A h539 A 13", 
+        "orbitalEccentricity": 0.000541, 
+        "orbitalInclination": -0.008437, 
+        "orbitalPeriod": 33.2247969453009, 
+        "parents": [
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 4804.6075, 
+        "rotationalPeriod": 0.872744836134259, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.701469278230511, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 85.7428, 
+          "Rock": 14.2572
+        }, 
+        "stations": [], 
+        "subType": "Metal-rich body", 
+        "surfacePressure": 0.582076124164816, 
+        "surfaceTemperature": 1293.205078, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:12:12Z", 
+          "meanAnomaly": "2026-03-06T20:12:12Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:12:12+00", 
+        "volcanismType": "Major Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 347.037797, 
+        "ascendingNode": -9.006947, 
+        "bodyId": 32, 
+        "id64": 1152921509131222359, 
+        "meanAnomaly": 312.113341, 
+        "name": "Eorld Byio AA-A h539 barycentre 32", 
+        "orbitalEccentricity": 0.005804, 
+        "orbitalInclination": 0.065983, 
+        "orbitalPeriod": 48.8933127511458, 
+        "semiMajorAxis": 0.907542003022587, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-03-06T20:11:27Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-03-06 20:11:27+00"
+      }, 
+      {
+        "argOfPeriapsis": 82.462209, 
+        "ascendingNode": 58.378183, 
+        "atmosphereType": null, 
+        "axialTilt": -0.137162, 
+        "bodyId": 33, 
+        "distanceToArrival": 450.73473, 
+        "earthMasses": 1.390722, 
+        "gravity": 1.33537921892526, 
+        "id64": 1188950306150186327, 
+        "isLandable": true, 
+        "materials": {
+          "Chromium": 15.855765, 
+          "Germanium": 1.642802, 
+          "Iron": 35.255939, 
+          "Manganese": 14.560342, 
+          "Mercury": 1.539569, 
+          "Molybdenum": 2.302192, 
+          "Nickel": 26.666113, 
+          "Ruthenium": 2.177279
+        }, 
+        "meanAnomaly": 252.303075, 
+        "name": "Eorld Byio AA-A h539 A 14", 
+        "orbitalEccentricity": 0.083168, 
+        "orbitalInclination": 7.661098, 
+        "orbitalPeriod": 14.73966020125, 
+        "parents": [
+          {
+            "Null": 32
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 6505.857, 
+        "rotationalPeriod": 13.7975802308565, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.000840405140651023, 
+        "signals": {
+          "genuses": [
+            "$Codex_Ent_Sphere_Name;"
+          ], 
+          "signals": {
+            "$SAA_SignalType_Biological;": 1, 
+            "$SAA_SignalType_Geological;": 2
+          }, 
+          "updateTime": "2026-03-06 20:11:33+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 93.9872, 
+          "Rock": 0.0
+        }, 
+        "stations": [], 
+        "subType": "Metal-rich body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 1218.250122, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:11:34Z", 
+          "meanAnomaly": "2026-03-06T20:11:34Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:11:34+00", 
+        "volcanismType": "Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 262.462204, 
+        "ascendingNode": 58.378183, 
+        "atmosphereType": null, 
+        "axialTilt": 0.222767, 
+        "bodyId": 34, 
+        "distanceToArrival": 451.735486, 
+        "earthMasses": 0.847037, 
+        "gravity": 1.61540022432956, 
+        "id64": 1224979103169150295, 
+        "isLandable": true, 
+        "materials": {
+          "Chromium": 15.735044, 
+          "Iron": 34.987507, 
+          "Manganese": 14.449483, 
+          "Molybdenum": 2.284664, 
+          "Nickel": 26.463083, 
+          "Niobium": 2.39121, 
+          "Selenium": 2.43765, 
+          "Technetium": 1.251362
+        }, 
+        "meanAnomaly": 252.30107, 
+        "name": "Eorld Byio AA-A h539 A 15", 
+        "orbitalEccentricity": 0.083168, 
+        "orbitalInclination": 7.661098, 
+        "orbitalPeriod": 14.73966020125, 
+        "parents": [
+          {
+            "Null": 32
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 4616.341, 
+        "rotationalPeriod": 18.6970899804861, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.001379832702192, 
+        "signals": {
+          "genuses": [
+            "$Codex_Ent_Sphere_Name;"
+          ], 
+          "signals": {
+            "$SAA_SignalType_Biological;": 1, 
+            "$SAA_SignalType_Geological;": 2
+          }, 
+          "updateTime": "2026-03-06 20:11:26+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 100.0, 
+          "Rock": 0.0
+        }, 
+        "stations": [], 
+        "subType": "Metal-rich body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 1218.254028, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:11:27Z", 
+          "meanAnomaly": "2026-03-06T20:11:27Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:11:27+00", 
+        "volcanismType": "Major Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 255.841558, 
+        "ascendingNode": 128.746136, 
+        "bodyId": 35, 
+        "id64": 1261007900188114263, 
+        "meanAnomaly": 280.536448, 
+        "name": "Eorld Byio AA-A h539 barycentre 35", 
+        "orbitalEccentricity": 0.000742, 
+        "orbitalInclination": -0.043586, 
+        "orbitalPeriod": 78.8197259384144, 
+        "semiMajorAxis": 1.24773884117624, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-03-06T20:10:48Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-03-06 20:10:48+00"
+      }, 
+      {
+        "absoluteMagnitude": 15.946808, 
+        "age": 2, 
+        "argOfPeriapsis": 48.602123, 
+        "ascendingNode": -50.438949, 
+        "axialTilt": 2.278072, 
+        "bodyId": 36, 
+        "distanceToArrival": 622.543533, 
+        "id64": 1297036697207078231, 
+        "luminosity": "VI", 
+        "mainStar": false, 
+        "meanAnomaly": 194.969212, 
+        "name": "Eorld Byio AA-A h539 A 16", 
+        "orbitalEccentricity": 0.16205, 
+        "orbitalInclination": -4.724358, 
+        "orbitalPeriod": 8.22429020923611, 
+        "parents": [
+          {
+            "Null": 35
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.423305715972222, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 1.88337305534924e-06, 
+        "solarMasses": 0.078125, 
+        "solarRadius": 0.21823118907261, 
+        "spectralClass": "TTS5", 
+        "stations": [], 
+        "subType": "T Tauri Star", 
+        "surfaceTemperature": 957.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:10:48Z", 
+          "meanAnomaly": "2026-03-06T20:10:48Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-03-06 20:10:48+00"
+      }, 
+      {
+        "argOfPeriapsis": 228.602098, 
+        "ascendingNode": -50.438949, 
+        "atmosphereType": null, 
+        "axialTilt": -0.060787, 
+        "bodyId": 37, 
+        "distanceToArrival": 622.006619, 
+        "earthMasses": 1.485032, 
+        "gravity": 2.04395594983175, 
+        "id64": 1333065494226042199, 
+        "isLandable": false, 
+        "meanAnomaly": 194.997766, 
+        "name": "Eorld Byio AA-A h539 A 17", 
+        "orbitalEccentricity": 0.16205, 
+        "orbitalInclination": -4.724358, 
+        "orbitalPeriod": 8.22429020923611, 
+        "parents": [
+          {
+            "Null": 35
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 5433.989, 
+        "rotationalPeriod": 8.22451558104167, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0346481241326018, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 100.0, 
+          "Rock": 0.0
+        }, 
+        "stations": [], 
+        "subType": "Metal-rich body", 
+        "surfacePressure": 9.34619195657538e-05, 
+        "surfaceTemperature": 1299.08667, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:11:45Z", 
+          "meanAnomaly": "2026-03-06T20:11:45Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:11:45+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 315.841556, 
+        "ascendingNode": 128.746136, 
+        "atmosphereComposition": {
+          "Sulphur dioxide": 99.996483
+        }, 
+        "atmosphereType": "Hot Sulphur dioxide", 
+        "axialTilt": 0.004578, 
+        "bodyId": 38, 
+        "distanceToArrival": 622.543453, 
+        "earthMasses": 3.32921, 
+        "gravity": 1.8304000203936, 
+        "id64": 1369094291245006167, 
+        "isLandable": false, 
+        "meanAnomaly": 280.540582, 
+        "name": "Eorld Byio AA-A h539 A 18", 
+        "orbitalEccentricity": 0.000742, 
+        "orbitalInclination": -0.043586, 
+        "orbitalPeriod": 78.8197259384144, 
+        "parents": [
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 8597.738, 
+        "rotationalPeriod": 0.509930390405093, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 1.24773884117624, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 33.1681, 
+          "Rock": 66.832
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 4.53705249198125, 
+        "surfaceTemperature": 1324.550293, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:12:07Z", 
+          "meanAnomaly": "2026-03-06T20:12:07Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:12:07+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 195.84156, 
+        "ascendingNode": 128.746136, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 1.598018, 
+          "Silicates": 98.384872
+        }, 
+        "atmosphereType": "Hot thick Carbon dioxide-rich", 
+        "axialTilt": -0.148329, 
+        "bodyId": 39, 
+        "distanceToArrival": 622.543465, 
+        "earthMasses": 6.224409, 
+        "gravity": 2.44311858876313, 
+        "id64": 1405123088263970135, 
+        "isLandable": false, 
+        "meanAnomaly": 280.539129, 
+        "name": "Eorld Byio AA-A h539 A 19", 
+        "orbitalEccentricity": 0.000742, 
+        "orbitalInclination": -0.043586, 
+        "orbitalPeriod": 78.8197259384144, 
+        "parents": [
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 10175.679, 
+        "rotationalPeriod": 1.49319471915509, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 1.24773884117624, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 33.1681, 
+          "Rock": 66.8319
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 47360.5078312361, 
+        "surfaceTemperature": 4557.572266, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:11:39Z", 
+          "meanAnomaly": "2026-03-06T20:11:39Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:11:39+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 251.926613, 
+        "ascendingNode": -140.106342, 
+        "bodyId": 40, 
+        "id64": 1441151885282934103, 
+        "meanAnomaly": 283.931606, 
+        "name": "Eorld Byio AA-A h539 barycentre 40", 
+        "orbitalEccentricity": 0.002843, 
+        "orbitalInclination": -0.979602, 
+        "orbitalPeriod": 107.55116326941, 
+        "semiMajorAxis": 1.53500751544923, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-03-06T20:10:48Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-03-06 20:10:48+00"
+      }, 
+      {
+        "absoluteMagnitude": 12.485504, 
+        "age": 2, 
+        "argOfPeriapsis": 21.516571, 
+        "ascendingNode": -0.657802, 
+        "axialTilt": 2.4759, 
+        "bodyId": 41, 
+        "distanceToArrival": 765.448246, 
+        "id64": 1477180682301898071, 
+        "luminosity": "VI", 
+        "mainStar": false, 
+        "meanAnomaly": 190.263928, 
+        "name": "Eorld Byio AA-A h539 A 20", 
+        "orbitalEccentricity": 0.161864, 
+        "orbitalInclination": 7.195391, 
+        "orbitalPeriod": 21.5254013461111, 
+        "parents": [
+          {
+            "Null": 40
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.690996807650463, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 3.62012532320154e-05, 
+        "solarMasses": 0.144531, 
+        "solarRadius": 0.315399154565061, 
+        "spectralClass": "TTS3", 
+        "stations": [], 
+        "subType": "T Tauri Star", 
+        "surfaceTemperature": 1766.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:10:48Z", 
+          "meanAnomaly": "2026-03-06T20:10:48Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-03-06 20:10:48+00"
+      }, 
+      {
+        "argOfPeriapsis": 201.516556, 
+        "ascendingNode": -0.657802, 
+        "atmosphereComposition": {
+          "Iron": 1.475549, 
+          "Silicates": 98.482574
+        }, 
+        "atmosphereType": "Hot thick Silicate vapour", 
+        "axialTilt": -0.035436, 
+        "bodyId": 42, 
+        "distanceToArrival": 787.409863, 
+        "earthMasses": 22.163439, 
+        "gravity": 4.7215937595595, 
+        "id64": 1513209479320862039, 
+        "isLandable": false, 
+        "meanAnomaly": 190.279522, 
+        "name": "Eorld Byio AA-A h539 A 21", 
+        "orbitalEccentricity": 0.161864, 
+        "orbitalInclination": 7.195391, 
+        "orbitalPeriod": 21.5254013461111, 
+        "parents": [
+          {
+            "Null": 40
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 13812.137, 
+        "rotationalPeriod": 32.2954247834838, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0798760185064006, 
+        "solidComposition": {
+          "Ice": 0.2961, 
+          "Metal": 33.0699, 
+          "Rock": 66.6341
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 16591377.7008241, 
+        "surfaceTemperature": 7384.395508, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-06T20:12:09Z", 
+          "meanAnomaly": "2026-03-06T20:12:09Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-06 20:12:09+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }
+    ], 
+    "bodyCount": 25, 
+    "coords": {
+      "x": 7320.125, 
+      "y": -929.75, 
+      "z": 29693.15625
+    }, 
+    "date": "2026-03-06 20:12:38+00", 
+    "government": "None", 
+    "id64": 4524375383, 
+    "name": "Eorld Byio AA-A h539", 
+    "population": 0, 
+    "primaryEconomy": "None", 
+    "region": {
+      "name": "Empyrean Straits", 
+      "region": 2
+    }, 
+    "secondaryEconomy": "None", 
+    "security": "Anarchy", 
+    "stations": []
+  }
+}

--- a/e2e/fixtures/pipe-stem-sector-dl-y-d17.json
+++ b/e2e/fixtures/pipe-stem-sector-dl-y-d17.json
@@ -1,0 +1,2400 @@
+{
+  "system": {
+    "allegiance": "Independent", 
+    "bodies": [
+      {
+        "absoluteMagnitude": 4.09024, 
+        "age": 350, 
+        "axialTilt": 0.0, 
+        "bodyId": 0, 
+        "distanceToArrival": 0.0, 
+        "id64": 594592926107, 
+        "luminosity": "Vb", 
+        "mainStar": true, 
+        "name": "Pipe (stem) Sector DL-Y d17", 
+        "rotationalPeriod": 5.45933544724537, 
+        "rotationalPeriodTidallyLocked": false, 
+        "solarMasses": 1.167969, 
+        "solarRadius": 1.17910756578001, 
+        "spectralClass": "F7", 
+        "stations": [], 
+        "subType": "F (White) Star", 
+        "surfaceTemperature": 6309.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-06-09T04:16:52Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-06-20 13:39:23+00"
+      }, 
+      {
+        "argOfPeriapsis": 184.44918, 
+        "ascendingNode": -59.420293, 
+        "atmosphereType": null, 
+        "axialTilt": 0.132454, 
+        "bodyId": 1, 
+        "distanceToArrival": 35.571579, 
+        "earthMasses": 0.747352, 
+        "gravity": 0.840861323544407, 
+        "id64": 36029391611890075, 
+        "isLandable": true, 
+        "materials": {
+          "Iron": 35.021702, 
+          "Manganese": 14.463607, 
+          "Mercury": 1.52934, 
+          "Molybdenum": 2.286897, 
+          "Nickel": 26.488949, 
+          "Vanadium": 8.600111, 
+          "Yttrium": 2.091805, 
+          "Zinc": 9.517588
+        }, 
+        "meanAnomaly": 180.989846, 
+        "name": "Pipe (stem) Sector DL-Y d17 1", 
+        "orbitalEccentricity": 2.1e-05, 
+        "orbitalInclination": 0.001838, 
+        "orbitalPeriod": 6.33506269918981, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 6010.175, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 72058188630854043, 
+            "innerRadius": 10590000.0, 
+            "mass": 5296900000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 1 A Ring", 
+            "outerRadius": 14774000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 6.4316404615625, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0712835719061062, 
+        "signals": {
+          "genuses": [], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 2
+          }, 
+          "updateTime": "2026-04-20 16:54:44+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 90.0932, 
+          "Rock": 0.0
+        }, 
+        "stations": [], 
+        "subType": "Metal-rich body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 1110.645142, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-20T13:39:30Z", 
+          "meanAnomaly": "2026-06-20T13:39:30Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-20 13:39:30+00", 
+        "volcanismType": "Major Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 95.312022, 
+        "ascendingNode": 83.003242, 
+        "atmosphereType": null, 
+        "axialTilt": 0.064125, 
+        "bodyId": 4, 
+        "distanceToArrival": 63.787871, 
+        "earthMasses": 4.759674, 
+        "gravity": 1.72926736004894, 
+        "id64": 144115782668781979, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.686906, 
+          "Carbon": 12.854026, 
+          "Chromium": 9.769653, 
+          "Iron": 21.723221, 
+          "Nickel": 16.430532, 
+          "Niobium": 1.484666, 
+          "Phosphorus": 8.229368, 
+          "Sulphur": 15.2861, 
+          "Vanadium": 5.334467, 
+          "Yttrium": 1.297502, 
+          "Zinc": 5.903558
+        }, 
+        "meanAnomaly": 135.340819, 
+        "name": "Pipe (stem) Sector DL-Y d17 2", 
+        "orbitalEccentricity": 0.000334, 
+        "orbitalInclination": 0.026354, 
+        "orbitalPeriod": 15.2076511747338, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 10576.552, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 180144579687745947, 
+            "innerRadius": 20365000.0, 
+            "mass": 2109600000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 2 A Ring", 
+            "outerRadius": 24062000.0, 
+            "signals": {
+              "signals": {
+                "Platinum": 1
+              }, 
+              "updateTime": "2025-03-22 22:13:36+00"
+            }, 
+            "type": "Metal Rich"
+          }, 
+          {
+            "id64": 216173376706709915, 
+            "innerRadius": 24162000.0, 
+            "mass": 36609000000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 2 B Ring", 
+            "outerRadius": 58560000.0, 
+            "signals": {
+              "signals": {
+                "Monazite": 2, 
+                "Painite": 8, 
+                "Platinum": 6, 
+                "Rhodplumsite": 4, 
+                "Serendibite": 3
+              }, 
+              "updateTime": "2025-03-22 22:13:44+00"
+            }, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": 15.4394897293056, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.127799823117554, 
+        "signals": {
+          "genuses": [], 
+          "geology": [
+            "Silicate Vapour Fumarole", 
+            "Silicate Vapour Gas Vent"
+          ], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-04-20 16:52:20+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0849, 
+          "Metal": 31.7355, 
+          "Rock": 63.5918
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 829.478088, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:52:20Z", 
+          "meanAnomaly": "2026-04-20T16:52:20Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:52:20+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 245.088388, 
+        "ascendingNode": 50.754364, 
+        "atmosphereType": null, 
+        "axialTilt": 1.680643, 
+        "bodyId": 7, 
+        "distanceToArrival": 101.247857, 
+        "earthMasses": 12.829909, 
+        "gravity": 3.51192454369328, 
+        "id64": 252202173725673883, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 0.98272, 
+          "Cadmium": 1.730912, 
+          "Carbon": 13.166603, 
+          "Germanium": 4.646997, 
+          "Iron": 22.2899, 
+          "Manganese": 9.2055, 
+          "Mercury": 0.973363, 
+          "Nickel": 16.859146, 
+          "Phosphorus": 8.429485, 
+          "Sulphur": 15.65782, 
+          "Zinc": 6.05756
+        }, 
+        "meanAnomaly": 231.415728, 
+        "name": "Pipe (stem) Sector DL-Y d17 3", 
+        "orbitalEccentricity": 0.000147, 
+        "orbitalInclination": 0.000123, 
+        "orbitalPeriod": 30.4178672808218, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 12185.008, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 288230970744637851, 
+            "innerRadius": 38312000.0, 
+            "mass": 109090000000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 3 A Ring", 
+            "outerRadius": 95228000.0, 
+            "signals": {
+              "signals": {
+                "Monazite": 2, 
+                "Platinum": 1, 
+                "Rhodplumsite": 2, 
+                "Serendibite": 1
+              }, 
+              "updateTime": "2025-03-22 22:18:31+00"
+            }, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": -30.8815848739005, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.202881002037814, 
+        "signals": {
+          "genuses": [], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-04-20 16:52:00+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 33.2972, 
+          "Rock": 66.7028
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 658.338623, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:52:01Z", 
+          "meanAnomaly": "2026-04-20T16:52:01Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:52:01+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 14.375612, 
+        "ascendingNode": 89.666836, 
+        "atmosphereType": null, 
+        "axialTilt": 0.242857, 
+        "bodyId": 9, 
+        "distanceToArrival": 101.48853, 
+        "earthMasses": 0.000958, 
+        "gravity": 0.0809551340878964, 
+        "id64": 324259767763601819, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.898676, 
+          "Chromium": 8.775134, 
+          "Iron": 19.511868, 
+          "Nickel": 14.757958, 
+          "Niobium": 1.333532, 
+          "Phosphorus": 10.178605, 
+          "Ruthenium": 1.204982, 
+          "Selenium": 2.959077, 
+          "Sulphur": 18.90682, 
+          "Tin": 1.17076, 
+          "Zinc": 5.302595
+        }, 
+        "meanAnomaly": 213.343487, 
+        "name": "Pipe (stem) Sector DL-Y d17 3 a", 
+        "orbitalEccentricity": 4.5e-05, 
+        "orbitalInclination": 0.006184, 
+        "orbitalPeriod": 3.97505473207176, 
+        "parents": [
+          {
+            "Planet": 7
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 693.616375, 
+        "rotationalPeriod": 3.97527248494213, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00165878146960724, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 658.338623, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:52:06Z", 
+          "meanAnomaly": "2026-04-20T16:52:06Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:52:06+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 98.707056, 
+        "ascendingNode": 44.391691, 
+        "atmosphereType": null, 
+        "axialTilt": -0.257932, 
+        "bodyId": 11, 
+        "distanceToArrival": 131.038598, 
+        "earthMasses": 1.799747, 
+        "gravity": 1.35718211481595, 
+        "id64": 396317361801529755, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.645345, 
+          "Carbon": 12.520127, 
+          "Chromium": 9.528953, 
+          "Iron": 21.188013, 
+          "Manganese": 8.750434, 
+          "Mercury": 0.925246, 
+          "Nickel": 16.025724, 
+          "Phosphorus": 8.0156, 
+          "Ruthenium": 1.308495, 
+          "Sulphur": 14.889023, 
+          "Vanadium": 5.203038
+        }, 
+        "meanAnomaly": 90.089546, 
+        "name": "Pipe (stem) Sector DL-Y d17 4", 
+        "orbitalEccentricity": 9.8e-05, 
+        "orbitalInclination": -0.00085, 
+        "orbitalPeriod": 44.7928201821065, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 7341.3055, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 432346158820493723, 
+            "innerRadius": 14549000.0, 
+            "mass": 1061100000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 4 A Ring", 
+            "outerRadius": 16938000.0, 
+            "type": "Rocky"
+          }, 
+          {
+            "id64": 468374955839457691, 
+            "innerRadius": 17038000.0, 
+            "mass": 21251000000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 4 B Ring", 
+            "outerRadius": 42346000.0, 
+            "signals": {
+              "signals": {
+                "Painite": 1
+              }, 
+              "updateTime": "2025-03-22 22:23:55+00"
+            }, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": 45.4756820655556, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.262599841256186, 
+        "signals": {
+          "genuses": [], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-04-20 16:52:15+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0124, 
+          "Metal": 33.0623, 
+          "Rock": 66.2671
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 578.659119, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:52:15Z", 
+          "meanAnomaly": "2026-04-20T16:52:15Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:52:15+00", 
+        "volcanismType": "Minor Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 326.211054, 
+        "ascendingNode": -26.329819, 
+        "bodyId": 21, 
+        "id64": 756605331991169435, 
+        "meanAnomaly": 194.9509, 
+        "name": "Pipe (stem) Sector DL-Y d17 barycentre 21", 
+        "orbitalEccentricity": 0.000973, 
+        "orbitalInclination": 0.043373, 
+        "orbitalPeriod": 75.0902991879861, 
+        "semiMajorAxis": 0.370576650373889, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-04-20T16:55:56Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-04-20 16:55:56+00"
+      }, 
+      {
+        "argOfPeriapsis": 48.654504, 
+        "ascendingNode": -159.923299, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 95.806847, 
+          "Nitrogen": 3.191737, 
+          "Sulphur dioxide": 0.958068
+        }, 
+        "atmosphereType": "Hot thick Carbon dioxide", 
+        "axialTilt": 0.513899, 
+        "bodyId": 22, 
+        "distanceToArrival": 184.627378, 
+        "earthMasses": 6.717751, 
+        "gravity": 2.53724839400428, 
+        "id64": 792634129010133403, 
+        "isLandable": false, 
+        "meanAnomaly": 228.412345, 
+        "name": "Pipe (stem) Sector DL-Y d17 5", 
+        "orbitalEccentricity": 0.045125, 
+        "orbitalInclination": -6.970556, 
+        "orbitalPeriod": 50.7146126970139, 
+        "parents": [
+          {
+            "Null": 21
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 10373.303, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 828662926029097371, 
+            "innerRadius": 54925000.0, 
+            "mass": 134470000000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 5 A Ring", 
+            "outerRadius": 88827000.0, 
+            "signals": {
+              "signals": {
+                "Alexandrite": 3, 
+                "Benitoite": 1, 
+                "Monazite": 3, 
+                "Musgravite": 5, 
+                "Serendibite": 4
+              }, 
+              "updateTime": "2025-03-22 22:29:01+00"
+            }, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 1.06847765728009, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.00116549075114866, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 33.361, 
+          "Rock": 66.639
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 907.277532691833, 
+        "surfaceTemperature": 1846.257568, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:56:07Z", 
+          "meanAnomaly": "2026-04-20T16:56:07Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:56:07+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 21.306427, 
+        "ascendingNode": 111.956834, 
+        "bodyId": 24, 
+        "id64": 864691723048061339, 
+        "meanAnomaly": 150.499626, 
+        "name": "Pipe (stem) Sector DL-Y d17 barycentre 24", 
+        "orbitalEccentricity": 0.000393, 
+        "orbitalInclination": 1.913925, 
+        "orbitalPeriod": 3.9225652537963, 
+        "semiMajorAxis": 0.00132532072951554, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-04-20T16:56:02Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-04-20 16:56:02+00"
+      }, 
+      {
+        "argOfPeriapsis": 287.938038, 
+        "ascendingNode": -8.381315, 
+        "atmosphereType": null, 
+        "axialTilt": -0.491022, 
+        "bodyId": 25, 
+        "distanceToArrival": 184.865327, 
+        "earthMasses": 0.000882, 
+        "gravity": 0.0787062302437035, 
+        "id64": 900720520067025307, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 2.614455, 
+          "Carbon": 16.564093, 
+          "Iron": 20.328508, 
+          "Manganese": 8.395466, 
+          "Nickel": 15.375632, 
+          "Niobium": 1.389345, 
+          "Phosphorus": 10.604616, 
+          "Selenium": 3.082925, 
+          "Sulphur": 19.698137, 
+          "Technetium": 0.727069, 
+          "Tin": 1.21976
+        }, 
+        "meanAnomaly": 273.550145, 
+        "name": "Pipe (stem) Sector DL-Y d17 5 a", 
+        "orbitalEccentricity": 0.047447, 
+        "orbitalInclination": 3.896579, 
+        "orbitalPeriod": 0.386992441840278, 
+        "parents": [
+          {
+            "Null": 24
+          }, 
+          {
+            "Planet": 22
+          }, 
+          {
+            "Null": 21
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 674.710375, 
+        "rotationalPeriod": 0.554252821701389, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 8.75906267999441e-06, 
+        "signals": {
+          "genuses": [], 
+          "guesses": [
+            "Lindigoticum Sinuous Tubers"
+          ], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-04-20 16:56:03+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 487.114441, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:56:04Z", 
+          "meanAnomaly": "2026-04-20T16:56:04Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:56:04+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 107.938043, 
+        "ascendingNode": -8.381315, 
+        "atmosphereType": null, 
+        "axialTilt": -0.157214, 
+        "bodyId": 26, 
+        "distanceToArrival": 184.870642, 
+        "earthMasses": 0.000839, 
+        "gravity": 0.0773906393392475, 
+        "id64": 936749317085989275, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 1.271423, 
+          "Arsenic": 2.688732, 
+          "Carbon": 17.034676, 
+          "Germanium": 6.012187, 
+          "Iron": 20.906036, 
+          "Nickel": 15.81245, 
+          "Niobium": 1.428816, 
+          "Phosphorus": 10.905891, 
+          "Sulphur": 20.257757, 
+          "Tin": 1.254413, 
+          "Zirconium": 2.427622
+        }, 
+        "meanAnomaly": 273.529544, 
+        "name": "Pipe (stem) Sector DL-Y d17 5 b", 
+        "orbitalEccentricity": 0.047447, 
+        "orbitalInclination": 3.896579, 
+        "orbitalPeriod": 0.386992441840278, 
+        "parents": [
+          {
+            "Null": 24
+          }, 
+          {
+            "Planet": 22
+          }, 
+          {
+            "Null": 21
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 663.6396875, 
+        "rotationalPeriod": 0.180194333356481, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 9.20764700751854e-06, 
+        "signals": {
+          "genuses": [], 
+          "guesses": [
+            "Lindigoticum Sinuous Tubers"
+          ], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-04-20 16:56:01+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 487.114441, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:56:02Z", 
+          "meanAnomaly": "2026-04-20T16:56:02Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:56:02+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 228.654478, 
+        "ascendingNode": -159.923299, 
+        "atmosphereType": null, 
+        "axialTilt": -0.182649, 
+        "bodyId": 27, 
+        "distanceToArrival": 187.724504, 
+        "earthMasses": 1.196757, 
+        "gravity": 1.18418089120016, 
+        "id64": 972778114104953243, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 0.988569, 
+          "Cadmium": 1.740976, 
+          "Carbon": 13.244963, 
+          "Germanium": 4.674653, 
+          "Iron": 22.419508, 
+          "Manganese": 9.259027, 
+          "Mercury": 0.979023, 
+          "Nickel": 16.957176, 
+          "Phosphorus": 8.479652, 
+          "Sulphur": 15.751004, 
+          "Vanadium": 5.505451
+        }, 
+        "meanAnomaly": 228.411407, 
+        "name": "Pipe (stem) Sector DL-Y d17 6", 
+        "orbitalEccentricity": 0.045125, 
+        "orbitalInclination": -6.970556, 
+        "orbitalPeriod": 50.7146126970139, 
+        "parents": [
+          {
+            "Null": 21
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 6408.856, 
+        "rotationalPeriod": 75.5799436529398, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00654508715919812, 
+        "signals": {
+          "genuses": [], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-04-20 16:55:56+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 33.2839, 
+          "Rock": 66.7161
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 487.114441, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:55:56Z", 
+          "meanAnomaly": "2026-04-20T16:55:56Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:55:56+00", 
+        "volcanismType": "Minor Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 289.084058, 
+        "ascendingNode": 139.017227, 
+        "bodyId": 28, 
+        "id64": 1008806911123917211, 
+        "meanAnomaly": 193.536624, 
+        "name": "Pipe (stem) Sector DL-Y d17 barycentre 28", 
+        "orbitalEccentricity": 0.000909, 
+        "orbitalInclination": 0.070111, 
+        "orbitalPeriod": 1515.72493767296, 
+        "semiMajorAxis": 2.74727686481283, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-04-20T16:52:53Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-04-20 16:52:53+00"
+      }, 
+      {
+        "argOfPeriapsis": 238.27033, 
+        "ascendingNode": -173.937252, 
+        "atmosphereComposition": {
+          "Helium": 27.750433, 
+          "Hydrogen": 72.249573
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -0.755191, 
+        "bodyId": 29, 
+        "distanceToArrival": 1372.092972, 
+        "earthMasses": 1717.265259, 
+        "gravity": 12.7916906291424, 
+        "id64": 1044835708142881179, 
+        "isLandable": false, 
+        "meanAnomaly": 29.761585, 
+        "name": "Pipe (stem) Sector DL-Y d17 7", 
+        "orbitalEccentricity": 0.01499, 
+        "orbitalInclination": -8.245811, 
+        "orbitalPeriod": 113.53145525963, 
+        "parents": [
+          {
+            "Null": 28
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 73865.456, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 1080864505161845147, 
+            "innerRadius": 146220000.0, 
+            "mass": 4747100000000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 7 A Ring", 
+            "outerRadius": 416890000.0, 
+            "signals": {
+              "signals": {
+                "Musgravite": 1
+              }, 
+              "updateTime": "2025-03-22 22:38:02+00"
+            }, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 0.509422251527778, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 6.87926679094303e-05, 
+        "stations": [], 
+        "subType": "Class III gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 507.687012, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:53:02Z", 
+          "meanAnomaly": "2026-04-20T16:53:02Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:53:02+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 208.123514, 
+        "ascendingNode": -167.666466, 
+        "atmosphereComposition": {
+          "Water": 100.0
+        }, 
+        "atmosphereType": "Hot thick Water", 
+        "axialTilt": 0.271999, 
+        "bodyId": 31, 
+        "distanceToArrival": 1370.681037, 
+        "earthMasses": 0.004308, 
+        "gravity": 0.13481084939329, 
+        "id64": 1116893302180809115, 
+        "isLandable": false, 
+        "meanAnomaly": 108.483884, 
+        "name": "Pipe (stem) Sector DL-Y d17 7 a", 
+        "orbitalEccentricity": 0.004719, 
+        "orbitalInclination": 0.525727, 
+        "orbitalPeriod": 1.14384065209491, 
+        "parents": [
+          {
+            "Planet": 29
+          }, 
+          {
+            "Null": 28
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1139.6695, 
+        "rotationalPeriod": 1.14384650239583, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00369823366032488, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 62.2788452997779, 
+        "surfaceTemperature": 917.390503, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:54:34Z", 
+          "meanAnomaly": "2026-04-20T16:54:34Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:54:34+00", 
+        "volcanismType": "Minor Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 141.742749, 
+        "ascendingNode": 153.085088, 
+        "atmosphereType": null, 
+        "axialTilt": 0.076701, 
+        "bodyId": 32, 
+        "distanceToArrival": 1373.632429, 
+        "earthMasses": 0.009237, 
+        "gravity": 0.17505312531865, 
+        "id64": 1152922099199773083, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.647881, 
+          "Germanium": 5.522734, 
+          "Iron": 19.204075, 
+          "Manganese": 7.931087, 
+          "Mercury": 0.83861, 
+          "Nickel": 14.525157, 
+          "Phosphorus": 10.018042, 
+          "Sulphur": 18.608572, 
+          "Tellurium": 1.430399, 
+          "Tungsten": 1.054497, 
+          "Zinc": 5.218949
+        }, 
+        "meanAnomaly": 258.467387, 
+        "name": "Pipe (stem) Sector DL-Y d17 7 b", 
+        "orbitalEccentricity": 0.010207, 
+        "orbitalInclination": 2.206636, 
+        "orbitalPeriod": 6.44631642434028, 
+        "parents": [
+          {
+            "Planet": 29
+          }, 
+          {
+            "Null": 28
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1464.395375, 
+        "rotationalPeriod": 6.4463495924537, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0117118383276684, 
+        "signals": {
+          "guesses": [
+            "Lindigoticum Sinuous Tubers"
+          ]
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 222.227173, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:54:37Z", 
+          "meanAnomaly": "2026-04-20T16:54:37Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:54:37+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 58.270335, 
+        "ascendingNode": -173.937252, 
+        "atmosphereComposition": {
+          "Argon": 0.66455, 
+          "Nitrogen": 99.335449
+        }, 
+        "atmosphereType": "Thin Argon-rich", 
+        "axialTilt": -0.247625, 
+        "bodyId": 33, 
+        "distanceToArrival": 1398.977801, 
+        "earthMasses": 1.490987, 
+        "gravity": 1.29649199551341, 
+        "id64": 1188950896218737051, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 13.360222, 
+          "Iron": 22.614603, 
+          "Manganese": 9.3396, 
+          "Nickel": 17.104738, 
+          "Niobium": 1.545587, 
+          "Phosphorus": 8.553443, 
+          "Sulphur": 15.888069, 
+          "Tin": 1.47117, 
+          "Yttrium": 1.350743, 
+          "Zinc": 6.145802, 
+          "Zirconium": 2.626021
+        }, 
+        "meanAnomaly": 29.76122, 
+        "name": "Pipe (stem) Sector DL-Y d17 8", 
+        "orbitalEccentricity": 0.01499, 
+        "orbitalInclination": -8.245811, 
+        "orbitalPeriod": 113.53145525963, 
+        "parents": [
+          {
+            "Null": 28
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 6836.5745, 
+        "rotationalPeriod": 0.664110165729167, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0792337414273568, 
+        "signals": {
+          "genuses": [], 
+          "guesses": [
+            "Bark Mounds", 
+            "Rubeum Bioluminescent Anemone", 
+            "Roseum Brain Tree", 
+            "Ostrinum Brain Tree"
+          ], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-04-20 16:52:52+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 33.2839, 
+          "Rock": 66.7161
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0830379406464347, 
+        "surfaceTemperature": 196.908173, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:52:53Z", 
+          "meanAnomaly": "2026-04-20T16:52:53Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:52:53+00", 
+        "volcanismType": "Minor Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 135.846247, 
+        "ascendingNode": -148.301524, 
+        "bodyId": 34, 
+        "id64": 1224979693237701019, 
+        "meanAnomaly": 271.037909, 
+        "name": "Pipe (stem) Sector DL-Y d17 barycentre 34", 
+        "orbitalEccentricity": 0.008643, 
+        "orbitalInclination": 1.524535, 
+        "orbitalPeriod": 2239.87114926179, 
+        "semiMajorAxis": 3.56427210739919, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-04-20T16:51:31Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-04-20 16:51:31+00"
+      }, 
+      {
+        "argOfPeriapsis": 79.352786, 
+        "ascendingNode": 51.708142, 
+        "atmosphereComposition": {
+          "Helium": 27.750433, 
+          "Hydrogen": 72.249573
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -0.433082, 
+        "bodyId": 35, 
+        "distanceToArrival": 1778.518344, 
+        "earthMasses": 1786.80481, 
+        "gravity": 13.6461833384317, 
+        "id64": 1261008490256664987, 
+        "isLandable": false, 
+        "meanAnomaly": 41.666589, 
+        "name": "Pipe (stem) Sector DL-Y d17 9", 
+        "orbitalEccentricity": 0.066595, 
+        "orbitalInclination": 8.237966, 
+        "orbitalPeriod": 163.45804626191, 
+        "parents": [
+          {
+            "Null": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 72949.048, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 1297037287275628955, 
+            "innerRadius": 126690000.0, 
+            "mass": 297700000000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 9 A Ring", 
+            "outerRadius": 181310000.0, 
+            "signals": {
+              "signals": {
+                "Monazite": 1
+              }, 
+              "updateTime": "2021-11-23 19:08:45+00"
+            }, 
+            "type": "Rocky"
+          }, 
+          {
+            "id64": 1333066084294592923, 
+            "innerRadius": 181410000.0, 
+            "mass": 2576000000000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 9 B Ring", 
+            "outerRadius": 422440000.0, 
+            "signals": {
+              "signals": {
+                "Alexandrite": 7, 
+                "Benitoite": 4, 
+                "Monazite": 6, 
+                "Musgravite": 4, 
+                "Serendibite": 4
+              }, 
+              "updateTime": "2021-11-23 19:08:45+00"
+            }, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 1.70195177986111, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.000159476795898306, 
+        "stations": [], 
+        "subType": "Class III gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 503.259979, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:51:31Z", 
+          "meanAnomaly": "2026-04-20T16:51:31Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:51:31+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 258.310535, 
+        "ascendingNode": 34.952281, 
+        "atmosphereComposition": {
+          "Oxygen": 2.999999, 
+          "Silicates": 5.0, 
+          "Sulphur dioxide": 90.0
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 1.011528, 
+        "bodyId": 38, 
+        "distanceToArrival": 1778.468196, 
+        "earthMasses": 0.007346, 
+        "gravity": 0.161944937289691, 
+        "id64": 1369094881313556891, 
+        "isLandable": false, 
+        "meanAnomaly": 238.66763, 
+        "name": "Pipe (stem) Sector DL-Y d17 9 a", 
+        "orbitalEccentricity": 9.5e-05, 
+        "orbitalInclination": -1.357349, 
+        "orbitalPeriod": 1.69560768538194, 
+        "parents": [
+          {
+            "Planet": 35
+          }, 
+          {
+            "Null": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1357.736375, 
+        "rotationalPeriod": 1.69562403916667, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00487209185132148, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.244, 
+          "Rock": 90.756
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 227.231018, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:51:40Z", 
+          "meanAnomaly": "2026-04-20T16:51:40Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:51:40+00", 
+        "volcanismType": "Major Rocky Magma"
+      }, 
+      {
+        "argOfPeriapsis": 248.454299, 
+        "ascendingNode": 14.570026, 
+        "atmosphereType": null, 
+        "axialTilt": -0.067289, 
+        "bodyId": 39, 
+        "distanceToArrival": 1774.631796, 
+        "earthMasses": 0.010059, 
+        "gravity": 0.180269195472622, 
+        "id64": 1405123678332520859, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.567986, 
+          "Germanium": 5.494536, 
+          "Iron": 19.106024, 
+          "Manganese": 7.890593, 
+          "Molybdenum": 1.247612, 
+          "Nickel": 14.450995, 
+          "Phosphorus": 9.966892, 
+          "Sulphur": 18.513561, 
+          "Tellurium": 1.423096, 
+          "Tin": 1.146408, 
+          "Zinc": 5.192302
+        }, 
+        "meanAnomaly": 93.473567, 
+        "name": "Pipe (stem) Sector DL-Y d17 9 b", 
+        "orbitalEccentricity": 0.010417, 
+        "orbitalInclination": -0.267026, 
+        "orbitalPeriod": 4.41653302145833, 
+        "parents": [
+          {
+            "Planet": 35
+          }, 
+          {
+            "Null": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1505.94325, 
+        "rotationalPeriod": 4.4165757600463, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00922329783223085, 
+        "signals": {
+          "guesses": [
+            "Lindigoticum Sinuous Tubers"
+          ]
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 208.062576, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:51:54Z", 
+          "meanAnomaly": "2026-04-20T16:51:54Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:51:54+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 10.973344, 
+        "ascendingNode": 71.494339, 
+        "atmosphereType": null, 
+        "axialTilt": -2.957158, 
+        "bodyId": 40, 
+        "distanceToArrival": 1773.348127, 
+        "earthMasses": 0.008576, 
+        "gravity": 0.170863566840012, 
+        "id64": 1441152475351484827, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.048308, 
+          "Chromium": 8.348125, 
+          "Iron": 18.562393, 
+          "Manganese": 7.666079, 
+          "Nickel": 14.039818, 
+          "Niobium": 1.268641, 
+          "Phosphorus": 9.634186, 
+          "Sulphur": 17.895555, 
+          "Tellurium": 1.375591, 
+          "Tin": 1.116735, 
+          "Zinc": 5.044564
+        }, 
+        "meanAnomaly": 339.677613, 
+        "name": "Pipe (stem) Sector DL-Y d17 9 c", 
+        "orbitalEccentricity": 0.000424, 
+        "orbitalInclination": 0.385196, 
+        "orbitalPeriod": 8.74768632153935, 
+        "parents": [
+          {
+            "Planet": 35
+          }, 
+          {
+            "Null": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1428.24775, 
+        "rotationalPeriod": -8.74777161920139, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0145465735835384, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.3307, 
+          "Rock": 90.6693
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 197.673782, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:51:44Z", 
+          "meanAnomaly": "2026-04-20T16:51:44Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:51:44+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 346.765924, 
+        "ascendingNode": -60.296866, 
+        "atmosphereType": null, 
+        "axialTilt": -0.435697, 
+        "bodyId": 41, 
+        "distanceToArrival": 1773.338055, 
+        "earthMasses": 0.000376, 
+        "gravity": 0.0574004282655246, 
+        "id64": 1477181272370448795, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.328879, 
+          "Carbon": 16.108046, 
+          "Chromium": 7.696153, 
+          "Germanium": 5.685144, 
+          "Iron": 17.112709, 
+          "Manganese": 7.067374, 
+          "Molybdenum": 1.11745, 
+          "Nickel": 12.943336, 
+          "Phosphorus": 10.312648, 
+          "Sulphur": 19.155802, 
+          "Tellurium": 1.472464
+        }, 
+        "meanAnomaly": 281.554274, 
+        "name": "Pipe (stem) Sector DL-Y d17 9 c a", 
+        "orbitalEccentricity": 0.0, 
+        "orbitalInclination": 5.857946, 
+        "orbitalPeriod": 0.938494337928241, 
+        "parents": [
+          {
+            "Planet": 40
+          }, 
+          {
+            "Planet": 35
+          }, 
+          {
+            "Null": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 516.23628125, 
+        "rotationalPeriod": 0.958868045277778, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 5.62000871009523e-05, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-04-20 16:51:46+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 3.1896, 
+          "Rock": 96.8104
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 197.673782, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:51:46Z", 
+          "meanAnomaly": "2026-04-20T16:51:46Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:51:46+00", 
+        "volcanismType": "Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 284.150493, 
+        "ascendingNode": 22.149214, 
+        "atmosphereType": null, 
+        "axialTilt": 0.26447, 
+        "bodyId": 42, 
+        "distanceToArrival": 1777.208579, 
+        "earthMasses": 0.005603, 
+        "gravity": 0.147471805852962, 
+        "id64": 1513210069389412763, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.507147, 
+          "Carbon": 15.814331, 
+          "Chromium": 8.72858, 
+          "Iron": 19.408352, 
+          "Molybdenum": 1.267354, 
+          "Nickel": 14.679665, 
+          "Phosphorus": 10.124606, 
+          "Selenium": 2.943378, 
+          "Sulphur": 18.806515, 
+          "Tellurium": 1.445615, 
+          "Zinc": 5.274464
+        }, 
+        "meanAnomaly": 241.45129, 
+        "name": "Pipe (stem) Sector DL-Y d17 9 d", 
+        "orbitalEccentricity": 0.002028, 
+        "orbitalInclination": -13.132339, 
+        "orbitalPeriod": 15.9656242639931, 
+        "parents": [
+          {
+            "Planet": 35
+          }, 
+          {
+            "Null": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1242.631625, 
+        "rotationalPeriod": 15.9657780466319, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0217248021643432, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 190.295029, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:51:50Z", 
+          "meanAnomaly": "2026-04-20T16:51:50Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:51:50+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 259.352781, 
+        "ascendingNode": 51.708142, 
+        "atmosphereComposition": {
+          "Argon": 1.526467, 
+          "Nitrogen": 91.681892, 
+          "Oxygen": 5.388079
+        }, 
+        "atmosphereType": "Thick Nitrogen", 
+        "axialTilt": 0.39323, 
+        "bodyId": 43, 
+        "distanceToArrival": 1730.255082, 
+        "earthMasses": 2.784824, 
+        "gravity": 1.39769695115734, 
+        "id64": 1549238866408376731, 
+        "isLandable": false, 
+        "meanAnomaly": 41.667047, 
+        "name": "Pipe (stem) Sector DL-Y d17 10", 
+        "orbitalEccentricity": 0.066595, 
+        "orbitalInclination": 8.237966, 
+        "orbitalPeriod": 163.45804626191, 
+        "parents": [
+          {
+            "Null": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 8998.685, 
+        "rotationalPeriod": 2.50886919614583, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.102325813918247, 
+        "solidComposition": {
+          "Ice": 0.0764, 
+          "Metal": 31.9309, 
+          "Rock": 64.0023
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 5.69802306933136, 
+        "surfaceTemperature": 238.030365, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:51:49Z", 
+          "meanAnomaly": "2026-04-20T16:51:49Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:51:49+00", 
+        "volcanismType": "Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 75.846249, 
+        "ascendingNode": -148.301524, 
+        "atmosphereComposition": {
+          "Ammonia": 32.634861, 
+          "Methane": 32.634861, 
+          "Nitrogen": 32.634861
+        }, 
+        "atmosphereType": "Thick Methane-rich", 
+        "axialTilt": -0.206654, 
+        "bodyId": 44, 
+        "distanceToArrival": 1778.443195, 
+        "earthMasses": 1.441109, 
+        "gravity": 1.27830886101764, 
+        "id64": 1585267663427340699, 
+        "isLandable": false, 
+        "meanAnomaly": 271.038015, 
+        "name": "Pipe (stem) Sector DL-Y d17 11", 
+        "orbitalEccentricity": 0.008643, 
+        "orbitalInclination": 1.524535, 
+        "orbitalPeriod": 2239.87114926179, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 6768.8855, 
+        "rotationalPeriod": 0.482147939583333, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 3.56427210739919, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 33.2839, 
+          "Rock": 66.7161
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 22.549333826795, 
+        "surfaceTemperature": 421.193787, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:52:28Z", 
+          "meanAnomaly": "2026-04-20T16:52:28Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:52:28+00", 
+        "volcanismType": "Minor Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 291.651711, 
+        "ascendingNode": 58.365882, 
+        "bodyId": 46, 
+        "id64": 1657325257465268635, 
+        "meanAnomaly": 188.553738, 
+        "name": "Pipe (stem) Sector DL-Y d17 barycentre 46", 
+        "orbitalEccentricity": 0.020724, 
+        "orbitalInclination": -6.279842, 
+        "orbitalPeriod": 3453.66855186444, 
+        "semiMajorAxis": 4.75710396997707, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-06-20T13:39:36Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-06-20 13:39:36+00"
+      }, 
+      {
+        "argOfPeriapsis": 104.90423, 
+        "ascendingNode": 6.838358, 
+        "atmosphereComposition": {
+          "Helium": 27.750427, 
+          "Hydrogen": 72.249565
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 1.427585, 
+        "bodyId": 47, 
+        "distanceToArrival": 2478.591638, 
+        "earthMasses": 3233.471436, 
+        "gravity": 29.4878706026308, 
+        "id64": 1693354054484232603, 
+        "isLandable": false, 
+        "meanAnomaly": 255.754166, 
+        "name": "Pipe (stem) Sector DL-Y d17 12", 
+        "orbitalEccentricity": 0.160098, 
+        "orbitalInclination": 7.951723, 
+        "orbitalPeriod": 359.199527237153, 
+        "parents": [
+          {
+            "Null": 46
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 66757.4, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 1729382851503196571, 
+            "innerRadius": 115100000.0, 
+            "mass": 574260000000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 12 A Ring", 
+            "outerRadius": 178270000.0, 
+            "signals": {
+              "signals": {
+                "Alexandrite": 1, 
+                "Benitoite": 2, 
+                "Monazite": 1, 
+                "Serendibite": 1
+              }, 
+              "updateTime": "2021-07-05 13:47:56+00"
+            }, 
+            "type": "Rocky"
+          }, 
+          {
+            "id64": 1765411648522160539, 
+            "innerRadius": 178370000.0, 
+            "mass": 7228300000000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 12 B Ring", 
+            "outerRadius": 514790000.0, 
+            "signals": {
+              "signals": {
+                "Alexandrite": 6, 
+                "Benitoite": 9, 
+                "Monazite": 4, 
+                "Musgravite": 6, 
+                "Serendibite": 1
+              }, 
+              "updateTime": "2021-07-05 13:48:03+00"
+            }, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 1.35954368482639, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.177917026206094, 
+        "stations": [], 
+        "subType": "Class IV gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 875.704712, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:55:18Z", 
+          "meanAnomaly": "2026-04-20T16:55:18Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:55:18+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 348.899518, 
+        "ascendingNode": 34.138091, 
+        "atmosphereType": null, 
+        "axialTilt": -0.851739, 
+        "bodyId": 50, 
+        "distanceToArrival": 2477.60179, 
+        "earthMasses": 0.005202, 
+        "gravity": 0.143909044560008, 
+        "id64": 1801440445541124507, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.906045, 
+          "Chromium": 8.81137, 
+          "Iron": 19.592438, 
+          "Mercury": 0.85557, 
+          "Nickel": 14.818899, 
+          "Phosphorus": 10.183323, 
+          "Selenium": 2.960448, 
+          "Sulphur": 18.915581, 
+          "Tellurium": 1.453998, 
+          "Tin": 1.177839, 
+          "Zinc": 5.324492
+        }, 
+        "meanAnomaly": 183.341241, 
+        "name": "Pipe (stem) Sector DL-Y d17 12 a", 
+        "orbitalEccentricity": 0.00197, 
+        "orbitalInclination": -0.136845, 
+        "orbitalPeriod": 1.34505366009259, 
+        "parents": [
+          {
+            "Planet": 47
+          }, 
+          {
+            "Null": 46
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1212.08925, 
+        "rotationalPeriod": 1.3450670240162, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00508770954319733, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Biological;": 1, 
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-04-20 16:55:26+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.2579, 
+          "Rock": 90.7422
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 281.482666, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:55:27Z", 
+          "meanAnomaly": "2026-04-20T16:55:27Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:55:27+00", 
+        "volcanismType": "Minor Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 23.944181, 
+        "ascendingNode": -146.756002, 
+        "atmosphereType": null, 
+        "axialTilt": -0.267675, 
+        "bodyId": 51, 
+        "distanceToArrival": 2476.933722, 
+        "earthMasses": 0.006204, 
+        "gravity": 0.152705822371775, 
+        "id64": 1837469242560088475, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 1.135859, 
+          "Carbon": 15.218375, 
+          "Chromium": 8.399649, 
+          "Iron": 18.676958, 
+          "Manganese": 7.713393, 
+          "Nickel": 14.12647, 
+          "Niobium": 1.276471, 
+          "Phosphorus": 9.743066, 
+          "Sulphur": 18.097801, 
+          "Tungsten": 1.025553, 
+          "Vanadium": 4.586411
+        }, 
+        "meanAnomaly": 53.047452, 
+        "name": "Pipe (stem) Sector DL-Y d17 12 b", 
+        "orbitalEccentricity": 0.001786, 
+        "orbitalInclination": 0.082829, 
+        "orbitalPeriod": 3.03632255505787, 
+        "parents": [
+          {
+            "Planet": 47
+          }, 
+          {
+            "Null": 46
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1284.9825, 
+        "rotationalPeriod": 3.03635252216435, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00875510226153218, 
+        "signals": {
+          "guesses": [
+            "Lindigoticum Sinuous Tubers"
+          ]
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 248.617661, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:55:29Z", 
+          "meanAnomaly": "2026-04-20T16:55:29Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:55:29+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 299.777085, 
+        "ascendingNode": 32.815302, 
+        "atmosphereType": null, 
+        "axialTilt": 2.952974, 
+        "bodyId": 52, 
+        "distanceToArrival": 2476.055576, 
+        "earthMasses": 0.010349, 
+        "gravity": 0.182204547772, 
+        "id64": 1873498039579052443, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.821493, 
+          "Iron": 19.48674, 
+          "Manganese": 8.047824, 
+          "Mercury": 0.850954, 
+          "Nickel": 14.738955, 
+          "Niobium": 1.331815, 
+          "Phosphorus": 10.129191, 
+          "Sulphur": 18.815031, 
+          "Technetium": 0.696962, 
+          "Vanadium": 4.785265, 
+          "Zinc": 5.295767
+        }, 
+        "meanAnomaly": 125.196564, 
+        "name": "Pipe (stem) Sector DL-Y d17 12 c", 
+        "orbitalEccentricity": 0.00012, 
+        "orbitalInclination": -0.075891, 
+        "orbitalPeriod": 5.67569197327546, 
+        "parents": [
+          {
+            "Planet": 47
+          }, 
+          {
+            "Null": 46
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1519.325375, 
+        "rotationalPeriod": -5.67574866825231, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0132854145815151, 
+        "signals": {
+          "guesses": [
+            "Lindigoticum Sinuous Tubers"
+          ]
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.2538, 
+          "Rock": 90.7462
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 228.779739, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:55:32Z", 
+          "meanAnomaly": "2026-04-20T16:55:32Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:55:32+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 122.258716, 
+        "ascendingNode": 70.478045, 
+        "atmosphereType": null, 
+        "axialTilt": -0.401388, 
+        "bodyId": 53, 
+        "distanceToArrival": 2476.050552, 
+        "earthMasses": 0.000319, 
+        "gravity": 0.0542882634852656, 
+        "id64": 1909526836598016411, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.434605, 
+          "Carbon": 17.389601, 
+          "Iron": 18.474194, 
+          "Manganese": 7.629654, 
+          "Nickel": 13.973106, 
+          "Phosphorus": 11.133121, 
+          "Sulphur": 20.679834, 
+          "Tellurium": 1.589613, 
+          "Tungsten": 1.014419, 
+          "Vanadium": 4.536619, 
+          "Zirconium": 2.145235
+        }, 
+        "meanAnomaly": 29.855599, 
+        "name": "Pipe (stem) Sector DL-Y d17 12 c a", 
+        "orbitalEccentricity": 0.0, 
+        "orbitalInclination": 1.970865, 
+        "orbitalPeriod": 0.29515721318287, 
+        "parents": [
+          {
+            "Planet": 52
+          }, 
+          {
+            "Planet": 47
+          }, 
+          {
+            "Null": 46
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 488.5979375, 
+        "rotationalPeriod": 0.299670165856481, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 2.75546512959225e-05, 
+        "signals": {
+          "guesses": [
+            "Lindigoticum Sinuous Tubers"
+          ], 
+          "signals": {
+            "$SAA_SignalType_Biological;": 1, 
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-04-20 16:55:33+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 3.1896, 
+          "Rock": 96.8104
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 228.779739, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:55:33Z", 
+          "meanAnomaly": "2026-04-20T16:55:33Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:55:33+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 55.441964, 
+        "ascendingNode": 161.975546, 
+        "atmosphereType": null, 
+        "axialTilt": 0.189613, 
+        "bodyId": 54, 
+        "distanceToArrival": 2475.642626, 
+        "earthMasses": 0.015446, 
+        "gravity": 0.209043234424391, 
+        "id64": 1945555633616980379, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 1.164401, 
+          "Arsenic": 2.462408, 
+          "Carbon": 15.600781, 
+          "Chromium": 8.610714, 
+          "Iron": 19.146271, 
+          "Manganese": 7.907214, 
+          "Mercury": 0.836086, 
+          "Molybdenum": 1.25024, 
+          "Nickel": 14.481438, 
+          "Phosphorus": 9.987887, 
+          "Sulphur": 18.552559
+        }, 
+        "meanAnomaly": 45.293882, 
+        "name": "Pipe (stem) Sector DL-Y d17 12 d", 
+        "orbitalEccentricity": 0.002274, 
+        "orbitalInclination": 2.352695, 
+        "orbitalPeriod": 7.80778378247685, 
+        "parents": [
+          {
+            "Planet": 47
+          }, 
+          {
+            "Null": 46
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1732.903, 
+        "rotationalPeriod": 7.80786175568287, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0164329081473777, 
+        "signals": {
+          "guesses": [
+            "Lindigoticum Sinuous Tubers"
+          ]
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 220.150238, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:55:36Z", 
+          "meanAnomaly": "2026-04-20T16:55:36Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:55:36+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 268.837834, 
+        "ascendingNode": -58.702266, 
+        "atmosphereType": null, 
+        "axialTilt": 0.073198, 
+        "bodyId": 55, 
+        "distanceToArrival": 2474.677822, 
+        "earthMasses": 0.01058, 
+        "gravity": 0.183427959620679, 
+        "id64": 1981584430635944347, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 2.609708, 
+          "Carbon": 16.534012, 
+          "Iron": 20.291592, 
+          "Manganese": 8.380219, 
+          "Mercury": 0.8861, 
+          "Nickel": 15.347711, 
+          "Phosphorus": 10.585358, 
+          "Selenium": 3.077326, 
+          "Sulphur": 19.662365, 
+          "Tellurium": 1.511402, 
+          "Tungsten": 1.114212
+        }, 
+        "meanAnomaly": 30.459817, 
+        "name": "Pipe (stem) Sector DL-Y d17 12 e", 
+        "orbitalEccentricity": 0.015191, 
+        "orbitalInclination": 0.880498, 
+        "orbitalPeriod": 12.2515312223495, 
+        "parents": [
+          {
+            "Planet": 47
+          }, 
+          {
+            "Null": 46
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1531.044, 
+        "rotationalPeriod": 12.2516537671644, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0221899417582202, 
+        "signals": {
+          "guesses": [
+            "Lindigoticum Sinuous Tubers"
+          ]
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 209.422134, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:55:39Z", 
+          "meanAnomaly": "2026-04-20T16:55:39Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:55:39+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "absoluteMagnitude": 22.832321, 
+        "age": 350, 
+        "argOfPeriapsis": 284.904225, 
+        "ascendingNode": 6.838358, 
+        "axialTilt": 2.621351, 
+        "bodyId": 56, 
+        "distanceToArrival": 2372.457046, 
+        "id64": 2017613227654908315, 
+        "luminosity": "V", 
+        "mainStar": false, 
+        "meanAnomaly": 316.753903, 
+        "name": "Pipe (stem) Sector DL-Y d17 13", 
+        "orbitalEccentricity": 0.160098, 
+        "orbitalInclination": 7.951723, 
+        "orbitalPeriod": 359.199527237153, 
+        "parents": [
+          {
+            "Null": 46
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "rings": [
+          {
+            "id64": 2053642024673872283, 
+            "innerRadius": 83429000.0, 
+            "mass": 10398000000000.0, 
+            "name": "Pipe (stem) Sector DL-Y d17 13 A Ring", 
+            "outerRadius": 600930000.0, 
+            "signals": {
+              "signals": {
+                "Alexandrite": 1, 
+                "Benitoite": 1
+              }, 
+              "updateTime": "2021-03-15 01:04:43+00"
+            }, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 0.973133466828704, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.111853680281648, 
+        "solarMasses": 0.011719, 
+        "solarRadius": 0.0598449690869878, 
+        "spectralClass": "Y4", 
+        "stations": [], 
+        "subType": "Y (Brown dwarf) Star", 
+        "surfaceTemperature": 376.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-06-20T13:39:36Z", 
+          "meanAnomaly": "2026-06-20T13:39:36Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-06-20 13:39:36+00"
+      }, 
+      {
+        "argOfPeriapsis": 10.679206, 
+        "ascendingNode": 128.855115, 
+        "atmosphereType": null, 
+        "axialTilt": -0.49926, 
+        "bodyId": 58, 
+        "distanceToArrival": 2387.14106, 
+        "earthMasses": 0.005993, 
+        "gravity": 0.150908330784134, 
+        "id64": 2089670821692836251, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 2.544144, 
+          "Carbon": 16.118628, 
+          "Chromium": 8.896535, 
+          "Iron": 19.781803, 
+          "Molybdenum": 1.29174, 
+          "Nickel": 14.962128, 
+          "Niobium": 1.351981, 
+          "Phosphorus": 10.319422, 
+          "Sulphur": 19.168386, 
+          "Technetium": 0.707515, 
+          "Vanadium": 4.857723
+        }, 
+        "meanAnomaly": 232.683626, 
+        "name": "Pipe (stem) Sector DL-Y d17 13 a", 
+        "orbitalEccentricity": 0.001825, 
+        "orbitalInclination": 0.015586, 
+        "orbitalPeriod": 1.23975370769676, 
+        "parents": [
+          {
+            "Star": 56
+          }, 
+          {
+            "Null": 46
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1270.45225, 
+        "rotationalPeriod": 1.2397582352662, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00562481974197559, 
+        "signals": {
+          "biology": [
+            "Bark Mounds"
+          ], 
+          "genuses": [
+            "$Codex_Ent_Cone_Name;"
+          ], 
+          "signals": {
+            "$SAA_SignalType_Biological;": 1, 
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-04-20 16:54:59+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 206.380539, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:54:59Z", 
+          "meanAnomaly": "2026-04-20T16:54:59Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:54:59+00", 
+        "volcanismType": "Minor Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 262.77768, 
+        "ascendingNode": -23.726195, 
+        "atmosphereType": null, 
+        "axialTilt": 0.278966, 
+        "bodyId": 59, 
+        "distanceToArrival": 2389.819215, 
+        "earthMasses": 0.019266, 
+        "gravity": 0.225703171204242, 
+        "id64": 2125699618711800219, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 1.248531, 
+          "Carbon": 16.72797, 
+          "Iron": 20.529629, 
+          "Nickel": 15.527752, 
+          "Phosphorus": 10.709534, 
+          "Sulphur": 19.893023, 
+          "Tin": 1.231828, 
+          "Tungsten": 1.127283, 
+          "Vanadium": 5.041362, 
+          "Zinc": 5.579185, 
+          "Zirconium": 2.383913
+        }, 
+        "meanAnomaly": 203.820052, 
+        "name": "Pipe (stem) Sector DL-Y d17 13 b", 
+        "orbitalEccentricity": 7.6e-05, 
+        "orbitalInclination": 0.210839, 
+        "orbitalPeriod": 3.24335514946759, 
+        "parents": [
+          {
+            "Star": 56
+          }, 
+          {
+            "Null": 46
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1862.584625, 
+        "rotationalPeriod": 3.24336690297454, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0106794289523403, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 192.090637, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:55:01Z", 
+          "meanAnomaly": "2026-04-20T16:55:01Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:55:01+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 261.743234, 
+        "ascendingNode": -28.211362, 
+        "atmosphereType": null, 
+        "axialTilt": -0.104661, 
+        "bodyId": 60, 
+        "distanceToArrival": 2394.210091, 
+        "earthMasses": 0.007229, 
+        "gravity": 0.160918017742429, 
+        "id64": 2161728415730764187, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.501564, 
+          "Carbon": 15.755751, 
+          "Germanium": 5.560805, 
+          "Iron": 19.336458, 
+          "Manganese": 7.985759, 
+          "Nickel": 14.625285, 
+          "Phosphorus": 10.087101, 
+          "Polonium": 0.501837, 
+          "Sulphur": 18.736849, 
+          "Tin": 1.160235, 
+          "Vanadium": 4.748361
+        }, 
+        "meanAnomaly": 63.277054, 
+        "name": "Pipe (stem) Sector DL-Y d17 13 c", 
+        "orbitalEccentricity": 0.011405, 
+        "orbitalInclination": 2.566813, 
+        "orbitalPeriod": 7.06587980190972, 
+        "parents": [
+          {
+            "Star": 56
+          }, 
+          {
+            "Null": 46
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1351.1785, 
+        "rotationalPeriod": 7.06590550118055, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0179471633888295, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0725, 
+          "Rock": 90.9275
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 183.446259, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-04-20T16:55:04Z", 
+          "meanAnomaly": "2026-04-20T16:55:04Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-04-20 16:55:04+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 35.177308, 
+        "ascendingNode": -126.320998, 
+        "atmosphereComposition": {
+          "Ammonia": 6.842093, 
+          "Carbon dioxide": 78.681412, 
+          "Methane": 6.842093
+        }, 
+        "atmosphereType": "Thick Carbon dioxide", 
+        "axialTilt": 0.059858, 
+        "bodyId": 61, 
+        "distanceToArrival": 5938.700125, 
+        "earthMasses": 6.676681, 
+        "gravity": 2.53064902620577, 
+        "id64": 2197757212749728155, 
+        "isLandable": false, 
+        "meanAnomaly": 328.936867, 
+        "name": "Pipe (stem) Sector DL-Y d17 14", 
+        "orbitalEccentricity": 0.162907, 
+        "orbitalInclination": 53.205729, 
+        "orbitalPeriod": 16862.2064369696, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 10355.021, 
+        "rotationalPeriod": 1.56355543515046, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 13.6908925032603, 
+        "solidComposition": {
+          "Ice": 0.8372, 
+          "Metal": 34.3321, 
+          "Rock": 64.8308
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 4945.88841845547, 
+        "surfaceTemperature": 411.635498, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-09T04:17:40Z", 
+          "meanAnomaly": "2026-06-09T04:17:40Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-09 04:17:40+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }
+    ], 
+    "bodyCount": 34, 
+    "controllingFaction": {
+      "activeStates": [
+        {
+          "state": "Expansion"
+        }
+      ], 
+      "allegiance": "Independent", 
+      "government": "Feudal", 
+      "name": "The Dukes of Mikunn", 
+      "state": "Expansion"
+    }, 
+    "coords": {
+      "x": 14.96875, 
+      "y": 42.8125, 
+      "z": 498.09375
+    }, 
+    "date": "2026-06-20 13:39:35+00", 
+    "government": "Feudal", 
+    "id64": 594592926107, 
+    "name": "Pipe (stem) Sector DL-Y d17", 
+    "population": 194368, 
+    "primaryEconomy": "Industrial", 
+    "region": {
+      "name": "Inner Orion Spur", 
+      "region": 18
+    }, 
+    "secondaryEconomy": "None", 
+    "security": "Low", 
+    "timestamps": {
+      "factions": "2026-06-20T13:39:23Z"
+    }
+  }
+}

--- a/e2e/fixtures/pro-eurl-hw-w-e1-1.json
+++ b/e2e/fixtures/pro-eurl-hw-w-e1-1.json
@@ -1,0 +1,2946 @@
+{
+  "system": {
+    "allegiance": null, 
+    "bodies": [
+      {
+        "absoluteMagnitude": 0.090546, 
+        "age": 260, 
+        "argOfPeriapsis": 24.430719, 
+        "axialTilt": 0.0, 
+        "bodyId": 1, 
+        "distanceToArrival": 0.0, 
+        "id64": 36028802670806228, 
+        "luminosity": "IVab", 
+        "mainStar": true, 
+        "name": "Pro Eurl HW-W e1-1 A", 
+        "orbitalEccentricity": 0.268097, 
+        "orbitalInclination": -12.879842, 
+        "orbitalPeriod": 1477900.98962963, 
+        "parents": [
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.918938711666667, 
+        "semiMajorAxis": 116.885322929292, 
+        "solarMasses": 3.605469, 
+        "solarRadius": 2.04296852336449, 
+        "spectralClass": "B9", 
+        "stations": [], 
+        "subType": "B (Blue-White) Star", 
+        "surfaceTemperature": 12036.0, 
+        "type": "Star", 
+        "updateTime": "2020-04-09 15:40:03+00"
+      }, 
+      {
+        "absoluteMagnitude": 3.987534, 
+        "age": 260, 
+        "argOfPeriapsis": 204.43071, 
+        "axialTilt": 0.0, 
+        "bodyId": 2, 
+        "distanceToArrival": 162286.0, 
+        "id64": 72057599689770196, 
+        "luminosity": "Vab", 
+        "mainStar": false, 
+        "name": "Pro Eurl HW-W e1-1 B", 
+        "orbitalEccentricity": 0.268097, 
+        "orbitalInclination": -12.879842, 
+        "orbitalPeriod": 1477900.98962963, 
+        "parents": [
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 3.24903718171296, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 315.63374684466, 
+        "solarMasses": 1.316406, 
+        "solarRadius": 1.26815783752696, 
+        "spectralClass": "F8", 
+        "stations": [], 
+        "subType": "F (White) Star", 
+        "surfaceTemperature": 6229.0, 
+        "type": "Star", 
+        "updateTime": "2020-04-09 15:40:36+00"
+      }, 
+      {
+        "argOfPeriapsis": 17.141216, 
+        "atmosphereType": null, 
+        "axialTilt": 2.479952, 
+        "bodyId": 4, 
+        "distanceToArrival": 315.378998, 
+        "earthMasses": 19.28507, 
+        "gravity": 4.31634454981136, 
+        "id64": 144115193727698132, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 12.939798, 
+          "Chromium": 9.446578, 
+          "Germanium": 4.473817, 
+          "Iron": 21.004847, 
+          "Manganese": 8.674788, 
+          "Molybdenum": 1.371604, 
+          "Nickel": 15.887186, 
+          "Phosphorus": 8.284281, 
+          "Sulphur": 15.388102, 
+          "Tellurium": 1.158728, 
+          "Tin": 1.370263
+        }, 
+        "name": "Pro Eurl HW-W e1-1 A 1", 
+        "orbitalEccentricity": 0.08464, 
+        "orbitalInclination": -8.46562, 
+        "orbitalPeriod": 19.9058752893519, 
+        "parents": [
+          {
+            "Null": 3
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 13475.323, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 43395000.0, 
+            "mass": 280010000000.0, 
+            "name": "Pro Eurl HW-W e1-1 A 1 A Ring", 
+            "outerRadius": 103920000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": -32.2646469907407, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.00129036050511112, 
+        "solidComposition": {
+          "Ice": 0.8948, 
+          "Metal": 31.9814, 
+          "Rock": 67.1238
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 952.088562, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:49:04+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 197.141205, 
+        "atmosphereType": null, 
+        "axialTilt": -0.013479, 
+        "bodyId": 6, 
+        "distanceToArrival": 312.400208, 
+        "earthMasses": 5.254098, 
+        "gravity": 2.24251218517386, 
+        "id64": 216172787765626068, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.816504, 
+          "Carbon": 14.180835, 
+          "Germanium": 4.982625, 
+          "Iron": 23.392115, 
+          "Nickel": 17.692814, 
+          "Niobium": 1.598726, 
+          "Phosphorus": 9.078814, 
+          "Selenium": 2.639351, 
+          "Sulphur": 16.863949, 
+          "Yttrium": 1.397183, 
+          "Zinc": 6.357101
+        }, 
+        "name": "Pro Eurl HW-W e1-1 A 2", 
+        "orbitalEccentricity": 0.08464, 
+        "orbitalInclination": -8.46562, 
+        "orbitalPeriod": 19.9058752893519, 
+        "parents": [
+          {
+            "Null": 3
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 9758.168, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 14860000.0, 
+            "mass": 685860.0, 
+            "name": "Pro Eurl HW-W e1-1 A 2 A Ring", 
+            "outerRadius": 60521000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 22.4543041087963, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00473634334957149, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 32.2635, 
+          "Rock": 67.7365
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 952.073242, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:49:11+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 67.407349, 
+        "atmosphereType": null, 
+        "axialTilt": 2.399919, 
+        "bodyId": 9, 
+        "distanceToArrival": 554.489441, 
+        "earthMasses": 22.186983, 
+        "gravity": 3.32993902314673, 
+        "id64": 324259178822517972, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.712725, 
+          "Carbon": 13.527261, 
+          "Chromium": 9.919182, 
+          "Iron": 22.055704, 
+          "Nickel": 16.682009, 
+          "Phosphorus": 8.660383, 
+          "Ruthenium": 1.36208, 
+          "Sulphur": 16.086712, 
+          "Tin": 1.438895, 
+          "Zinc": 5.993914, 
+          "Zirconium": 2.561122
+        }, 
+        "name": "Pro Eurl HW-W e1-1 A 3", 
+        "orbitalEccentricity": 0.073515, 
+        "orbitalInclination": 4.885519, 
+        "orbitalPeriod": 44.8393923611111, 
+        "parents": [
+          {
+            "Null": 8
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 16455.748, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 43663000.0, 
+            "mass": 34147000000.0, 
+            "name": "Pro Eurl HW-W e1-1 A 3 A Ring", 
+            "outerRadius": 55397000.0, 
+            "type": "Metal Rich"
+          }, 
+          {
+            "innerRadius": 55497000.0, 
+            "mass": 223750000000.0, 
+            "name": "Pro Eurl HW-W e1-1 A 3 B Ring", 
+            "outerRadius": 103370000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 0.505844681354167, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.000959900935274475, 
+        "solidComposition": {
+          "Ice": 0.6248, 
+          "Metal": 29.7969, 
+          "Rock": 62.3999
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 708.443237, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:48:44+00"
+      }, 
+      {
+        "argOfPeriapsis": 247.407333, 
+        "atmosphereType": null, 
+        "axialTilt": 0.459954, 
+        "bodyId": 12, 
+        "distanceToArrival": 559.26593, 
+        "earthMasses": 2.269463, 
+        "gravity": 1.53925553176303, 
+        "id64": 432345569879409876, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 0.988129, 
+          "Carbon": 13.298409, 
+          "Chromium": 9.865574, 
+          "Germanium": 4.672574, 
+          "Iron": 21.936502, 
+          "Molybdenum": 1.432441, 
+          "Nickel": 16.591852, 
+          "Niobium": 1.499243, 
+          "Phosphorus": 8.51387, 
+          "Sulphur": 15.814564, 
+          "Vanadium": 5.386842
+        }, 
+        "name": "Pro Eurl HW-W e1-1 A 4", 
+        "orbitalEccentricity": 0.073515, 
+        "orbitalInclination": 4.885519, 
+        "orbitalPeriod": 44.8393923611111, 
+        "parents": [
+          {
+            "Null": 8
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 7740.924, 
+        "rotationalPeriod": 47.0767737268519, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00938469229161294, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 32.2635, 
+          "Rock": 67.7365
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 721.076477, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:48:40+00", 
+        "volcanismType": "Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 236.645935, 
+        "atmosphereComposition": {
+          "Helium": 28.512102, 
+          "Hydrogen": 71.4879
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 0.023848, 
+        "bodyId": 14, 
+        "distanceToArrival": 950.617493, 
+        "earthMasses": 18.970049, 
+        "gravity": 2.37260885082084, 
+        "id64": 504403163917337812, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 A 5", 
+        "orbitalEccentricity": 0.067068, 
+        "orbitalInclination": -0.538008, 
+        "orbitalPeriod": 42.3143634259259, 
+        "parents": [
+          {
+            "Null": 13
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 18026.348, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 42447000.0, 
+            "mass": 21388000000.0, 
+            "name": "Pro Eurl HW-W e1-1 A 5 A Ring", 
+            "outerRadius": 49825000.0, 
+            "type": "Metal Rich"
+          }, 
+          {
+            "innerRadius": 49925000.0, 
+            "mass": 251010000000.0, 
+            "name": "Pro Eurl HW-W e1-1 A 5 B Ring", 
+            "outerRadius": 102340000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": 106.9678125, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00151449449741399, 
+        "stations": [], 
+        "subType": "Class III gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 545.156189, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:47:56+00"
+      }, 
+      {
+        "argOfPeriapsis": 137.975891, 
+        "atmosphereType": null, 
+        "axialTilt": 0.057055, 
+        "bodyId": 17, 
+        "distanceToArrival": 950.249084, 
+        "earthMasses": 0.001146, 
+        "gravity": 0.086015193229326, 
+        "id64": 612489554974229716, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.871141, 
+          "Germanium": 5.576538, 
+          "Iron": 19.203281, 
+          "Manganese": 7.930759, 
+          "Mercury": 0.838576, 
+          "Nickel": 14.524558, 
+          "Phosphorus": 10.160977, 
+          "Sulphur": 18.874073, 
+          "Tin": 1.157453, 
+          "Vanadium": 4.715658, 
+          "Yttrium": 1.146989
+        }, 
+        "name": "Pro Eurl HW-W e1-1 A 5 a", 
+        "orbitalEccentricity": 0.001754, 
+        "orbitalInclination": -1.53862, 
+        "orbitalPeriod": 1.53018645109954, 
+        "parents": [
+          {
+            "Planet": 14
+          }, 
+          {
+            "Null": 13
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 735.762375, 
+        "rotationalPeriod": 1.53024576822917, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00100000075736372, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.1305, 
+          "Rock": 90.8695
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 554.718933, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:48:03+00"
+      }, 
+      {
+        "argOfPeriapsis": 56.645935, 
+        "atmosphereType": null, 
+        "axialTilt": -0.322312, 
+        "bodyId": 18, 
+        "distanceToArrival": 946.177429, 
+        "earthMasses": 3.519477, 
+        "gravity": 1.86637809727745, 
+        "id64": 648518351993193684, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 13.621536, 
+          "Chromium": 10.105291, 
+          "Iron": 22.469522, 
+          "Mercury": 0.981207, 
+          "Molybdenum": 1.467247, 
+          "Nickel": 16.995005, 
+          "Phosphorus": 8.72074, 
+          "Ruthenium": 1.387636, 
+          "Selenium": 2.535254, 
+          "Sulphur": 16.198828, 
+          "Vanadium": 5.517732
+        }, 
+        "name": "Pro Eurl HW-W e1-1 A 6", 
+        "orbitalEccentricity": 0.067068, 
+        "orbitalInclination": -0.538008, 
+        "orbitalPeriod": 42.3143634259259, 
+        "parents": [
+          {
+            "Null": 13
+          }, 
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 8754.39, 
+        "rotationalPeriod": 61.4299074074074, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.00816378507451577, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 32.2635, 
+          "Rock": 67.7365
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 554.544922, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:48:09+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 196.656784, 
+        "atmosphereComposition": {
+          "Argon": 4.305343, 
+          "Carbon dioxide": 0.268672, 
+          "Nitrogen": 95.393639
+        }, 
+        "atmosphereType": "Thick Argon-rich", 
+        "axialTilt": -0.516663, 
+        "bodyId": 19, 
+        "distanceToArrival": 3458.40625, 
+        "earthMasses": 6.707201, 
+        "gravity": 1.68892097481391, 
+        "id64": 684547149012157652, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 A 7", 
+        "orbitalEccentricity": 0.839927, 
+        "orbitalInclination": 60.899117, 
+        "orbitalPeriod": 20037.2088888889, 
+        "parents": [
+          {
+            "Star": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 12704.354, 
+        "rotationalPeriod": 0.697866527418981, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 22.1407608154145, 
+        "solidComposition": {
+          "Ice": 53.7027, 
+          "Metal": 16.6443, 
+          "Rock": 29.6531
+        }, 
+        "stations": [], 
+        "subType": "Water world", 
+        "surfacePressure": 2059.7832321737, 
+        "surfaceTemperature": 334.805023, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:50:10+00", 
+        "volcanismType": "Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 68.374619, 
+        "atmosphereType": null, 
+        "axialTilt": -2.088392, 
+        "bodyId": 20, 
+        "distanceToArrival": 162363.984375, 
+        "earthMasses": 13.385809, 
+        "gravity": 2.27069674722137, 
+        "id64": 720575946031121620, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 2.392379, 
+          "Cadmium": 1.950644, 
+          "Carbon": 15.300303, 
+          "Iron": 25.119511, 
+          "Mercury": 1.096928, 
+          "Nickel": 18.999346, 
+          "Phosphorus": 9.795517, 
+          "Selenium": 2.847707, 
+          "Sulphur": 18.195229, 
+          "Tellurium": 1.385537, 
+          "Zirconium": 2.916893
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 1", 
+        "orbitalEccentricity": 4e-06, 
+        "orbitalInclination": 0.00222, 
+        "orbitalPeriod": 26.8588773148148, 
+        "parents": [
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 15478.516, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 28135000.0, 
+            "mass": 12735000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 1 A Ring", 
+            "outerRadius": 34597000.0, 
+            "type": "Metallic"
+          }, 
+          {
+            "id64": 792633540069049556, 
+            "innerRadius": 34697000.0, 
+            "mass": 177040000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 1 B Ring", 
+            "outerRadius": 82659000.0, 
+            "signals": {
+              "signals": {
+                "Monazite": 3, 
+                "Musgravite": 4
+              }, 
+              "updateTime": "2020-04-09 16:12:30+00"
+            }, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": -27.0511631944444, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.193294059017646, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Biological;": 1, 
+            "$SAA_SignalType_Geological;": 22
+          }, 
+          "updateTime": "2020-04-09 16:14:28+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.2422, 
+          "Metal": 28.9883, 
+          "Rock": 60.8077
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 726.423584, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 16:14:29+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 67.910072, 
+        "atmosphereType": null, 
+        "axialTilt": -0.918987, 
+        "bodyId": 23, 
+        "distanceToArrival": 162379.765625, 
+        "earthMasses": 6.564318, 
+        "gravity": 2.47588559192414, 
+        "id64": 828662337088013524, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 13.43512, 
+          "Germanium": 4.655124, 
+          "Iron": 21.856485, 
+          "Manganese": 9.026505, 
+          "Molybdenum": 1.427216, 
+          "Nickel": 16.531328, 
+          "Phosphorus": 8.601394, 
+          "Ruthenium": 1.349777, 
+          "Sulphur": 15.977139, 
+          "Tungsten": 1.200141, 
+          "Zinc": 5.939774
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 2", 
+        "orbitalEccentricity": 0.000569, 
+        "orbitalInclination": -0.005212, 
+        "orbitalPeriod": 67.4370601851852, 
+        "parents": [
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 10380.449, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 27481000.0, 
+            "mass": 12975000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 2 A Ring", 
+            "outerRadius": 34333000.0, 
+            "type": "Metal Rich"
+          }, 
+          {
+            "innerRadius": 34433000.0, 
+            "mass": 121040000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 2 B Ring", 
+            "outerRadius": 71626000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": 67.9198611111111, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.357074676357676, 
+        "solidComposition": {
+          "Ice": 0.7724, 
+          "Metal": 32.0226, 
+          "Rock": 67.2049
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 543.928894, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:42:18+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 3.941887, 
+        "atmosphereType": null, 
+        "axialTilt": -0.462705, 
+        "bodyId": 26, 
+        "distanceToArrival": 162379.921875, 
+        "earthMasses": 0.00026, 
+        "gravity": 0.0520701539716529, 
+        "id64": 936748728144905428, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 1.203343, 
+          "Carbon": 16.194794, 
+          "Chromium": 8.736423, 
+          "Iron": 19.425791, 
+          "Molybdenum": 1.268493, 
+          "Nickel": 14.692855, 
+          "Phosphorus": 10.368185, 
+          "Selenium": 3.014191, 
+          "Sulphur": 19.258966, 
+          "Tungsten": 1.066671, 
+          "Vanadium": 4.770298
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 2 a", 
+        "orbitalEccentricity": 0.002804, 
+        "orbitalInclination": 1.933192, 
+        "orbitalPeriod": 2.60120135271991, 
+        "parents": [
+          {
+            "Planet": 23
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 450.37334375, 
+        "rotationalPeriod": 2.60136085792824, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00100000075736372, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 543.928894, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:42:26+00"
+      }, 
+      {
+        "argOfPeriapsis": 193.904556, 
+        "atmosphereType": null, 
+        "axialTilt": -0.060594, 
+        "bodyId": 27, 
+        "distanceToArrival": 162379.5625, 
+        "earthMasses": 0.000326, 
+        "gravity": 0.0562122973386357, 
+        "id64": 972777525163869396, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.722236, 
+          "Chromium": 8.481498, 
+          "Germanium": 5.524218, 
+          "Iron": 18.858953, 
+          "Nickel": 14.264123, 
+          "Niobium": 1.288909, 
+          "Phosphorus": 10.065646, 
+          "Sulphur": 18.696995, 
+          "Tellurium": 1.430784, 
+          "Tungsten": 1.035546, 
+          "Vanadium": 4.631103
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 2 b", 
+        "orbitalEccentricity": 5.1e-05, 
+        "orbitalInclination": 3.858377, 
+        "orbitalPeriod": 4.56375940393518, 
+        "parents": [
+          {
+            "Planet": 23
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 485.74715625, 
+        "rotationalPeriod": 4.56403935185185, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00145467557112763, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 543.928894, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:42:10+00"
+      }, 
+      {
+        "argOfPeriapsis": 116.651703, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 95.848145, 
+          "Nitrogen": 3.193112, 
+          "Sulphur dioxide": 0.958481
+        }, 
+        "atmosphereType": "Hot thick Carbon dioxide", 
+        "axialTilt": 0.005315, 
+        "bodyId": 28, 
+        "distanceToArrival": 162079.609375, 
+        "earthMasses": 6.261141, 
+        "gravity": 2.43753553584175, 
+        "id64": 1008806322182833364, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 3", 
+        "orbitalEccentricity": 0.0007, 
+        "orbitalInclination": 0.370386, 
+        "orbitalPeriod": 167.117233796296, 
+        "parents": [
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 10217.341, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 43702000.0, 
+            "mass": 10793000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 3 A Ring", 
+            "outerRadius": 47475000.0, 
+            "type": "Metallic"
+          }, 
+          {
+            "innerRadius": 47575000.0, 
+            "mass": 119680000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 3 B Ring", 
+            "outerRadius": 77897000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": 0.898267234525463, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.653894089951108, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 32.3345, 
+          "Rock": 67.6655
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 849.900419442388, 
+        "surfaceTemperature": 1546.248657, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:42:37+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 111.912498, 
+        "atmosphereType": null, 
+        "axialTilt": 2.001663, 
+        "bodyId": 31, 
+        "distanceToArrival": 162079.15625, 
+        "earthMasses": 0.00147, 
+        "gravity": 0.0934650759661466, 
+        "id64": 1116892713239725268, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.825152, 
+          "Chromium": 8.572463, 
+          "Iron": 19.061216, 
+          "Mercury": 0.832372, 
+          "Nickel": 14.417106, 
+          "Niobium": 1.302733, 
+          "Phosphorus": 10.131534, 
+          "Ruthenium": 1.177152, 
+          "Sulphur": 18.819384, 
+          "Vanadium": 4.680772, 
+          "Zinc": 5.180126
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 3 a", 
+        "orbitalEccentricity": 0.000801, 
+        "orbitalInclination": -0.353022, 
+        "orbitalPeriod": 2.66276909722222, 
+        "parents": [
+          {
+            "Planet": 28
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 799.377125, 
+        "rotationalPeriod": -2.66359754774306, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.00100000075736372, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.9032, 
+          "Rock": 91.0968
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 411.294312, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:42:32+00"
+      }, 
+      {
+        "argOfPeriapsis": 291.153168, 
+        "atmosphereType": null, 
+        "axialTilt": 0.273423, 
+        "bodyId": 32, 
+        "distanceToArrival": 162080.09375, 
+        "earthMasses": 0.001134, 
+        "gravity": 0.0855321708983379, 
+        "id64": 1152921510258689236, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 1.133428, 
+          "Cadmium": 1.420856, 
+          "Carbon": 15.25387, 
+          "Chromium": 8.228833, 
+          "Germanium": 5.359652, 
+          "Iron": 18.297144, 
+          "Manganese": 7.556533, 
+          "Nickel": 13.839194, 
+          "Phosphorus": 9.76579, 
+          "Sulphur": 18.140011, 
+          "Tungsten": 1.004697
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 3 b", 
+        "orbitalEccentricity": 0.001184, 
+        "orbitalInclination": -0.273856, 
+        "orbitalPeriod": 2.66276909722222, 
+        "parents": [
+          {
+            "Planet": 28
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 734.04975, 
+        "rotationalPeriod": 2.66359754774306, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00100000075736372, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 411.294312, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:42:34+00"
+      }, 
+      {
+        "argOfPeriapsis": 118.497894, 
+        "atmosphereType": null, 
+        "axialTilt": 0.494687, 
+        "bodyId": 33, 
+        "distanceToArrival": 162079.484375, 
+        "earthMasses": 0.000626, 
+        "gravity": 0.0699971448965025, 
+        "id64": 1188950307277653204, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 2.559077, 
+          "Carbon": 16.285904, 
+          "Iron": 19.535078, 
+          "Manganese": 8.067787, 
+          "Nickel": 14.775515, 
+          "Niobium": 1.335118, 
+          "Phosphorus": 10.426516, 
+          "Sulphur": 19.367313, 
+          "Tin": 1.171974, 
+          "Yttrium": 1.166807, 
+          "Zinc": 5.308903
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 3 c", 
+        "orbitalEccentricity": 0.003688, 
+        "orbitalInclination": -3.343658, 
+        "orbitalPeriod": 5.3544603587963, 
+        "parents": [
+          {
+            "Planet": 28
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 602.9495625, 
+        "rotationalPeriod": 5.35612666377315, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00159314417300727, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 411.294312, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:42:54+00"
+      }, 
+      {
+        "argOfPeriapsis": 78.150757, 
+        "atmosphereComposition": {
+          "Helium": 28.512106, 
+          "Hydrogen": 71.4879
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 0.545609, 
+        "bodyId": 35, 
+        "distanceToArrival": 161352.203125, 
+        "earthMasses": 1344.328125, 
+        "gravity": 9.87144539614561, 
+        "id64": 1261007901315581140, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 4", 
+        "orbitalEccentricity": 0.031059, 
+        "orbitalInclination": 2.776545, 
+        "orbitalPeriod": 67.4565162037037, 
+        "parents": [
+          {
+            "Null": 34
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 74395.88, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 126310000.0, 
+            "mass": 162920000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 4 A Ring", 
+            "outerRadius": 145400000.0, 
+            "type": "Metal Rich"
+          }, 
+          {
+            "innerRadius": 145500000.0, 
+            "mass": 3973400000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 4 B Ring", 
+            "outerRadius": 384220000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": 0.99052472150463, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 6.61355736796593e-05, 
+        "stations": [], 
+        "subType": "Class III gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 496.718292, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:41:18+00"
+      }, 
+      {
+        "argOfPeriapsis": 203.806534, 
+        "atmosphereType": null, 
+        "axialTilt": 0.005196, 
+        "bodyId": 38, 
+        "distanceToArrival": 161353.046875, 
+        "earthMasses": 0.013752, 
+        "gravity": 0.200428265524625, 
+        "id64": 1369094292372473044, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 17.34416, 
+          "Iron": 20.804464, 
+          "Nickel": 15.735626, 
+          "Phosphorus": 11.10403, 
+          "Selenium": 3.228112, 
+          "Sulphur": 20.625799, 
+          "Tin": 1.248129, 
+          "Tungsten": 1.142374, 
+          "Vanadium": 5.108852, 
+          "Yttrium": 1.242626, 
+          "Zirconium": 2.415827
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 4 a", 
+        "orbitalEccentricity": 0.005259, 
+        "orbitalInclination": -0.414945, 
+        "orbitalPeriod": 0.796779333043982, 
+        "parents": [
+          {
+            "Planet": 35
+          }, 
+          {
+            "Null": 34
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 1669.87475, 
+        "rotationalPeriod": 0.796790364583333, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00267835298808167, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 324.274323, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:41:29+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 138.202591, 
+        "atmosphereType": null, 
+        "axialTilt": 0.040122, 
+        "bodyId": 39, 
+        "distanceToArrival": 161351.890625, 
+        "earthMasses": 0.015493, 
+        "gravity": 0.208871010502702, 
+        "id64": 1405123089391437012, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.884638, 
+          "Chromium": 8.569107, 
+          "Iron": 19.053757, 
+          "Manganese": 7.869006, 
+          "Nickel": 14.411463, 
+          "Niobium": 1.302223, 
+          "Phosphorus": 10.169619, 
+          "Polonium": 0.494425, 
+          "Sulphur": 18.890125, 
+          "Tin": 1.143098, 
+          "Zirconium": 2.212534
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 4 b", 
+        "orbitalEccentricity": 1.5e-05, 
+        "orbitalInclination": -0.001479, 
+        "orbitalPeriod": 1.42045012297454, 
+        "parents": [
+          {
+            "Planet": 35
+          }, 
+          {
+            "Null": 34
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 1736.256375, 
+        "rotationalPeriod": 1.42046974465278, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00393785540692191, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 312.553589, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:41:37+00", 
+        "volcanismType": "Minor Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 258.150757, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 95.84819, 
+          "Nitrogen": 3.193114, 
+          "Sulphur dioxide": 0.958482
+        }, 
+        "atmosphereType": "Hot thick Carbon dioxide", 
+        "axialTilt": -0.011275, 
+        "bodyId": 40, 
+        "distanceToArrival": 161370.84375, 
+        "earthMasses": 1.723095, 
+        "gravity": 1.36933170184562, 
+        "id64": 1441151886410400980, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 5", 
+        "orbitalEccentricity": 0.031059, 
+        "orbitalInclination": 2.776545, 
+        "orbitalPeriod": 67.4565162037037, 
+        "parents": [
+          {
+            "Null": 34
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 7151.3305, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 34489000.0, 
+            "mass": 48711000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 5 A Ring", 
+            "outerRadius": 52351000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": 67.4997395833333, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0515965726776885, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 32.2873, 
+          "Rock": 67.7127
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 268.402250185048, 
+        "surfaceTemperature": 888.273987, 
+        "terraformingState": "Terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:41:49+00", 
+        "volcanismType": "Minor Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 59.446735, 
+        "atmosphereComposition": {
+          "Helium": 28.512102, 
+          "Hydrogen": 71.4879
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 1.255038, 
+        "bodyId": 43, 
+        "distanceToArrival": 160693.53125, 
+        "earthMasses": 1023.117188, 
+        "gravity": 7.2992573671867, 
+        "id64": 1549238277467292884, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 6", 
+        "orbitalEccentricity": 0.018856, 
+        "orbitalInclination": -5.981788, 
+        "orbitalPeriod": 250.566435185185, 
+        "parents": [
+          {
+            "Null": 42
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 75476.184, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 124540000.0, 
+            "mass": 804020000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 6 A Ring", 
+            "outerRadius": 373980000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 1.79693974247685, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.000119644136084619, 
+        "stations": [], 
+        "subType": "Class III gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 372.968781, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:43:09+00"
+      }, 
+      {
+        "argOfPeriapsis": 46.287868, 
+        "atmosphereType": null, 
+        "axialTilt": -0.876936, 
+        "bodyId": 45, 
+        "distanceToArrival": 160692.59375, 
+        "earthMasses": 0.002924, 
+        "gravity": 0.117962577750586, 
+        "id64": 1621295871505220820, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.429294, 
+          "Carbon": 15.319451, 
+          "Chromium": 8.277703, 
+          "Iron": 18.405807, 
+          "Manganese": 7.60141, 
+          "Nickel": 13.921382, 
+          "Phosphorus": 9.807775, 
+          "Sulphur": 18.218, 
+          "Tellurium": 1.394129, 
+          "Tin": 1.105216, 
+          "Vanadium": 4.519826
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 6 a", 
+        "orbitalEccentricity": 2.6e-05, 
+        "orbitalInclination": -0.000479, 
+        "orbitalPeriod": 1.03747124565972, 
+        "parents": [
+          {
+            "Planet": 43
+          }, 
+          {
+            "Null": 42
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 1003.6874375, 
+        "rotationalPeriod": 0.956199996388889, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00291585455032817, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.7782, 
+          "Rock": 91.2218
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 250.584702, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:43:30+00", 
+        "volcanismType": "Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 82.085526, 
+        "atmosphereComposition": {
+          "Oxygen": 2.999999, 
+          "Silicates": 5.0, 
+          "Sulphur dioxide": 90.0
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 1.935662, 
+        "bodyId": 46, 
+        "distanceToArrival": 160693.953125, 
+        "earthMasses": 0.003469, 
+        "gravity": 0.124979708371571, 
+        "id64": 1657324668524184788, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 6 b", 
+        "orbitalEccentricity": 0.001655, 
+        "orbitalInclination": -0.85105, 
+        "orbitalPeriod": 2.09889666521991, 
+        "parents": [
+          {
+            "Planet": 43
+          }, 
+          {
+            "Null": 42
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 1062.126875, 
+        "rotationalPeriod": -1.99713469328704, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.00466418574499136, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 240.334824, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:43:20+00", 
+        "volcanismType": "Rocky Magma"
+      }, 
+      {
+        "argOfPeriapsis": 81.724258, 
+        "atmosphereType": null, 
+        "axialTilt": 0.423874, 
+        "bodyId": 47, 
+        "distanceToArrival": 160696.453125, 
+        "earthMasses": 0.003637, 
+        "gravity": 0.127008667278475, 
+        "id64": 1693353465543148756, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.719234, 
+          "Chromium": 8.479878, 
+          "Iron": 18.855354, 
+          "Manganese": 7.787068, 
+          "Molybdenum": 1.231244, 
+          "Nickel": 14.261397, 
+          "Niobium": 1.288663, 
+          "Phosphorus": 10.063725, 
+          "Sulphur": 18.693426, 
+          "Tellurium": 1.430511, 
+          "Zirconium": 2.189495
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 6 c", 
+        "orbitalEccentricity": 0.000284, 
+        "orbitalInclination": 0.698491, 
+        "orbitalPeriod": 3.27635344328704, 
+        "parents": [
+          {
+            "Planet": 43
+          }, 
+          {
+            "Null": 42
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 1078.811625, 
+        "rotationalPeriod": 3.16007414641204, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00627637596448757, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 235.110229, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:43:33+00"
+      }, 
+      {
+        "argOfPeriapsis": 100.295441, 
+        "atmosphereType": null, 
+        "axialTilt": 0.404956, 
+        "bodyId": 48, 
+        "distanceToArrival": 160688.015625, 
+        "earthMasses": 0.00924, 
+        "gravity": 0.17474875089222, 
+        "id64": 1729382262562112724, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.865811, 
+          "Germanium": 5.574666, 
+          "Iron": 19.031174, 
+          "Manganese": 7.85968, 
+          "Mercury": 0.83106, 
+          "Nickel": 14.394382, 
+          "Niobium": 1.300679, 
+          "Phosphorus": 10.157566, 
+          "Sulphur": 18.867737, 
+          "Tellurium": 1.44385, 
+          "Vanadium": 4.673394
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 6 d", 
+        "orbitalEccentricity": 0.001345, 
+        "orbitalInclination": 0.005486, 
+        "orbitalPeriod": 7.84219184027778, 
+        "parents": [
+          {
+            "Planet": 43
+          }, 
+          {
+            "Null": 42
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 1465.954625, 
+        "rotationalPeriod": 7.6937109375, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0112306984593999, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 226.996964, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:43:26+00"
+      }, 
+      {
+        "argOfPeriapsis": 239.446732, 
+        "atmosphereComposition": {
+          "Nitrogen": 99.982758
+        }, 
+        "atmosphereType": "Nitrogen", 
+        "axialTilt": -0.511796, 
+        "bodyId": 49, 
+        "distanceToArrival": 160692.875, 
+        "earthMasses": 1.083268, 
+        "gravity": 1.13039849087387, 
+        "id64": 1765411059581076692, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 7", 
+        "orbitalEccentricity": 0.018856, 
+        "orbitalInclination": -5.981788, 
+        "orbitalPeriod": 250.566435185185, 
+        "parents": [
+          {
+            "Null": 42
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 6240.78, 
+        "rotationalPeriod": 0.522226155601852, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.113003184449737, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 32.2635, 
+          "Rock": 67.7365
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 2.46910991857883, 
+        "surfaceTemperature": 218.04628, 
+        "terraformingState": "Terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:42:48+00"
+      }, 
+      {
+        "argOfPeriapsis": 21.101746, 
+        "atmosphereComposition": {
+          "Helium": 28.512106, 
+          "Hydrogen": 71.4879
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 1.244873, 
+        "bodyId": 51, 
+        "distanceToArrival": 160687.5625, 
+        "earthMasses": 2398.643066, 
+        "gravity": 19.6082083205873, 
+        "id64": 1837468653619004628, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 8", 
+        "orbitalEccentricity": 0.073692, 
+        "orbitalInclination": 2.33446, 
+        "orbitalPeriod": 209.479027777778, 
+        "parents": [
+          {
+            "Null": 50
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 70509.96, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 127820000.0, 
+            "mass": 642330000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 8 A Ring", 
+            "outerRadius": 192060000.0, 
+            "type": "Metal Rich"
+          }, 
+          {
+            "innerRadius": 192160000.0, 
+            "mass": 5635300000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 8 B Ring", 
+            "outerRadius": 466010000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": 1.07525707104167, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.00368281947745664, 
+        "stations": [], 
+        "subType": "Class III gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 686.806824, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:44:44+00"
+      }, 
+      {
+        "argOfPeriapsis": 92.149361, 
+        "atmosphereComposition": {
+          "Oxygen": 2.999999, 
+          "Silicates": 5.0, 
+          "Sulphur dioxide": 90.0
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -0.019699, 
+        "bodyId": 54, 
+        "distanceToArrival": 160686.453125, 
+        "earthMasses": 0.002238, 
+        "gravity": 0.107672988681554, 
+        "id64": 1945555044675896532, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 8 a", 
+        "orbitalEccentricity": 0.000391, 
+        "orbitalInclination": -0.013332, 
+        "orbitalPeriod": 1.6345628978588, 
+        "parents": [
+          {
+            "Planet": 51
+          }, 
+          {
+            "Null": 50
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 919.051875, 
+        "rotationalPeriod": 1.63456615306713, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00524477539906589, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 281.20224, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:45:06+00", 
+        "volcanismType": "Major Rocky Magma"
+      }, 
+      {
+        "argOfPeriapsis": 23.609102, 
+        "atmosphereComposition": {
+          "Water": 100.0
+        }, 
+        "atmosphereType": "Hot thick Water", 
+        "axialTilt": 0.274993, 
+        "bodyId": 55, 
+        "distanceToArrival": 160688.0, 
+        "earthMasses": 0.001602, 
+        "gravity": 0.0961462220862649, 
+        "id64": 1981583841694860500, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 8 b", 
+        "orbitalEccentricity": 0.000734, 
+        "orbitalInclination": 0.45579, 
+        "orbitalPeriod": 2.87309769241898, 
+        "parents": [
+          {
+            "Planet": 51
+          }, 
+          {
+            "Null": 50
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 823.01, 
+        "rotationalPeriod": 2.87310347945602, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00763881674687499, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 15.7255588452998, 
+        "surfaceTemperature": 799.872742, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:45:04+00"
+      }, 
+      {
+        "argOfPeriapsis": 26.649366, 
+        "atmosphereType": null, 
+        "axialTilt": 0.306686, 
+        "bodyId": 56, 
+        "distanceToArrival": 160690.921875, 
+        "earthMasses": 0.001692, 
+        "gravity": 0.0979375955949832, 
+        "id64": 2017612638713824468, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.427136, 
+          "Chromium": 8.322303, 
+          "Iron": 18.504978, 
+          "Manganese": 7.642367, 
+          "Nickel": 13.996389, 
+          "Niobium": 1.264717, 
+          "Phosphorus": 9.876718, 
+          "Polonium": 0.480185, 
+          "Sulphur": 18.346062, 
+          "Tin": 1.110175, 
+          "Zinc": 5.028961
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 8 c", 
+        "orbitalEccentricity": 0.002706, 
+        "orbitalInclination": -0.27063, 
+        "orbitalPeriod": 6.49371166087963, 
+        "parents": [
+          {
+            "Planet": 51
+          }, 
+          {
+            "Null": 50
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 837.9748125, 
+        "rotationalPeriod": 6.49372395833333, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0131559168776324, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 245.739441, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:44:57+00"
+      }, 
+      {
+        "argOfPeriapsis": 201.10173, 
+        "atmosphereComposition": {
+          "Helium": 28.505825, 
+          "Hydrogen": 71.472183
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -0.436375, 
+        "bodyId": 57, 
+        "distanceToArrival": 160738.234375, 
+        "earthMasses": 67.493324, 
+        "gravity": 1.04747282553278, 
+        "id64": 2053641435732788436, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 9", 
+        "orbitalEccentricity": 0.073692, 
+        "orbitalInclination": 2.33446, 
+        "orbitalPeriod": 209.479027777778, 
+        "parents": [
+          {
+            "Null": 50
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 51173.56, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 79112000.0, 
+            "mass": 16725000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 9 A Ring", 
+            "outerRadius": 82546000.0, 
+            "type": "Rocky"
+          }, 
+          {
+            "innerRadius": 82646000.0, 
+            "mass": 400020000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 9 B Ring", 
+            "outerRadius": 141740000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 0.772179904513889, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.13087336136797, 
+        "stations": [], 
+        "subType": "Gas giant with water-based life", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 205.489212, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:44:04+00"
+      }, 
+      {
+        "argOfPeriapsis": 103.690681, 
+        "atmosphereType": null, 
+        "axialTilt": 1.566405, 
+        "bodyId": 60, 
+        "distanceToArrival": 160737.8125, 
+        "earthMasses": 0.003199, 
+        "gravity": 0.121633731008463, 
+        "id64": 2161727826789680340, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.381761, 
+          "Chromium": 8.314843, 
+          "Iron": 18.48839, 
+          "Manganese": 7.635516, 
+          "Nickel": 13.983843, 
+          "Niobium": 1.263583, 
+          "Phosphorus": 9.847667, 
+          "Ruthenium": 1.141776, 
+          "Sulphur": 18.292099, 
+          "Tin": 1.110428, 
+          "Vanadium": 4.540105
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 9 a", 
+        "orbitalEccentricity": 0.000421, 
+        "orbitalInclination": -0.740705, 
+        "orbitalPeriod": 0.811235984525463, 
+        "parents": [
+          {
+            "Planet": 57
+          }, 
+          {
+            "Null": 50
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 1033.804625, 
+        "rotationalPeriod": 0.811269350405093, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00100000075736372, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.7989, 
+          "Rock": 91.2011
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 205.929596, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:44:18+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 82.703293, 
+        "atmosphereType": null, 
+        "axialTilt": 0.395662, 
+        "bodyId": 61, 
+        "distanceToArrival": 160738.25, 
+        "earthMasses": 0.000669, 
+        "gravity": 0.0715676557560926, 
+        "id64": 2197756623808644308, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.420037, 
+          "Carbon": 15.245078, 
+          "Chromium": 8.224091, 
+          "Iron": 18.2866, 
+          "Manganese": 7.552178, 
+          "Molybdenum": 1.194104, 
+          "Nickel": 13.831216, 
+          "Phosphorus": 9.76016, 
+          "Sulphur": 18.129557, 
+          "Tellurium": 1.38736, 
+          "Zinc": 4.969613
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 9 b", 
+        "orbitalEccentricity": 0.001369, 
+        "orbitalInclination": 0.02851, 
+        "orbitalPeriod": 1.22432843244213, 
+        "parents": [
+          {
+            "Planet": 57
+          }, 
+          {
+            "Null": 50
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 616.2510625, 
+        "rotationalPeriod": 1.22437879774306, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00131573209617883, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 205.657181, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:44:22+00", 
+        "volcanismType": "Minor Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 61.821056, 
+        "atmosphereType": null, 
+        "axialTilt": -2.938238, 
+        "bodyId": 62, 
+        "distanceToArrival": 160737.734375, 
+        "earthMasses": 0.001128, 
+        "gravity": 0.085446721729377, 
+        "id64": 2233785420827608276, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 2.571372, 
+          "Carbon": 16.364147, 
+          "Iron": 19.703445, 
+          "Manganese": 8.137322, 
+          "Molybdenum": 1.286624, 
+          "Nickel": 14.902863, 
+          "Phosphorus": 10.476608, 
+          "Sulphur": 19.46036, 
+          "Tungsten": 1.081917, 
+          "Vanadium": 4.838481, 
+          "Yttrium": 1.176863
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 9 c", 
+        "orbitalEccentricity": 0.004478, 
+        "orbitalInclination": -0.240415, 
+        "orbitalPeriod": 1.59059461805556, 
+        "parents": [
+          {
+            "Planet": 57
+          }, 
+          {
+            "Null": 50
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 732.3183125, 
+        "rotationalPeriod": -1.59066008391204, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.00156654144142173, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.8855, 
+          "Rock": 91.1145
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 205.502426, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:44:25+00"
+      }, 
+      {
+        "argOfPeriapsis": 207.924133, 
+        "atmosphereComposition": {
+          "Helium": 28.512102, 
+          "Hydrogen": 71.4879
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 0.574726, 
+        "bodyId": 63, 
+        "distanceToArrival": 161240.140625, 
+        "earthMasses": 1157.454468, 
+        "gravity": 8.44814754767003, 
+        "id64": 2269814217846572244, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 10", 
+        "orbitalEccentricity": 0.000167, 
+        "orbitalInclination": -0.039887, 
+        "orbitalPeriod": 4266.57777777778, 
+        "parents": [
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 74620.448, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 129890000.0, 
+            "mass": 177730000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 10 A Ring", 
+            "outerRadius": 150440000.0, 
+            "type": "Metal Rich"
+          }, 
+          {
+            "innerRadius": 150540000.0, 
+            "mass": 3423700000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 10 B Ring", 
+            "outerRadius": 365520000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 2.05227701822917, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 5.66952120245653, 
+        "stations": [], 
+        "subType": "Class III gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 362.648956, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:45:18+00"
+      }, 
+      {
+        "argOfPeriapsis": 288.610138, 
+        "atmosphereType": null, 
+        "axialTilt": 0.157284, 
+        "bodyId": 66, 
+        "distanceToArrival": 161245.15625, 
+        "earthMasses": 0.001583, 
+        "gravity": 0.0957498725400224, 
+        "id64": 2377900608903464148, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.604359, 
+          "Chromium": 8.417908, 
+          "Iron": 18.717558, 
+          "Manganese": 7.73016, 
+          "Molybdenum": 1.222246, 
+          "Nickel": 14.157178, 
+          "Niobium": 1.279245, 
+          "Phosphorus": 9.990178, 
+          "Selenium": 2.904299, 
+          "Sulphur": 18.556814, 
+          "Tellurium": 1.420056
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 10 a", 
+        "orbitalEccentricity": 0.002003, 
+        "orbitalInclination": 0.044774, 
+        "orbitalPeriod": 8.49603009259259, 
+        "parents": [
+          {
+            "Planet": 63
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 819.6964375, 
+        "rotationalPeriod": 8.49613208912037, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0123438933412573, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 189.181824, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:45:54+00"
+      }, 
+      {
+        "argOfPeriapsis": 92.812225, 
+        "atmosphereType": null, 
+        "axialTilt": 0.263402, 
+        "bodyId": 67, 
+        "distanceToArrival": 161241.5, 
+        "earthMasses": 0.001003, 
+        "gravity": 0.0820568981339859, 
+        "id64": 2413929405922428116, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 16.184177, 
+          "Iron": 19.413059, 
+          "Manganese": 8.017394, 
+          "Molybdenum": 1.267661, 
+          "Nickel": 14.683225, 
+          "Phosphorus": 10.361389, 
+          "Selenium": 3.012215, 
+          "Sulphur": 19.246342, 
+          "Tellurium": 1.472822, 
+          "Tungsten": 1.065972, 
+          "Zinc": 5.275743
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 10 b", 
+        "orbitalEccentricity": 0.000447, 
+        "orbitalInclination": -0.029528, 
+        "orbitalPeriod": 17.5556843171296, 
+        "parents": [
+          {
+            "Planet": 63
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 704.8133125, 
+        "rotationalPeriod": 17.5558955439815, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0200256523036193, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 183.626556, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:45:41+00"
+      }, 
+      {
+        "argOfPeriapsis": 266.372498, 
+        "atmosphereType": null, 
+        "axialTilt": -0.335497, 
+        "bodyId": 69, 
+        "distanceToArrival": 161250.25, 
+        "earthMasses": 0.002884, 
+        "gravity": 0.11736596308759, 
+        "id64": 2485986999960356052, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.436845, 
+          "Carbon": 15.425517, 
+          "Chromium": 8.32143, 
+          "Iron": 18.503036, 
+          "Manganese": 7.641565, 
+          "Mercury": 0.807997, 
+          "Nickel": 13.994922, 
+          "Phosphorus": 9.875681, 
+          "Sulphur": 18.344135, 
+          "Vanadium": 4.543702, 
+          "Yttrium": 1.105164
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 10 c", 
+        "orbitalEccentricity": 0.057498, 
+        "orbitalInclination": -9.839912, 
+        "orbitalPeriod": 5.84299334490741, 
+        "parents": [
+          {
+            "Null": 68
+          }, 
+          {
+            "Planet": 63
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 999.3511875, 
+        "rotationalPeriod": 8.99869502314815, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 6.59782586063239e-05, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 178.370834, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:45:46+00"
+      }, 
+      {
+        "argOfPeriapsis": 86.372513, 
+        "atmosphereType": null, 
+        "axialTilt": -0.12236, 
+        "bodyId": 70, 
+        "distanceToArrival": 161250.1875, 
+        "earthMasses": 0.002102, 
+        "gravity": 0.105415621494851, 
+        "id64": 2522015796979320020, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 2.650098, 
+          "Cadmium": 1.570943, 
+          "Carbon": 16.865158, 
+          "Germanium": 5.925799, 
+          "Iron": 20.229898, 
+          "Nickel": 15.301048, 
+          "Phosphorus": 10.797364, 
+          "Polonium": 0.524945, 
+          "Sulphur": 20.056168, 
+          "Tungsten": 1.110825, 
+          "Vanadium": 4.967759
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 10 d", 
+        "orbitalEccentricity": 0.057498, 
+        "orbitalInclination": -9.839912, 
+        "orbitalPeriod": 5.84299334490741, 
+        "parents": [
+          {
+            "Null": 68
+          }, 
+          {
+            "Planet": 63
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 900.290625, 
+        "rotationalPeriod": 7.68290798611111, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 9.05125583448562e-05, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 178.370834, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:45:49+00"
+      }, 
+      {
+        "argOfPeriapsis": 286.387085, 
+        "atmosphereType": null, 
+        "axialTilt": -0.169575, 
+        "bodyId": 71, 
+        "distanceToArrival": 161217.375, 
+        "earthMasses": 0.002803, 
+        "gravity": 0.116238503110023, 
+        "id64": 2558044593998283988, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.417246, 
+          "Carbon": 15.215113, 
+          "Chromium": 8.207925, 
+          "Germanium": 5.346033, 
+          "Iron": 18.250652, 
+          "Manganese": 7.537333, 
+          "Nickel": 13.80403, 
+          "Phosphorus": 9.740976, 
+          "Sulphur": 18.09392, 
+          "Tellurium": 1.384633, 
+          "Tungsten": 1.002144
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 10 e", 
+        "orbitalEccentricity": 0.001576, 
+        "orbitalInclination": -0.130925, 
+        "orbitalPeriod": 65.6999247685185, 
+        "parents": [
+          {
+            "Planet": 63
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 990.032625, 
+        "rotationalPeriod": 2.20949797453704, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0482708252344129, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 176.402832, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:45:25+00"
+      }, 
+      {
+        "argOfPeriapsis": 296.424469, 
+        "atmosphereType": null, 
+        "axialTilt": 1.941039, 
+        "bodyId": 72, 
+        "distanceToArrival": 161209.515625, 
+        "earthMasses": 0.0052, 
+        "gravity": 0.14366085449169, 
+        "id64": 2594073391017247956, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.50997, 
+          "Carbon": 16.131847, 
+          "Germanium": 5.668139, 
+          "Iron": 19.444708, 
+          "Manganese": 8.030465, 
+          "Molybdenum": 1.269728, 
+          "Nickel": 14.707162, 
+          "Phosphorus": 10.327885, 
+          "Sulphur": 19.184105, 
+          "Tellurium": 1.46806, 
+          "Zirconium": 2.257931
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 10 f", 
+        "orbitalEccentricity": 0.014621, 
+        "orbitalInclination": 0.048211, 
+        "orbitalPeriod": 102.985810185185, 
+        "parents": [
+          {
+            "Planet": 63
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 1212.894875, 
+        "rotationalPeriod": 1.38937002677083, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0651367936348575, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.9394, 
+          "Rock": 91.0606
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 174.58374, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:45:34+00"
+      }, 
+      {
+        "argOfPeriapsis": 332.765045, 
+        "atmosphereType": null, 
+        "axialTilt": 0.201782, 
+        "bodyId": 73, 
+        "distanceToArrival": 161209.53125, 
+        "earthMasses": 0.000223, 
+        "gravity": 0.0480797389619659, 
+        "id64": 2630102188036211924, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 1.308306, 
+          "Carbon": 17.607399, 
+          "Germanium": 6.186595, 
+          "Iron": 18.339762, 
+          "Nickel": 13.871428, 
+          "Niobium": 1.253425, 
+          "Phosphorus": 11.27256, 
+          "Selenium": 3.277107, 
+          "Sulphur": 20.938845, 
+          "Tin": 0.960497, 
+          "Zinc": 4.984061
+        }, 
+        "name": "Pro Eurl HW-W e1-1 B 10 f a", 
+        "orbitalEccentricity": 0.0, 
+        "orbitalInclination": 41.312443, 
+        "orbitalPeriod": 7.04280237268518, 
+        "parents": [
+          {
+            "Planet": 72
+          }, 
+          {
+            "Planet": 63
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 433.77296875, 
+        "rotationalPeriod": 7.19195963541667, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.000182265869643825, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 3.0496, 
+          "Rock": 96.9504
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 174.58374, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:45:30+00"
+      }, 
+      {
+        "argOfPeriapsis": 328.746246, 
+        "atmosphereComposition": {
+          "Helium": 28.512106, 
+          "Hydrogen": 71.4879
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -2.852062, 
+        "bodyId": 76, 
+        "distanceToArrival": 162574.1875, 
+        "earthMasses": 181.852341, 
+        "gravity": 1.89163821759967, 
+        "id64": 2738188579093103828, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 11", 
+        "orbitalEccentricity": 0.031025, 
+        "orbitalInclination": 0.647413, 
+        "orbitalPeriod": 314.736481481481, 
+        "parents": [
+          {
+            "Null": 75
+          }, 
+          {
+            "Null": 74
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 62506.772, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 102360000.0, 
+            "mass": 98064000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 11 A Ring", 
+            "outerRadius": 116650000.0, 
+            "type": "Metallic"
+          }, 
+          {
+            "innerRadius": 116750000.0, 
+            "mass": 793010000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 11 B Ring", 
+            "outerRadius": 197230000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 1.38358760127315, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0151238670270726, 
+        "stations": [], 
+        "subType": "Class II gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 161.524094, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:47:23+00"
+      }, 
+      {
+        "argOfPeriapsis": 334.427277, 
+        "atmosphereComposition": {
+          "Oxygen": 2.999999, 
+          "Silicates": 5.0, 
+          "Sulphur dioxide": 90.0
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -0.131792, 
+        "bodyId": 79, 
+        "distanceToArrival": 162574.484375, 
+        "earthMasses": 0.001423, 
+        "gravity": 0.092368716223106, 
+        "id64": 2846274970149995732, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 11 a", 
+        "orbitalEccentricity": 0.000204, 
+        "orbitalInclination": -0.973378, 
+        "orbitalPeriod": 1.83252875434028, 
+        "parents": [
+          {
+            "Planet": 76
+          }, 
+          {
+            "Null": 75
+          }, 
+          {
+            "Null": 74
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 791.4058125, 
+        "rotationalPeriod": 1.83257957175926, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0023956216911582, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 149.799911, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:46:51+00", 
+        "volcanismType": "Major Rocky Magma"
+      }, 
+      {
+        "argOfPeriapsis": 198.986038, 
+        "atmosphereComposition": {
+          "Ammonia": 0.180788, 
+          "Carbon dioxide": 99.819214
+        }, 
+        "atmosphereType": "Carbon dioxide", 
+        "axialTilt": -0.414306, 
+        "bodyId": 80, 
+        "distanceToArrival": 162572.109375, 
+        "earthMasses": 0.005243, 
+        "gravity": 0.143895686754359, 
+        "id64": 2882303767168959700, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 11 b", 
+        "orbitalEccentricity": 0.003474, 
+        "orbitalInclination": -0.444607, 
+        "orbitalPeriod": 4.40081814236111, 
+        "parents": [
+          {
+            "Planet": 76
+          }, 
+          {
+            "Null": 75
+          }, 
+          {
+            "Null": 74
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 1216.9485, 
+        "rotationalPeriod": 4.4009400318287, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00429608938277489, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 1.12835715828275, 
+        "surfaceTemperature": 252.603973, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:47:36+00"
+      }, 
+      {
+        "argOfPeriapsis": 148.746262, 
+        "atmosphereComposition": {
+          "Helium": 28.512096, 
+          "Hydrogen": 71.4879
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -0.451323, 
+        "bodyId": 81, 
+        "distanceToArrival": 162614.453125, 
+        "earthMasses": 42.773903, 
+        "gravity": 0.9047636382176, 
+        "id64": 2918332564187923668, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 12", 
+        "orbitalEccentricity": 0.031025, 
+        "orbitalInclination": 0.647413, 
+        "orbitalPeriod": 314.736481481481, 
+        "parents": [
+          {
+            "Null": 75
+          }, 
+          {
+            "Null": 74
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 43833.736, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 87095000.0, 
+            "mass": 224970000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 12 A Ring", 
+            "outerRadius": 121750000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 1.01167435258102, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0642962871262311, 
+        "stations": [], 
+        "subType": "Class I gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 145.674957, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:46:32+00"
+      }, 
+      {
+        "argOfPeriapsis": 12.171045, 
+        "atmosphereComposition": {
+          "Ammonia": 3.193121, 
+          "Carbon dioxide": 95.848389, 
+          "Sulphur dioxide": 0.958484
+        }, 
+        "atmosphereType": "Carbon dioxide", 
+        "axialTilt": 2.980354, 
+        "bodyId": 83, 
+        "distanceToArrival": 162614.5625, 
+        "earthMasses": 0.002144, 
+        "gravity": 0.106331599877638, 
+        "id64": 2990390158225851604, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 12 a", 
+        "orbitalEccentricity": 0.000936, 
+        "orbitalInclination": -0.046312, 
+        "orbitalPeriod": 0.994846733946759, 
+        "parents": [
+          {
+            "Planet": 81
+          }, 
+          {
+            "Null": 75
+          }, 
+          {
+            "Null": 74
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 905.1849375, 
+        "rotationalPeriod": -0.994893844039352, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.000984118713128181, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.1068, 
+          "Rock": 90.8932
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 2.17246992968172, 
+        "surfaceTemperature": 267.983582, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:46:58+00", 
+        "volcanismType": "Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 288.432953, 
+        "atmosphereComposition": {
+          "Ammonia": 3.193121, 
+          "Carbon dioxide": 95.848396, 
+          "Sulphur dioxide": 0.958484
+        }, 
+        "atmosphereType": "Carbon dioxide", 
+        "axialTilt": -0.005094, 
+        "bodyId": 84, 
+        "distanceToArrival": 162614.125, 
+        "earthMasses": 0.000665, 
+        "gravity": 0.0714297950443561, 
+        "id64": 3026418955244815572, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 12 b", 
+        "orbitalEccentricity": 0.00019, 
+        "orbitalInclination": -0.121966, 
+        "orbitalPeriod": 1.33221661603009, 
+        "parents": [
+          {
+            "Planet": 81
+          }, 
+          {
+            "Null": 75
+          }, 
+          {
+            "Null": 74
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 615.082875, 
+        "rotationalPeriod": 1.33227973090278, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00119562022616409, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.6976, 
+          "Rock": 91.3024
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.984777094132741, 
+        "surfaceTemperature": 245.159302, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:47:00+00", 
+        "volcanismType": "Minor Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 119.648636, 
+        "atmosphereComposition": {
+          "Oxygen": 2.986233, 
+          "Silicates": 4.977055, 
+          "Sulphur dioxide": 89.58699
+        }, 
+        "atmosphereType": "Sulphur dioxide", 
+        "axialTilt": -1.627694, 
+        "bodyId": 85, 
+        "distanceToArrival": 162615.140625, 
+        "earthMasses": 0.000749, 
+        "gravity": 0.0744894463138574, 
+        "id64": 3062447752263779540, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 12 c", 
+        "orbitalEccentricity": 0.005051, 
+        "orbitalInclination": 0.197428, 
+        "orbitalPeriod": 1.68968532986111, 
+        "parents": [
+          {
+            "Planet": 81
+          }, 
+          {
+            "Null": 75
+          }, 
+          {
+            "Null": 74
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 639.4680625, 
+        "rotationalPeriod": -1.68976526331019, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.00140092175790574, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0158, 
+          "Rock": 90.9842
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 1.06721795583518, 
+        "surfaceTemperature": 247.194504, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:46:45+00", 
+        "volcanismType": "Major Rocky Magma"
+      }, 
+      {
+        "argOfPeriapsis": 193.606796, 
+        "atmosphereComposition": {
+          "Helium": 0.893936, 
+          "Nitrogen": 96.996338, 
+          "Oxygen": 1.619288
+        }, 
+        "atmosphereType": "Thick Nitrogen", 
+        "axialTilt": 0.060265, 
+        "bodyId": 86, 
+        "distanceToArrival": 162682.453125, 
+        "earthMasses": 17.593855, 
+        "gravity": 4.08940756602427, 
+        "id64": 3098476549282743508, 
+        "isLandable": false, 
+        "name": "Pro Eurl HW-W e1-1 B 13", 
+        "orbitalEccentricity": 0.141464, 
+        "orbitalInclination": 3.154288, 
+        "orbitalPeriod": 1051.88231481481, 
+        "parents": [
+          {
+            "Null": 74
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 13223.212, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 24967000.0, 
+            "mass": 25483000000.0, 
+            "name": "Pro Eurl HW-W e1-1 B 13 A Ring", 
+            "outerRadius": 90545000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 1.10716480396991, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.1688283931437, 
+        "solidComposition": {
+          "Ice": 0.005, 
+          "Metal": 32.195, 
+          "Rock": 67.592
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 26.8547915124599, 
+        "surfaceTemperature": 175.603836, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2020-04-09 15:46:06+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }
+    ], 
+    "coords": {
+      "x": 1802.75, 
+      "y": 443.3125, 
+      "z": 592.84375
+    }, 
+    "date": "2020-04-09 15:39:57+00", 
+    "government": "None", 
+    "id64": 5651842260, 
+    "name": "Pro Eurl HW-W e1-1", 
+    "population": 0, 
+    "primaryEconomy": "None", 
+    "secondaryEconomy": "None", 
+    "security": "Anarchy", 
+    "stations": []
+  }
+}

--- a/e2e/fixtures/pro-eurl-jf-a-d88.json
+++ b/e2e/fixtures/pro-eurl-jf-a-d88.json
@@ -1,0 +1,268 @@
+{
+  "system": {
+    "allegiance": null, 
+    "bodies": [
+      {
+        "absoluteMagnitude": 3.149216, 
+        "age": 4390, 
+        "argOfPeriapsis": 288.727276, 
+        "ascendingNode": 74.406421, 
+        "axialTilt": 0.0, 
+        "bodyId": 1, 
+        "distanceToArrival": 0.0, 
+        "id64": 36031831606315395, 
+        "luminosity": "VI", 
+        "mainStar": true, 
+        "meanAnomaly": 347.01986, 
+        "name": "Pro Eurl JF-A d88 A", 
+        "orbitalEccentricity": 0.153106, 
+        "orbitalInclination": 61.329034, 
+        "orbitalPeriod": 54886.044451484, 
+        "parents": [
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 2.6098740494213, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 4.83540897335335, 
+        "solarMasses": 1.34375, 
+        "solarRadius": 1.26947013659238, 
+        "spectralClass": "A9", 
+        "stations": [], 
+        "subType": "A (Blue-White) Star", 
+        "surfaceTemperature": 7551.0, 
+        "timestamps": {
+          "distanceToArrival": "2022-01-11T08:05:16Z", 
+          "meanAnomaly": "2022-01-11T08:05:16Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2022-01-11 08:05:16+00"
+      }, 
+      {
+        "absoluteMagnitude": 10.644608, 
+        "age": 4390, 
+        "argOfPeriapsis": 108.727282, 
+        "ascendingNode": 74.406421, 
+        "axialTilt": 0.0, 
+        "belts": [
+          {
+            "innerRadius": 422980000.0, 
+            "mass": 63144000000000.0, 
+            "name": "Pro Eurl JF-A d88 B A Belt", 
+            "outerRadius": 1479500000.0, 
+            "type": "Metallic"
+          }, 
+          {
+            "innerRadius": 3479200000.0, 
+            "mass": 286260000000000.0, 
+            "name": "Pro Eurl JF-A d88 B B Belt", 
+            "outerRadius": 222670000000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "bodyId": 2, 
+        "distanceToArrival": 13988.649969, 
+        "id64": 72060628625279363, 
+        "luminosity": "Va", 
+        "mainStar": false, 
+        "meanAnomaly": 347.01986, 
+        "name": "Pro Eurl JF-A d88 B", 
+        "orbitalEccentricity": 0.153106, 
+        "orbitalInclination": 61.329034, 
+        "orbitalPeriod": 54886.044451484, 
+        "parents": [
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 1.25403375167824, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 28.0550621216282, 
+        "solarMasses": 0.230469, 
+        "solarRadius": 0.383087137311287, 
+        "spectralClass": "M7", 
+        "stations": [], 
+        "subType": "M (Red dwarf) Star", 
+        "surfaceTemperature": 2448.0, 
+        "timestamps": {
+          "distanceToArrival": "2022-01-11T08:05:16Z", 
+          "meanAnomaly": "2022-01-11T08:05:16Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2022-01-11 08:05:16+00"
+      }, 
+      {
+        "argOfPeriapsis": 256.983124, 
+        "atmosphereComposition": {
+          "Helium": 27.78, 
+          "Hydrogen": 72.22
+        }, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -2.908406, 
+        "bodyId": 30, 
+        "distanceToArrival": 15313.0, 
+        "earthMasses": 374.208435, 
+        "gravity": 2.81090536324833, 
+        "id64": 1080866945156270467, 
+        "isLandable": false, 
+        "name": "Pro Eurl JF-A d88 B 2", 
+        "orbitalEccentricity": 0.00941, 
+        "orbitalInclination": 0.115677, 
+        "orbitalPeriod": 2756.17222222222, 
+        "parents": [
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 73589.896, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 121420000.0, 
+            "mass": 990060000000.0, 
+            "name": "Pro Eurl JF-A d88 B 2 A Ring", 
+            "outerRadius": 263390000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 0.586287887013889, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 2.36276632726164, 
+        "stations": [], 
+        "subType": "Class II gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 153.0, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2018-05-09 15:30:32+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 292.964142, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": 0.044125, 
+        "bodyId": 32, 
+        "distanceToArrival": 15315.0, 
+        "earthMasses": 0.043793, 
+        "gravity": 0.186720456337121, 
+        "id64": 1152924539194198403, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 22.52, 
+          "Chromium": 5.3, 
+          "Iron": 11.78, 
+          "Manganese": 4.87, 
+          "Molybdenum": 0.77, 
+          "Nickel": 8.91, 
+          "Phosphorus": 14.42, 
+          "Ruthenium": 0.73, 
+          "Sulphur": 26.78, 
+          "Tin": 0.73, 
+          "Zinc": 3.2
+        }, 
+        "name": "Pro Eurl JF-A d88 B 2 a", 
+        "orbitalEccentricity": 0.0, 
+        "orbitalInclination": 17.257261, 
+        "orbitalPeriod": 123.859305555556, 
+        "parents": [
+          {
+            "Planet": 30
+          }, 
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 3088.808, 
+        "rotationalPeriod": 123.614571759259, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0505605827449789, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 87.7026, 
+          "Metal": 1.7312, 
+          "Rock": 10.5663
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 97.0, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2018-05-09 15:40:07+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 316.983124, 
+        "atmosphereComposition": {
+          "Argon": 0.78, 
+          "Methane": 20.08, 
+          "Nitrogen": 78.4
+        }, 
+        "atmosphereType": "Thick Methane-rich", 
+        "axialTilt": -0.268303, 
+        "bodyId": 33, 
+        "distanceToArrival": 14726.0, 
+        "earthMasses": 1.309031, 
+        "gravity": 0.747945009393682, 
+        "id64": 1188953336213162371, 
+        "isLandable": false, 
+        "name": "Pro Eurl JF-A d88 B 3", 
+        "orbitalEccentricity": 0.00941, 
+        "orbitalInclination": 0.115677, 
+        "orbitalPeriod": 2756.17222222222, 
+        "parents": [
+          {
+            "Star": 2
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 8437.711, 
+        "rotationalPeriod": 0.491864420578704, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 2.36276632726164, 
+        "solidComposition": {
+          "Ice": 68.6542, 
+          "Metal": 10.362, 
+          "Rock": 20.9838
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 2830.70657784357, 
+        "surfaceTemperature": 401.0, 
+        "terraformingState": "Not terraformable", 
+        "type": "Planet", 
+        "updateTime": "2018-05-09 15:32:57+00", 
+        "volcanismType": "Water Geysers"
+      }
+    ], 
+    "bodyCount": 12, 
+    "coords": {
+      "x": 2147.0, 
+      "y": 65.78125, 
+      "z": 267.40625
+    }, 
+    "date": "2022-01-11 08:05:15+00", 
+    "government": "None", 
+    "id64": 3034587351427, 
+    "name": "Pro Eurl JF-A d88", 
+    "population": 0, 
+    "primaryEconomy": "None", 
+    "region": {
+      "name": "Inner Orion Spur", 
+      "region": 18
+    }, 
+    "secondaryEconomy": "None", 
+    "security": "Anarchy", 
+    "stations": [], 
+    "timestamps": {}
+  }
+}

--- a/e2e/fixtures/prooe-bli-fq-r-c19-2.json
+++ b/e2e/fixtures/prooe-bli-fq-r-c19-2.json
@@ -1,0 +1,1087 @@
+{
+  "system": {
+    "allegiance": null, 
+    "bodies": [
+      {
+        "absoluteMagnitude": 7.396439, 
+        "age": 10882, 
+        "axialTilt": 0.0, 
+        "belts": [
+          {
+            "innerRadius": 759470000.0, 
+            "mass": 101830000000000.0, 
+            "name": "Prooe Bli FQ-R c19-2 A Belt", 
+            "outerRadius": 2066600000.0, 
+            "type": "Metal Rich"
+          }, 
+          {
+            "innerRadius": 7184300000.0, 
+            "mass": 5955900000000000.0, 
+            "name": "Prooe Bli FQ-R c19-2 B Belt", 
+            "outerRadius": 179380000000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "bodyId": 0, 
+        "distanceToArrival": 0.0, 
+        "id64": 646492666282, 
+        "luminosity": "Va", 
+        "mainStar": true, 
+        "name": "Prooe Bli FQ-R c19-2", 
+        "rotationalPeriod": 2.68818540219907, 
+        "solarMasses": 0.519531, 
+        "solarRadius": 0.661804169662114, 
+        "stations": [], 
+        "subType": "K (Yellow-Orange) Star", 
+        "surfaceTemperature": 3934.0, 
+        "type": "Star", 
+        "updateTime": "2019-01-06 18:06:01+00"
+      }, 
+      {
+        "argOfPeriapsis": 56.600533, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 29.87, 
+          "Nitrogen": 0.62, 
+          "Silicates": 69.21
+        }, 
+        "atmosphereType": "Hot thick Carbon dioxide-rich", 
+        "axialTilt": 0.350787, 
+        "bodyId": 7, 
+        "distanceToArrival": 13.0, 
+        "earthMasses": 5.015754, 
+        "gravity": 2.20147542018281, 
+        "id64": 252202225625414058, 
+        "isLandable": false, 
+        "name": "Prooe Bli FQ-R c19-2 1", 
+        "orbitalEccentricity": 2e-06, 
+        "orbitalInclination": -0.006139, 
+        "orbitalPeriod": 2.17397406684028, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 9627.105, 
+        "rotationalPeriod": 2.08077112268519, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0264910482846866, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 2210.22523562793, 
+        "surfaceTemperature": 3182.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:06:07+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 213.138443, 
+        "atmosphereComposition": {
+          "Helium": 26.89, 
+          "Hydrogen": 73.11
+        }, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": 1.675548, 
+        "bodyId": 18, 
+        "distanceToArrival": 950.0, 
+        "earthMasses": 1023.682129, 
+        "gravity": 7.05601793787338, 
+        "id64": 648518992834017706, 
+        "isLandable": false, 
+        "name": "Prooe Bli FQ-R c19-2 2", 
+        "orbitalEccentricity": 0.00011, 
+        "orbitalInclination": -0.020306, 
+        "orbitalPeriod": 1323.52527777778, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 76822.288, 
+        "rings": [
+          {
+            "innerRadius": 141850000.0, 
+            "mass": 299480000000.0, 
+            "name": "Prooe Bli FQ-R c19-2 2 A Ring", 
+            "outerRadius": 350860000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": 0.506888066041667, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 1.90290777597278, 
+        "stations": [], 
+        "subType": "Class III gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 272.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:06:53+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 273.138428, 
+        "atmosphereComposition": {
+          "Argon": 6.22, 
+          "Neon": 0.15, 
+          "Nitrogen": 93.62
+        }, 
+        "atmosphereType": "Argon-rich", 
+        "axialTilt": 0.170149, 
+        "bodyId": 25, 
+        "distanceToArrival": 950.0, 
+        "earthMasses": 1.082789, 
+        "gravity": 0.642250109833082, 
+        "id64": 900720571966765482, 
+        "isLandable": false, 
+        "name": "Prooe Bli FQ-R c19-2 3", 
+        "orbitalEccentricity": 0.00011, 
+        "orbitalInclination": -0.020306, 
+        "orbitalPeriod": 1323.52527777778, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 8281.411, 
+        "rotationalPeriod": 1.49693133319444, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 1.90290777597278, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 3.72374599062423, 
+        "surfaceTemperature": 93.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:06:49+00", 
+        "volcanismType": "Water Magma"
+      }, 
+      {
+        "argOfPeriapsis": 91.758347, 
+        "atmosphereComposition": {
+          "Helium": 26.89, 
+          "Hydrogen": 73.1
+        }, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -1.136286, 
+        "bodyId": 27, 
+        "distanceToArrival": 1602.0, 
+        "earthMasses": 518.561768, 
+        "gravity": 3.75296152165953, 
+        "id64": 972778166004693418, 
+        "isLandable": false, 
+        "name": "Prooe Bli FQ-R c19-2 4", 
+        "orbitalEccentricity": 0.015352, 
+        "orbitalInclination": -5.592374, 
+        "orbitalPeriod": 230.112106481481, 
+        "parents": [
+          {
+            "Null": 26
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 74971.76, 
+        "rings": [
+          {
+            "innerRadius": 123700000.0, 
+            "mass": 66125000000.0, 
+            "name": "Prooe Bli FQ-R c19-2 4 A Ring", 
+            "outerRadius": 133470000.0, 
+            "type": "Rocky"
+          }, 
+          {
+            "innerRadius": 133570000.0, 
+            "mass": 1824300000000.0, 
+            "name": "Prooe Bli FQ-R c19-2 4 B Ring", 
+            "outerRadius": 290820000.0, 
+            "type": "Icy"
+          }
+        ], 
+        "rotationalPeriod": 1.63114583333333, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.000762968399656507, 
+        "stations": [], 
+        "subType": "Gas giant with ammonia-based life", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 149.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:08:39+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 150.203278, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -0.357522, 
+        "bodyId": 30, 
+        "distanceToArrival": 1603.0, 
+        "earthMasses": 0.011656, 
+        "gravity": 0.12048959932069, 
+        "id64": 1080864557061585322, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 0.97, 
+          "Carbon": 23.58, 
+          "Iron": 12.55, 
+          "Mercury": 0.55, 
+          "Nickel": 9.5, 
+          "Phosphorus": 15.1, 
+          "Selenium": 4.39, 
+          "Sulphur": 28.04, 
+          "Technetium": 0.45, 
+          "Zinc": 3.41, 
+          "Zirconium": 1.46
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 4 a", 
+        "orbitalEccentricity": 0.000305, 
+        "orbitalInclination": 0.090492, 
+        "orbitalPeriod": 2.21407425491898, 
+        "parents": [
+          {
+            "Planet": 27
+          }, 
+          {
+            "Null": 26
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1983.738875, 
+        "rotationalPeriod": 2.15193576388889, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00385366854021673, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 83.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:08:50+00", 
+        "volcanismType": "Major Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 356.543213, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -0.197833, 
+        "bodyId": 31, 
+        "distanceToArrival": 1604.0, 
+        "earthMasses": 0.01044, 
+        "gravity": 0.116008669870303, 
+        "id64": 1116893354080549290, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 1.61, 
+          "Carbon": 23.24, 
+          "Chromium": 5.56, 
+          "Iron": 12.37, 
+          "Nickel": 9.36, 
+          "Niobium": 0.85, 
+          "Phosphorus": 14.88, 
+          "Sulphur": 27.64, 
+          "Technetium": 0.44, 
+          "Tungsten": 0.68, 
+          "Zinc": 3.36
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 4 b", 
+        "orbitalEccentricity": 0.000319, 
+        "orbitalInclination": -0.466039, 
+        "orbitalPeriod": 3.40522135416667, 
+        "parents": [
+          {
+            "Planet": 27
+          }, 
+          {
+            "Null": 26
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1913.3285, 
+        "rotationalPeriod": 3.33469328703704, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00513463778866473, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 81.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:08:46+00", 
+        "volcanismType": "Minor Carbon Dioxide Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 271.758331, 
+        "atmosphereComposition": {
+          "Helium": 77.96, 
+          "Neon": 3.0, 
+          "Nitrogen": 19.04
+        }, 
+        "atmosphereType": "Helium", 
+        "axialTilt": 0.224644, 
+        "bodyId": 32, 
+        "distanceToArrival": 1588.0, 
+        "earthMasses": 4.67255, 
+        "gravity": 1.0960811771752, 
+        "id64": 1152922151099513258, 
+        "isLandable": false, 
+        "name": "Prooe Bli FQ-R c19-2 5", 
+        "orbitalEccentricity": 0.015352, 
+        "orbitalInclination": -5.592374, 
+        "orbitalPeriod": 230.112106481481, 
+        "parents": [
+          {
+            "Null": 26
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 13168.616, 
+        "rings": [
+          {
+            "innerRadius": 23432000.0, 
+            "mass": 60715000000.0, 
+            "name": "Prooe Bli FQ-R c19-2 5 A Ring", 
+            "outerRadius": 58201000.0, 
+            "type": "Icy"
+          }
+        ], 
+        "rotationalPeriod": 231.146388888889, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0846789549926395, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.437972450964717, 
+        "surfaceTemperature": 73.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:07:50+00", 
+        "volcanismType": "Major Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 315.665955, 
+        "atmosphereComposition": {
+          "Helium": 26.89, 
+          "Hydrogen": 73.11
+        }, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -2.626472, 
+        "bodyId": 34, 
+        "distanceToArrival": 1993.0, 
+        "earthMasses": 119.59726, 
+        "gravity": 1.37576783950655, 
+        "id64": 1224979745137441194, 
+        "isLandable": false, 
+        "name": "Prooe Bli FQ-R c19-2 6", 
+        "orbitalEccentricity": 0.14534, 
+        "orbitalInclination": -178.347031, 
+        "orbitalPeriod": 5023.5737037037, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 59466.524, 
+        "rotationalPeriod": 0.405867060914352, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 4.6302530814832, 
+        "stations": [], 
+        "subType": "Class I gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 74.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:06:58+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 335.228851, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -0.472156, 
+        "bodyId": 35, 
+        "distanceToArrival": 1994.0, 
+        "earthMasses": 0.001737, 
+        "gravity": 0.0629341369818619, 
+        "id64": 1261008542156405162, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 22.38, 
+          "Chromium": 5.36, 
+          "Iron": 11.91, 
+          "Manganese": 4.92, 
+          "Molybdenum": 0.78, 
+          "Nickel": 9.01, 
+          "Phosphorus": 14.33, 
+          "Ruthenium": 0.74, 
+          "Sulphur": 26.62, 
+          "Tin": 0.72, 
+          "Zinc": 3.24
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 6 a", 
+        "orbitalEccentricity": 0.00063, 
+        "orbitalInclination": -0.039446, 
+        "orbitalPeriod": 2.55962456597222, 
+        "parents": [
+          {
+            "Planet": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1059.598375, 
+        "rotationalPeriod": 2.55988245081019, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00260329758824569, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 59.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:07:39+00", 
+        "volcanismType": "Carbon Dioxide Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 356.148376, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -0.298411, 
+        "bodyId": 36, 
+        "distanceToArrival": 1992.0, 
+        "earthMasses": 0.001657, 
+        "gravity": 0.0619376712120548, 
+        "id64": 1297037339175369130, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 0.74, 
+          "Carbon": 22.72, 
+          "Iron": 12.09, 
+          "Manganese": 4.99, 
+          "Nickel": 9.15, 
+          "Niobium": 0.83, 
+          "Phosphorus": 14.54, 
+          "Selenium": 4.23, 
+          "Sulphur": 27.01, 
+          "Tin": 0.73, 
+          "Vanadium": 2.97
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 6 b", 
+        "orbitalEccentricity": 0.000893, 
+        "orbitalInclination": -0.001433, 
+        "orbitalPeriod": 5.417412109375, 
+        "parents": [
+          {
+            "Planet": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1043.2018125, 
+        "rotationalPeriod": 5.41795862268518, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00429141851415403, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 59.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:07:32+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 53.701431, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -1.279497, 
+        "bodyId": 37, 
+        "distanceToArrival": 1996.0, 
+        "earthMasses": 0.005871, 
+        "gravity": 0.0954357856254704, 
+        "id64": 1333066136194333098, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 22.95, 
+          "Germanium": 3.58, 
+          "Iron": 12.33, 
+          "Molybdenum": 0.81, 
+          "Nickel": 9.33, 
+          "Phosphorus": 14.69, 
+          "Selenium": 4.27, 
+          "Sulphur": 27.29, 
+          "Tungsten": 0.68, 
+          "Yttrium": 0.74, 
+          "Zinc": 3.35
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 6 c", 
+        "orbitalEccentricity": 0.00021, 
+        "orbitalInclination": 0.134497, 
+        "orbitalPeriod": 11.2355237268519, 
+        "parents": [
+          {
+            "Planet": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1581.9215, 
+        "rotationalPeriod": 11.2366572627315, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00697913890829196, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 58.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:07:13+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 166.022659, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -0.520218, 
+        "bodyId": 38, 
+        "distanceToArrival": 1996.0, 
+        "earthMasses": 0.000257, 
+        "gravity": 0.0314454538316534, 
+        "id64": 1369094933213297066, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 25.72, 
+          "Chromium": 4.23, 
+          "Iron": 9.41, 
+          "Manganese": 3.89, 
+          "Mercury": 0.41, 
+          "Nickel": 7.12, 
+          "Phosphorus": 16.47, 
+          "Ruthenium": 0.58, 
+          "Sulphur": 30.59, 
+          "Tin": 0.49, 
+          "Zirconium": 1.09
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 6 c a", 
+        "orbitalEccentricity": 0.0, 
+        "orbitalInclination": 8.024307, 
+        "orbitalPeriod": 0.932349717881944, 
+        "parents": [
+          {
+            "Planet": 37
+          }, 
+          {
+            "Planet": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 576.5966875, 
+        "rotationalPeriod": 0.952531738287037, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 4.93140073817909e-05, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 58.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:07:09+00", 
+        "volcanismType": "Major Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 17.914965, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -0.455535, 
+        "bodyId": 39, 
+        "distanceToArrival": 1996.0, 
+        "earthMasses": 0.001444, 
+        "gravity": 0.0591208314420053, 
+        "id64": 1405123730232261034, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 23.25, 
+          "Chromium": 5.57, 
+          "Iron": 12.38, 
+          "Molybdenum": 0.81, 
+          "Nickel": 9.36, 
+          "Niobium": 0.85, 
+          "Phosphorus": 14.89, 
+          "Ruthenium": 0.76, 
+          "Sulphur": 27.65, 
+          "Vanadium": 3.04, 
+          "Zirconium": 1.44
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 6 d", 
+        "orbitalEccentricity": 7e-05, 
+        "orbitalInclination": 0.002593, 
+        "orbitalPeriod": 19.5837065972222, 
+        "parents": [
+          {
+            "Planet": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 996.776625, 
+        "rotationalPeriod": 19.5856814236111, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0101081002351459, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 58.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:07:14+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 261.594391, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -0.232584, 
+        "bodyId": 40, 
+        "distanceToArrival": 1988.0, 
+        "earthMasses": 0.001198, 
+        "gravity": 0.0554976724616751, 
+        "id64": 1441152527251225002, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 0.92, 
+          "Carbon": 22.36, 
+          "Chromium": 5.35, 
+          "Iron": 11.9, 
+          "Manganese": 4.92, 
+          "Mercury": 0.52, 
+          "Nickel": 9.0, 
+          "Phosphorus": 14.31, 
+          "Sulphur": 26.59, 
+          "Tellurium": 0.9, 
+          "Zinc": 3.23
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 6 e", 
+        "orbitalEccentricity": 0.00073, 
+        "orbitalInclination": -0.517589, 
+        "orbitalPeriod": 28.7052777777778, 
+        "parents": [
+          {
+            "Planet": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 937.0775625, 
+        "rotationalPeriod": 28.7081712962963, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0130430998708058, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 58.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:07:18+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 37.829426, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -0.380245, 
+        "bodyId": 41, 
+        "distanceToArrival": 2000.0, 
+        "earthMasses": 0.002476, 
+        "gravity": 0.0709786735424819, 
+        "id64": 1477181324270188970, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 0.93, 
+          "Carbon": 22.59, 
+          "Chromium": 5.41, 
+          "Iron": 12.03, 
+          "Nickel": 9.1, 
+          "Niobium": 0.82, 
+          "Phosphorus": 14.46, 
+          "Polonium": 0.31, 
+          "Selenium": 4.2, 
+          "Sulphur": 26.87, 
+          "Zinc": 3.27
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 6 f", 
+        "orbitalEccentricity": 6.7e-05, 
+        "orbitalInclination": -0.29012, 
+        "orbitalPeriod": 47.459615162037, 
+        "parents": [
+          {
+            "Planet": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1191.23075, 
+        "rotationalPeriod": 47.4644010416667, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0182370989321842, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 57.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:07:25+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 90.056686, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": 0.028146, 
+        "bodyId": 42, 
+        "distanceToArrival": 1984.0, 
+        "earthMasses": 0.002754, 
+        "gravity": 0.073577817929999, 
+        "id64": 1513210121289152938, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 0.93, 
+          "Carbon": 22.54, 
+          "Chromium": 5.4, 
+          "Germanium": 3.49, 
+          "Iron": 12.0, 
+          "Nickel": 9.08, 
+          "Niobium": 0.82, 
+          "Phosphorus": 14.43, 
+          "Polonium": 0.31, 
+          "Selenium": 4.2, 
+          "Sulphur": 26.8
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 6 g", 
+        "orbitalEccentricity": 0.000464, 
+        "orbitalInclination": 0.021185, 
+        "orbitalPeriod": 70.2866203703704, 
+        "parents": [
+          {
+            "Planet": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1233.937125, 
+        "rotationalPeriod": 70.2937152777778, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0236948929781793, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 57.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:07:31+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 151.641388, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": 0.515053, 
+        "bodyId": 43, 
+        "distanceToArrival": 2005.0, 
+        "earthMasses": 0.002807, 
+        "gravity": 0.0740536429304015, 
+        "id64": 1549238918308116906, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 0.91, 
+          "Carbon": 22.13, 
+          "Chromium": 5.3, 
+          "Iron": 11.78, 
+          "Manganese": 4.87, 
+          "Molybdenum": 0.77, 
+          "Nickel": 8.91, 
+          "Phosphorus": 14.17, 
+          "Ruthenium": 0.73, 
+          "Selenium": 4.12, 
+          "Sulphur": 26.32
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 6 h", 
+        "orbitalEccentricity": 0.014242, 
+        "orbitalInclination": -0.025291, 
+        "orbitalPeriod": 117.643449074074, 
+        "parents": [
+          {
+            "Planet": 34
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1241.74525, 
+        "rotationalPeriod": 117.655324074074, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0334029481610797, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 57.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:07:20+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 129.539017, 
+        "atmosphereComposition": {
+          "Helium": 89.34, 
+          "Hydrogen": 8.43, 
+          "Neon": 2.24
+        }, 
+        "atmosphereType": "Helium", 
+        "axialTilt": 0.443969, 
+        "bodyId": 44, 
+        "distanceToArrival": 3252.0, 
+        "earthMasses": 13.653534, 
+        "gravity": 1.6553088999867, 
+        "id64": 1585267715327080874, 
+        "isLandable": false, 
+        "name": "Prooe Bli FQ-R c19-2 7", 
+        "orbitalEccentricity": 0.067508, 
+        "orbitalInclination": 77.431061, 
+        "orbitalPeriod": 8070.46, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 18317.556, 
+        "rings": [
+          {
+            "innerRadius": 30224000.0, 
+            "mass": 143320000000.0, 
+            "name": "Prooe Bli FQ-R c19-2 7 A Ring", 
+            "outerRadius": 86581000.0, 
+            "type": "Icy"
+          }
+        ], 
+        "rotationalPeriod": 1.56925672743056, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 6.35128666921594, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 1.29139279546015, 
+        "surfaceTemperature": 50.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:08:12+00", 
+        "volcanismType": "Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 213.651581, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -0.025905, 
+        "bodyId": 46, 
+        "distanceToArrival": 3251.0, 
+        "earthMasses": 0.00017, 
+        "gravity": 0.0287740002133507, 
+        "id64": 1657325309365008810, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 23.11, 
+          "Chromium": 5.53, 
+          "Germanium": 3.58, 
+          "Iron": 12.3, 
+          "Molybdenum": 0.8, 
+          "Nickel": 9.3, 
+          "Phosphorus": 14.79, 
+          "Sulphur": 27.48, 
+          "Tellurium": 0.93, 
+          "Tin": 0.74, 
+          "Zirconium": 1.43
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 7 a", 
+        "orbitalEccentricity": 0.001224, 
+        "orbitalInclination": -0.001324, 
+        "orbitalPeriod": 5.84583441840278, 
+        "parents": [
+          {
+            "Planet": 44
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 490.240125, 
+        "rotationalPeriod": 5.75676215277778, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00219010069105215, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 48.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:08:10+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 235.124985, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -0.502607, 
+        "bodyId": 47, 
+        "distanceToArrival": 3253.0, 
+        "earthMasses": 0.000328, 
+        "gravity": 0.0358805164930384, 
+        "id64": 1693354106383972778, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 23.19, 
+          "Iron": 12.35, 
+          "Mercury": 0.54, 
+          "Nickel": 9.34, 
+          "Phosphorus": 14.85, 
+          "Ruthenium": 0.76, 
+          "Selenium": 4.32, 
+          "Sulphur": 27.58, 
+          "Tungsten": 0.68, 
+          "Vanadium": 3.03, 
+          "Zinc": 3.36
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 7 b", 
+        "orbitalEccentricity": 7.4e-05, 
+        "orbitalInclination": -0.421005, 
+        "orbitalPeriod": 20.5954441550926, 
+        "parents": [
+          {
+            "Planet": 44
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 609.8065625, 
+        "rotationalPeriod": 20.4627170138889, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00507084736200059, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 48.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:08:15+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 106.007935, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": 1.672828, 
+        "bodyId": 48, 
+        "distanceToArrival": 3253.0, 
+        "earthMasses": 0.000304, 
+        "gravity": 0.0350505368186345, 
+        "id64": 1729382903402936746, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 22.54, 
+          "Chromium": 5.47, 
+          "Germanium": 3.53, 
+          "Iron": 12.15, 
+          "Mercury": 0.53, 
+          "Nickel": 9.19, 
+          "Niobium": 0.83, 
+          "Phosphorus": 14.43, 
+          "Polonium": 0.32, 
+          "Selenium": 4.2, 
+          "Sulphur": 26.81
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 7 c", 
+        "orbitalEccentricity": 4.4e-05, 
+        "orbitalInclination": -0.034087, 
+        "orbitalPeriod": 77.3657233796296, 
+        "parents": [
+          {
+            "Planet": 44
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 593.9829375, 
+        "rotationalPeriod": -77.1703240740741, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0122536503455727, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 48.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:08:17+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 303.501923, 
+        "atmosphereType": "No atmosphere", 
+        "axialTilt": -0.162595, 
+        "bodyId": 49, 
+        "distanceToArrival": 3249.0, 
+        "earthMasses": 0.000204, 
+        "gravity": 0.0305753892974472, 
+        "id64": 1765411700421900714, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 0.77, 
+          "Arsenic": 1.63, 
+          "Cadmium": 0.97, 
+          "Carbon": 23.46, 
+          "Iron": 12.49, 
+          "Mercury": 0.55, 
+          "Nickel": 9.45, 
+          "Phosphorus": 15.02, 
+          "Selenium": 4.37, 
+          "Sulphur": 27.9, 
+          "Zinc": 3.39
+        }, 
+        "name": "Prooe Bli FQ-R c19-2 7 d", 
+        "orbitalEccentricity": 0.001417, 
+        "orbitalInclination": -0.036236, 
+        "orbitalPeriod": 134.848611111111, 
+        "parents": [
+          {
+            "Planet": 44
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 520.9710625, 
+        "rotationalPeriod": 1.60042914496528, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0177472369865756, 
+        "signals": {}, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 48.0, 
+        "type": "Planet", 
+        "updateTime": "2019-01-06 18:08:22+00", 
+        "volcanismType": "No volcanism"
+      }
+    ], 
+    "coords": {
+      "x": 7662.21875, 
+      "y": -734.0625, 
+      "z": 49709.75
+    }, 
+    "date": "2019-01-06 18:05:55+00", 
+    "government": "None", 
+    "id64": 646492666282, 
+    "name": "Prooe Bli FQ-R c19-2", 
+    "population": 0, 
+    "primaryEconomy": "None", 
+    "region": {
+      "name": "Formorian Frontier", 
+      "region": 24
+    }, 
+    "secondaryEconomy": "None", 
+    "security": "Anarchy", 
+    "stations": []
+  }
+}

--- a/e2e/fixtures/truecho-ne-p-c22-0.json
+++ b/e2e/fixtures/truecho-ne-p-c22-0.json
@@ -1,0 +1,1733 @@
+{
+  "system": {
+    "allegiance": null, 
+    "bodies": [
+      {
+        "absoluteMagnitude": 5.361557, 
+        "age": 6592, 
+        "axialTilt": 0.0, 
+        "belts": [
+          {
+            "innerRadius": 1183600000.0, 
+            "mass": 115840000000000.0, 
+            "name": "Truecho NE-P c22-0 A Belt", 
+            "outerRadius": 2297700000.0, 
+            "type": "Rocky"
+          }, 
+          {
+            "innerRadius": 7684100000.0, 
+            "mass": 1284900000000000.0, 
+            "name": "Truecho NE-P c22-0 B Belt", 
+            "outerRadius": 122950000000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "bodyId": 0, 
+        "distanceToArrival": 0.0, 
+        "id64": 94590909634, 
+        "luminosity": "Vab", 
+        "mainStar": true, 
+        "name": "Truecho NE-P c22-0", 
+        "rotationalPeriod": 3.56788911306713, 
+        "solarMasses": 0.863281, 
+        "solarRadius": 0.885192787922358, 
+        "spectralClass": "G7", 
+        "stations": [], 
+        "subType": "G (White-Yellow) Star", 
+        "surfaceTemperature": 5434.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:00:07Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-03-01 08:00:07+00"
+      }, 
+      {
+        "argOfPeriapsis": 53.884267, 
+        "ascendingNode": -97.108785, 
+        "atmosphereComposition": {
+          "Silicates": 99.999985
+        }, 
+        "atmosphereType": "Hot thick Silicate vapour", 
+        "axialTilt": -0.009316, 
+        "bodyId": 5, 
+        "distanceToArrival": 7.910102, 
+        "earthMasses": 1.349739, 
+        "gravity": 1.96223156928724, 
+        "id64": 180144079685729474, 
+        "isLandable": false, 
+        "meanAnomaly": 25.674108, 
+        "name": "Truecho NE-P c22-0 1", 
+        "orbitalEccentricity": 1e-06, 
+        "orbitalInclination": -5.5e-05, 
+        "orbitalPeriod": 0.779716932662037, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 5287.3305, 
+        "rotationalPeriod": 0.784501082037037, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0158517669404968, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 100.0, 
+          "Rock": 0.0
+        }, 
+        "stations": [], 
+        "subType": "Metal-rich body", 
+        "surfacePressure": 8083.02345916605, 
+        "surfaceTemperature": 3053.126953, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:00:08Z", 
+          "meanAnomaly": "2026-03-01T08:00:08Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:00:08+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 283.404834, 
+        "ascendingNode": 58.250066, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 0.667093, 
+          "Silicates": 99.320786
+        }, 
+        "atmosphereType": "Hot thick Silicate vapour", 
+        "axialTilt": 0.369941, 
+        "bodyId": 6, 
+        "distanceToArrival": 14.1624, 
+        "earthMasses": 5.845429, 
+        "gravity": 2.37029978586724, 
+        "id64": 216172876704693442, 
+        "isLandable": false, 
+        "meanAnomaly": 12.326106, 
+        "name": "Truecho NE-P c22-0 2", 
+        "orbitalEccentricity": 1e-06, 
+        "orbitalInclination": -0.0012, 
+        "orbitalPeriod": 1.86796776122685, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 10011.362, 
+        "rotationalPeriod": 1.87942910385417, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0283813213148805, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 33.1106, 
+          "Rock": 66.8894
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 63006.2829114236, 
+        "surfaceTemperature": 4715.780762, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:00:08Z", 
+          "meanAnomaly": "2026-03-01T08:00:08Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:00:08+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 221.679278, 
+        "ascendingNode": -44.167695, 
+        "atmosphereComposition": {
+          "Helium": 26.493919, 
+          "Hydrogen": 73.448204
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -0.011384, 
+        "bodyId": 18, 
+        "distanceToArrival": 651.390934, 
+        "earthMasses": 272.968903, 
+        "gravity": 2.21527154073621, 
+        "id64": 648518440932261058, 
+        "isLandable": false, 
+        "meanAnomaly": 188.281501, 
+        "name": "Truecho NE-P c22-0 3", 
+        "orbitalEccentricity": 0.000606, 
+        "orbitalInclination": -0.97573, 
+        "orbitalPeriod": 582.150866587951, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 70766.824, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 137240000.0, 
+            "mass": 1010400000000.0, 
+            "name": "Truecho NE-P c22-0 3 A Ring", 
+            "outerRadius": 225830000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 0.585401793240741, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 1.30459809889173, 
+        "stations": [], 
+        "subType": "Gas giant with water-based life", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 222.94429, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:00:59Z", 
+          "meanAnomaly": "2026-03-01T08:00:59Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:00:59+00"
+      }, 
+      {
+        "argOfPeriapsis": 131.971986, 
+        "ascendingNode": 123.106046, 
+        "atmosphereComposition": {
+          "Oxygen": 2.999999, 
+          "Silicates": 5.0, 
+          "Sulphur dioxide": 90.0
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 0.057233, 
+        "bodyId": 20, 
+        "distanceToArrival": 650.899112, 
+        "earthMasses": 0.003781, 
+        "gravity": 0.128894157234628, 
+        "id64": 720576034970188994, 
+        "isLandable": false, 
+        "meanAnomaly": 195.434717, 
+        "name": "Truecho NE-P c22-0 3 a", 
+        "orbitalEccentricity": 0.001021, 
+        "orbitalInclination": 0.021974, 
+        "orbitalPeriod": 1.71890516799769, 
+        "parents": [
+          {
+            "Planet": 18
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1091.816125, 
+        "rotationalPeriod": 1.71893807980324, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00262833796801155, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0083, 
+          "Rock": 90.9917
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 202.634857, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:02Z", 
+          "meanAnomaly": "2026-03-01T08:01:02Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:02+00", 
+        "volcanismType": "Major Rocky Magma"
+      }, 
+      {
+        "argOfPeriapsis": 149.552077, 
+        "ascendingNode": 48.5563, 
+        "atmosphereType": null, 
+        "axialTilt": 0.181431, 
+        "bodyId": 21, 
+        "distanceToArrival": 646.133128, 
+        "earthMasses": 0.002452, 
+        "gravity": 0.111240644437647, 
+        "id64": 756604831989152962, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 2.511564, 
+          "Cadmium": 1.520143, 
+          "Carbon": 15.968937, 
+          "Chromium": 8.803851, 
+          "Iron": 19.575718, 
+          "Nickel": 14.806254, 
+          "Niobium": 1.337896, 
+          "Phosphorus": 10.223586, 
+          "Sulphur": 18.99037, 
+          "Tellurium": 1.454562, 
+          "Vanadium": 4.807116
+        }, 
+        "meanAnomaly": 187.006747, 
+        "name": "Truecho NE-P c22-0 3 b", 
+        "orbitalEccentricity": 0.010268, 
+        "orbitalInclination": 0.56745, 
+        "orbitalPeriod": 14.8612805814699, 
+        "parents": [
+          {
+            "Planet": 18
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 946.498875, 
+        "rotationalPeriod": 14.8615645569792, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.011071779322023, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0083, 
+          "Rock": 90.9917
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 198.070114, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:01Z", 
+          "meanAnomaly": "2026-03-01T08:01:01Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:01+00"
+      }, 
+      {
+        "argOfPeriapsis": 272.416122, 
+        "ascendingNode": 33.456285, 
+        "atmosphereType": null, 
+        "axialTilt": -0.03538, 
+        "bodyId": 22, 
+        "distanceToArrival": 652.971413, 
+        "earthMasses": 0.00223, 
+        "gravity": 0.107718772305496, 
+        "id64": 792633629008116930, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 2.437658, 
+          "Cadmium": 1.475412, 
+          "Carbon": 15.499035, 
+          "Chromium": 8.544789, 
+          "Iron": 18.999681, 
+          "Manganese": 7.846675, 
+          "Nickel": 14.370565, 
+          "Niobium": 1.298527, 
+          "Phosphorus": 9.922748, 
+          "Ruthenium": 1.173352, 
+          "Sulphur": 18.431561
+        }, 
+        "meanAnomaly": 210.979277, 
+        "name": "Truecho NE-P c22-0 3 c", 
+        "orbitalEccentricity": 0.001357, 
+        "orbitalInclination": 18.319923, 
+        "orbitalPeriod": 24.3563494748495, 
+        "parents": [
+          {
+            "Planet": 18
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 917.3399375, 
+        "rotationalPeriod": 24.3568186746528, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0153905734215144, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0083, 
+          "Rock": 90.9917
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 197.41156, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:05Z", 
+          "meanAnomaly": "2026-03-01T08:01:05Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:05+00"
+      }, 
+      {
+        "argOfPeriapsis": 18.268789, 
+        "ascendingNode": -39.02267, 
+        "atmosphereComposition": {
+          "Helium": 26.488102, 
+          "Hydrogen": 73.432083, 
+          "Oxygen": 0.079826
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -0.301133, 
+        "bodyId": 26, 
+        "distanceToArrival": 882.300237, 
+        "earthMasses": 252.641479, 
+        "gravity": 2.0895767309065, 
+        "id64": 936748817083972802, 
+        "isLandable": false, 
+        "meanAnomaly": 95.941872, 
+        "name": "Truecho NE-P c22-0 4", 
+        "orbitalEccentricity": 0.004298, 
+        "orbitalInclination": 0.014521, 
+        "orbitalPeriod": 917.880802794734, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 70098.672, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 131810000.0, 
+            "mass": 49914000000.0, 
+            "name": "Truecho NE-P c22-0 4 A Ring", 
+            "outerRadius": 137710000.0, 
+            "type": "Rocky"
+          }, 
+          {
+            "innerRadius": 137810000.0, 
+            "mass": 924770000000.0, 
+            "name": "Truecho NE-P c22-0 4 B Ring", 
+            "outerRadius": 220080000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": 0.720369648472222, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 1.76730111901972, 
+        "stations": [], 
+        "subType": "Gas giant with water-based life", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 193.144119, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:00:45Z", 
+          "meanAnomaly": "2026-03-01T08:00:45Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:00:45+00"
+      }, 
+      {
+        "argOfPeriapsis": 334.486798, 
+        "ascendingNode": 74.485658, 
+        "atmosphereType": null, 
+        "axialTilt": 0.169982, 
+        "bodyId": 29, 
+        "distanceToArrival": 883.216388, 
+        "earthMasses": 0.00286, 
+        "gravity": 0.117208422555318, 
+        "id64": 1044835208140864706, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 2.465757, 
+          "Carbon": 15.677688, 
+          "Chromium": 8.643281, 
+          "Iron": 19.218685, 
+          "Manganese": 7.93712, 
+          "Mercury": 0.839248, 
+          "Nickel": 14.536208, 
+          "Niobium": 1.313495, 
+          "Phosphorus": 10.037125, 
+          "Sulphur": 18.644016, 
+          "Technetium": 0.687375
+        }, 
+        "meanAnomaly": 113.436472, 
+        "name": "Truecho NE-P c22-0 4 a", 
+        "orbitalEccentricity": 0.000616, 
+        "orbitalInclination": -0.002423, 
+        "orbitalPeriod": 1.43347294241898, 
+        "parents": [
+          {
+            "Planet": 26
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 995.7813125, 
+        "rotationalPeriod": 1.4335547350463, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00226941759416301, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-03-01 08:01:33+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0083, 
+          "Rock": 90.9917
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 175.103348, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:34Z", 
+          "meanAnomaly": "2026-03-01T08:01:34Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:34+00", 
+        "volcanismType": "Minor Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 177.742501, 
+        "ascendingNode": -78.68812, 
+        "bodyId": 30, 
+        "id64": 1080864005159828674, 
+        "meanAnomaly": 172.746084, 
+        "name": "Truecho NE-P c22-0 barycentre 30", 
+        "orbitalEccentricity": 0.000916, 
+        "orbitalInclination": -0.405405, 
+        "orbitalPeriod": 2.42868141719907, 
+        "semiMajorAxis": 0.00322528801790912, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-03-01T08:01:35Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-03-01 08:01:35+00"
+      }, 
+      {
+        "argOfPeriapsis": 285.228737, 
+        "ascendingNode": -120.674416, 
+        "atmosphereType": null, 
+        "axialTilt": -0.02341, 
+        "bodyId": 31, 
+        "distanceToArrival": 883.715999, 
+        "earthMasses": 0.003896, 
+        "gravity": 0.130226266952177, 
+        "id64": 1116892802178792642, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 15.980479, 
+          "Chromium": 8.810213, 
+          "Germanium": 5.620087, 
+          "Iron": 19.589867, 
+          "Nickel": 14.816955, 
+          "Niobium": 1.338863, 
+          "Phosphorus": 10.230978, 
+          "Sulphur": 19.004101, 
+          "Tin": 1.163586, 
+          "Yttrium": 1.170079, 
+          "Zirconium": 2.274787
+        }, 
+        "meanAnomaly": 87.728775, 
+        "name": "Truecho NE-P c22-0 4 b", 
+        "orbitalEccentricity": 0.147853, 
+        "orbitalInclination": -0.338572, 
+        "orbitalPeriod": 0.389306157546296, 
+        "parents": [
+          {
+            "Null": 30
+          }, 
+          {
+            "Planet": 26
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1102.72475, 
+        "rotationalPeriod": 0.580495130185185, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 1.30022912780469e-05, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-03-01 08:01:35+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0083, 
+          "Rock": 90.9917
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 173.708817, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:35Z", 
+          "meanAnomaly": "2026-03-01T08:01:35Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:35+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 105.228743, 
+        "ascendingNode": -120.674416, 
+        "atmosphereType": null, 
+        "axialTilt": -1.410871, 
+        "bodyId": 32, 
+        "distanceToArrival": 883.7195, 
+        "earthMasses": 0.003185, 
+        "gravity": 0.121879677781177, 
+        "id64": 1152921599197756610, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.437978, 
+          "Carbon": 14.96166, 
+          "Chromium": 8.327996, 
+          "Germanium": 5.261784, 
+          "Iron": 18.517635, 
+          "Manganese": 7.647594, 
+          "Nickel": 14.005963, 
+          "Phosphorus": 9.578712, 
+          "Sulphur": 17.792515, 
+          "Tellurium": 1.362813, 
+          "Tin": 1.105358
+        }, 
+        "meanAnomaly": 87.74534, 
+        "name": "Truecho NE-P c22-0 4 c", 
+        "orbitalEccentricity": 0.147853, 
+        "orbitalInclination": -0.338572, 
+        "orbitalPeriod": 0.389306157546296, 
+        "parents": [
+          {
+            "Null": 30
+          }, 
+          {
+            "Planet": 26
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1030.5503125, 
+        "rotationalPeriod": 0.524828088159722, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 1.59068079916127e-05, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-03-01 08:01:37+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.4965, 
+          "Rock": 90.5035
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 173.708817, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:37Z", 
+          "meanAnomaly": "2026-03-01T08:01:37Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:37+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 135.948543, 
+        "ascendingNode": -149.937713, 
+        "atmosphereType": null, 
+        "axialTilt": -0.514644, 
+        "bodyId": 33, 
+        "distanceToArrival": 880.157107, 
+        "earthMasses": 0.006854, 
+        "gravity": 0.158111349036403, 
+        "id64": 1188950396216720578, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.437282, 
+          "Carbon": 15.039528, 
+          "Chromium": 8.32396, 
+          "Germanium": 5.289169, 
+          "Iron": 18.508663, 
+          "Manganese": 7.643889, 
+          "Nickel": 13.999178, 
+          "Phosphorus": 9.628564, 
+          "Ruthenium": 1.143028, 
+          "Sulphur": 17.885115, 
+          "Tin": 1.101627
+        }, 
+        "meanAnomaly": 249.375089, 
+        "name": "Truecho NE-P c22-0 4 d", 
+        "orbitalEccentricity": 0.000167, 
+        "orbitalInclination": -0.282766, 
+        "orbitalPeriod": 4.1556069972338, 
+        "parents": [
+          {
+            "Planet": 26
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1327.2985, 
+        "rotationalPeriod": 4.15584436115741, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00461400169952214, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.2059, 
+          "Rock": 90.7941
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 172.519058, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:29Z", 
+          "meanAnomaly": "2026-03-01T08:01:29Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:29+00"
+      }, 
+      {
+        "argOfPeriapsis": 269.632195, 
+        "ascendingNode": -46.982959, 
+        "atmosphereType": null, 
+        "axialTilt": 0.197556, 
+        "bodyId": 34, 
+        "distanceToArrival": 880.161039, 
+        "earthMasses": 0.000232, 
+        "gravity": 0.048764351993474, 
+        "id64": 1224979193235684546, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 2.731233, 
+          "Carbon": 17.365629, 
+          "Chromium": 8.291901, 
+          "Iron": 18.437376, 
+          "Nickel": 13.945257, 
+          "Niobium": 1.260096, 
+          "Phosphorus": 11.117775, 
+          "Sulphur": 20.651331, 
+          "Technetium": 0.659431, 
+          "Tungsten": 1.012397, 
+          "Vanadium": 4.527578
+        }, 
+        "meanAnomaly": 207.729809, 
+        "name": "Truecho NE-P c22-0 4 d a", 
+        "orbitalEccentricity": 0.0, 
+        "orbitalInclination": -26.127041, 
+        "orbitalPeriod": 0.431715476296296, 
+        "parents": [
+          {
+            "Planet": 33
+          }, 
+          {
+            "Planet": 26
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 439.5130625, 
+        "rotationalPeriod": 0.438954667731482, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 3.09783860417005e-05, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-03-01 08:01:31+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 3.1655, 
+          "Rock": 96.8345
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 172.519058, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:31Z", 
+          "meanAnomaly": "2026-03-01T08:01:31Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:31+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 187.82929, 
+        "ascendingNode": 84.188826, 
+        "bodyId": 35, 
+        "id64": 1261007990254648514, 
+        "meanAnomaly": 102.344336, 
+        "name": "Truecho NE-P c22-0 barycentre 35", 
+        "orbitalEccentricity": 0.002856, 
+        "orbitalInclination": 1.404531, 
+        "orbitalPeriod": 8.491596345, 
+        "semiMajorAxis": 0.00742986615906708, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-03-01T08:01:24Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-03-01 08:01:24+00"
+      }, 
+      {
+        "argOfPeriapsis": 69.34395, 
+        "ascendingNode": -100.090675, 
+        "atmosphereType": null, 
+        "axialTilt": -1.697308, 
+        "bodyId": 36, 
+        "distanceToArrival": 882.041686, 
+        "earthMasses": 0.006669, 
+        "gravity": 0.156664525339044, 
+        "id64": 1297036787273612482, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.513404, 
+          "Carbon": 15.824127, 
+          "Iron": 19.488937, 
+          "Manganese": 8.048732, 
+          "Mercury": 0.85105, 
+          "Nickel": 14.740615, 
+          "Phosphorus": 10.130877, 
+          "Polonium": 0.50192, 
+          "Sulphur": 18.818165, 
+          "Vanadium": 4.785805, 
+          "Zinc": 5.296363
+        }, 
+        "meanAnomaly": 36.381441, 
+        "name": "Truecho NE-P c22-0 4 e", 
+        "orbitalEccentricity": 0.132424, 
+        "orbitalInclination": 0.159769, 
+        "orbitalPeriod": 0.719075098078704, 
+        "parents": [
+          {
+            "Null": 35
+          }, 
+          {
+            "Planet": 26
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1315.284125, 
+        "rotationalPeriod": -1.27125645980324, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 1.55203014305403e-05, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-03-01 08:01:25+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.2442, 
+          "Rock": 90.7558
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 171.232864, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:26Z", 
+          "meanAnomaly": "2026-03-01T08:01:26Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:26+00", 
+        "volcanismType": "Minor Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 249.343945, 
+        "ascendingNode": -100.090675, 
+        "atmosphereType": null, 
+        "axialTilt": 0.021322, 
+        "bodyId": 37, 
+        "distanceToArrival": 882.034224, 
+        "earthMasses": 0.003137, 
+        "gravity": 0.120963699398389, 
+        "id64": 1333065584292576450, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.487785, 
+          "Carbon": 15.629022, 
+          "Chromium": 8.616451, 
+          "Germanium": 5.496485, 
+          "Iron": 19.159027, 
+          "Nickel": 14.491087, 
+          "Phosphorus": 10.005968, 
+          "Sulphur": 18.586143, 
+          "Technetium": 0.685241, 
+          "Tin": 1.137995, 
+          "Vanadium": 4.70479
+        }, 
+        "meanAnomaly": 36.373723, 
+        "name": "Truecho NE-P c22-0 4 f", 
+        "orbitalEccentricity": 0.132424, 
+        "orbitalInclination": 0.159769, 
+        "orbitalPeriod": 0.719075098078704, 
+        "parents": [
+          {
+            "Null": 35
+          }, 
+          {
+            "Planet": 26
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1026.71025, 
+        "rotationalPeriod": 0.871974664201389, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 3.29882227092488e-05, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-03-01 08:01:24+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 9.0083, 
+          "Rock": 90.9917
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 171.232864, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:24Z", 
+          "meanAnomaly": "2026-03-01T08:01:24Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:24+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 192.434207, 
+        "ascendingNode": -37.664856, 
+        "atmosphereComposition": {
+          "Helium": 26.509264, 
+          "Hydrogen": 73.490746
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -0.415211, 
+        "bodyId": 40, 
+        "distanceToArrival": 1654.764056, 
+        "earthMasses": 28.671562, 
+        "gravity": 0.701475068828388, 
+        "id64": 1441151975349468354, 
+        "isLandable": false, 
+        "meanAnomaly": 235.613607, 
+        "name": "Truecho NE-P c22-0 5", 
+        "orbitalEccentricity": 0.000778, 
+        "orbitalInclination": 0.160264, 
+        "orbitalPeriod": 2357.65861968199, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 40757.372, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 67250000.0, 
+            "mass": 1567800000.0, 
+            "name": "Truecho NE-P c22-0 5 A Ring", 
+            "outerRadius": 72689000.0, 
+            "type": "Rocky"
+          }, 
+          {
+            "innerRadius": 72789000.0, 
+            "mass": 16064000000.0, 
+            "name": "Truecho NE-P c22-0 5 B Ring", 
+            "outerRadius": 113470000.0, 
+            "type": "Rocky"
+          }
+        ], 
+        "rotationalPeriod": 1.5130758418287, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 3.3146703196936, 
+        "stations": [], 
+        "subType": "Class I gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 121.086746, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:00:41Z", 
+          "meanAnomaly": "2026-03-01T08:00:41Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:00:41+00"
+      }, 
+      {
+        "argOfPeriapsis": 152.369154, 
+        "ascendingNode": 167.928305, 
+        "atmosphereType": null, 
+        "axialTilt": 0.176287, 
+        "bodyId": 43, 
+        "distanceToArrival": 1654.578959, 
+        "earthMasses": 0.000284, 
+        "gravity": 0.0385973284388702, 
+        "id64": 1549238366406360258, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 21.307066, 
+          "Germanium": 4.382949, 
+          "Iron": 15.277595, 
+          "Molybdenum": 0.997618, 
+          "Nickel": 11.55533, 
+          "Phosphorus": 13.641149, 
+          "Sulphur": 25.338512, 
+          "Tellurium": 1.135193, 
+          "Tungsten": 0.838893, 
+          "Vanadium": 3.751645, 
+          "Zirconium": 1.774043
+        }, 
+        "meanAnomaly": 303.728238, 
+        "name": "Truecho NE-P c22-0 5 a", 
+        "orbitalEccentricity": 0.000141, 
+        "orbitalInclination": 0.002513, 
+        "orbitalPeriod": 1.50503866650463, 
+        "parents": [
+          {
+            "Planet": 40
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 547.0986875, 
+        "rotationalPeriod": 1.41446690387731, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00113503361912894, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Geological;": 2
+          }, 
+          "updateTime": "2026-03-01 08:01:13+00"
+        }, 
+        "solidComposition": {
+          "Ice": 57.8559, 
+          "Metal": 3.7965, 
+          "Rock": 38.3476
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 108.198135, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:13Z", 
+          "meanAnomaly": "2026-03-01T08:01:13Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:13+00", 
+        "volcanismType": "Major Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 147.837805, 
+        "ascendingNode": 176.114293, 
+        "atmosphereType": null, 
+        "axialTilt": -0.334257, 
+        "bodyId": 44, 
+        "distanceToArrival": 1654.107703, 
+        "earthMasses": 0.000276, 
+        "gravity": 0.0382144386662588, 
+        "id64": 1585267163425324226, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.105861, 
+          "Carbon": 19.861053, 
+          "Chromium": 6.404549, 
+          "Iron": 14.240774, 
+          "Manganese": 5.881294, 
+          "Nickel": 10.771124, 
+          "Phosphorus": 12.715387, 
+          "Sulphur": 23.618906, 
+          "Tellurium": 1.058152, 
+          "Tin": 0.845864, 
+          "Vanadium": 3.497038
+        }, 
+        "meanAnomaly": 338.11915, 
+        "name": "Truecho NE-P c22-0 5 b", 
+        "orbitalEccentricity": 8e-06, 
+        "orbitalInclination": -0.096665, 
+        "orbitalPeriod": 2.99028458971065, 
+        "parents": [
+          {
+            "Planet": 40
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 541.734125, 
+        "rotationalPeriod": 2.87680216875, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00179384683976719, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Geological;": 2
+          }, 
+          "updateTime": "2026-03-01 08:01:14+00"
+        }, 
+        "solidComposition": {
+          "Ice": 57.8559, 
+          "Metal": 3.7965, 
+          "Rock": 38.3476
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 108.082314, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:14Z", 
+          "meanAnomaly": "2026-03-01T08:01:14Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:14+00", 
+        "volcanismType": "Minor Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 148.366957, 
+        "ascendingNode": 72.299916, 
+        "atmosphereType": null, 
+        "axialTilt": -0.051393, 
+        "bodyId": 45, 
+        "distanceToArrival": 1654.522108, 
+        "earthMasses": 0.000205, 
+        "gravity": 0.0345712246354645, 
+        "id64": 1621295960444288194, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.130733, 
+          "Carbon": 20.307756, 
+          "Germanium": 4.177387, 
+          "Iron": 14.56107, 
+          "Manganese": 6.013573, 
+          "Nickel": 11.013382, 
+          "Niobium": 0.995172, 
+          "Phosphorus": 13.001375, 
+          "Selenium": 3.779699, 
+          "Sulphur": 24.150129, 
+          "Yttrium": 0.869715
+        }, 
+        "meanAnomaly": 354.176285, 
+        "name": "Truecho NE-P c22-0 5 c", 
+        "orbitalEccentricity": 0.00017, 
+        "orbitalInclination": 0.070871, 
+        "orbitalPeriod": 6.75489242981481, 
+        "parents": [
+          {
+            "Planet": 40
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 490.62171875, 
+        "rotationalPeriod": 6.60763181570602, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00308832196563314, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 57.8559, 
+          "Metal": 3.7965, 
+          "Rock": 38.3476
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 107.977295, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:16Z", 
+          "meanAnomaly": "2026-03-01T08:01:16Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:16+00"
+      }, 
+      {
+        "argOfPeriapsis": 149.501595, 
+        "ascendingNode": -88.600394, 
+        "atmosphereType": null, 
+        "axialTilt": -2.903719, 
+        "bodyId": 46, 
+        "distanceToArrival": 1653.546066, 
+        "earthMasses": 0.001832, 
+        "gravity": 0.0724932191291934, 
+        "id64": 1657324757463252162, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.153829, 
+          "Carbon": 20.633123, 
+          "Chromium": 6.682357, 
+          "Germanium": 4.258387, 
+          "Iron": 14.858492, 
+          "Nickel": 11.23834, 
+          "Phosphorus": 13.20968, 
+          "Sulphur": 24.537056, 
+          "Tungsten": 0.81588, 
+          "Yttrium": 0.88748, 
+          "Zirconium": 1.725377
+        }, 
+        "meanAnomaly": 54.362805, 
+        "name": "Truecho NE-P c22-0 5 d", 
+        "orbitalEccentricity": 0.004157, 
+        "orbitalInclination": 0.267997, 
+        "orbitalPeriod": 14.3416363883912, 
+        "parents": [
+          {
+            "Planet": 40
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1013.425125, 
+        "rotationalPeriod": -14.1554565362847, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.0051016353546552, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 57.4759, 
+          "Metal": 3.8524, 
+          "Rock": 38.6717
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 107.903549, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:12Z", 
+          "meanAnomaly": "2026-03-01T08:01:12Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:12+00"
+      }, 
+      {
+        "argOfPeriapsis": 80.845336, 
+        "ascendingNode": 129.416307, 
+        "atmosphereType": null, 
+        "axialTilt": 3.082347, 
+        "bodyId": 47, 
+        "distanceToArrival": 1655.778305, 
+        "earthMasses": 0.000781, 
+        "gravity": 0.054695829509534, 
+        "id64": 1693353554482216130, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 20.740032, 
+          "Germanium": 4.325901, 
+          "Iron": 15.141336, 
+          "Molybdenum": 0.98872, 
+          "Nickel": 11.452271, 
+          "Niobium": 1.03483, 
+          "Phosphorus": 13.278125, 
+          "Sulphur": 24.664194, 
+          "Technetium": 0.541544, 
+          "Vanadium": 3.718185, 
+          "Zinc": 4.114848
+        }, 
+        "meanAnomaly": 11.37534, 
+        "name": "Truecho NE-P c22-0 5 e", 
+        "orbitalEccentricity": 0.00881, 
+        "orbitalInclination": 0.000904, 
+        "orbitalPeriod": 22.7744566897569, 
+        "parents": [
+          {
+            "Planet": 40
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 761.5945625, 
+        "rotationalPeriod": -22.5604912394792, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.00694398815664157, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 56.2541, 
+          "Metal": 4.0323, 
+          "Rock": 39.7136
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 107.866852, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:17Z", 
+          "meanAnomaly": "2026-03-01T08:01:17Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:17+00"
+      }, 
+      {
+        "argOfPeriapsis": 145.126859, 
+        "ascendingNode": -41.078421, 
+        "atmosphereType": null, 
+        "axialTilt": -0.042916, 
+        "bodyId": 48, 
+        "distanceToArrival": 1652.505068, 
+        "earthMasses": 0.000474, 
+        "gravity": 0.045827062302437, 
+        "id64": 1729382351501180098, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 0.88517, 
+          "Carbon": 20.348215, 
+          "Chromium": 6.561643, 
+          "Iron": 14.590078, 
+          "Manganese": 6.025554, 
+          "Mercury": 0.637125, 
+          "Nickel": 11.035323, 
+          "Niobium": 0.997154, 
+          "Phosphorus": 13.027278, 
+          "Sulphur": 24.198242, 
+          "Zirconium": 1.694209
+        }, 
+        "meanAnomaly": 215.716507, 
+        "name": "Truecho NE-P c22-0 5 f", 
+        "orbitalEccentricity": 0.000925, 
+        "orbitalInclination": -1.042983, 
+        "orbitalPeriod": 35.3116204065278, 
+        "parents": [
+          {
+            "Planet": 40
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 648.1381875, 
+        "rotationalPeriod": 35.0725442509606, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00930226594671851, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 57.8559, 
+          "Metal": 3.7965, 
+          "Rock": 38.3476
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 107.836983, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:18Z", 
+          "meanAnomaly": "2026-03-01T08:01:18Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:18+00"
+      }, 
+      {
+        "argOfPeriapsis": 55.239595, 
+        "ascendingNode": 57.140393, 
+        "atmosphereComposition": {
+          "Helium": 26.509262, 
+          "Hydrogen": 73.490746
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 1.910221, 
+        "bodyId": 50, 
+        "distanceToArrival": 2799.836806, 
+        "earthMasses": 2957.534668, 
+        "gravity": 25.4192023044764, 
+        "id64": 1801439945539108034, 
+        "isLandable": false, 
+        "meanAnomaly": 311.627298, 
+        "name": "Truecho NE-P c22-0 6", 
+        "orbitalEccentricity": 0.001362, 
+        "orbitalInclination": -0.875237, 
+        "orbitalPeriod": 5199.37670065297, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 68765.496, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 1837468742558072002, 
+            "innerRadius": 114760000.0, 
+            "mass": 341560000000.0, 
+            "name": "Truecho NE-P c22-0 6 A Ring", 
+            "outerRadius": 175840000.0, 
+            "signals": {
+              "signals": {
+                "Platinum": 1
+              }, 
+              "updateTime": "2026-03-01 08:12:51+00"
+            }, 
+            "type": "Metal Rich"
+          }, 
+          {
+            "id64": 1873497539577035970, 
+            "innerRadius": 175940000.0, 
+            "mass": 4210700000000.0, 
+            "name": "Truecho NE-P c22-0 6 B Ring", 
+            "outerRadius": 499710000.0, 
+            "signals": {
+              "signals": {
+                "Monazite": 6, 
+                "Painite": 2, 
+                "Platinum": 1, 
+                "Rhodplumsite": 5, 
+                "Serendibite": 3
+              }, 
+              "updateTime": "2026-03-01 08:12:50+00"
+            }, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": 0.55999028849537, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 5.61591537457029, 
+        "stations": [], 
+        "subType": "Class III gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 748.97522, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:13:19Z", 
+          "meanAnomaly": "2026-03-01T08:13:19Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:13:19+00"
+      }, 
+      {
+        "argOfPeriapsis": 151.775672, 
+        "ascendingNode": 10.257875, 
+        "atmosphereType": null, 
+        "axialTilt": 0.103599, 
+        "bodyId": 53, 
+        "distanceToArrival": 2801.543415, 
+        "earthMasses": 0.003713, 
+        "gravity": 0.0995806056898134, 
+        "id64": 1909526336595999938, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 19.323729, 
+          "Iron": 15.752256, 
+          "Manganese": 6.505521, 
+          "Molybdenum": 1.028613, 
+          "Nickel": 11.914347, 
+          "Niobium": 1.076583, 
+          "Phosphorus": 12.371384, 
+          "Selenium": 3.596551, 
+          "Sulphur": 22.979916, 
+          "Tellurium": 1.170223, 
+          "Zinc": 4.280873
+        }, 
+        "meanAnomaly": 214.225424, 
+        "name": "Truecho NE-P c22-0 6 a", 
+        "orbitalEccentricity": 0.000484, 
+        "orbitalInclination": -0.000102, 
+        "orbitalPeriod": 1.65108004929398, 
+        "parents": [
+          {
+            "Planet": 50
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1231.05075, 
+        "rotationalPeriod": 1.6511381890162, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00566198775128375, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-03-01 08:01:48+00"
+        }, 
+        "solidComposition": {
+          "Ice": 42.836, 
+          "Metal": 5.1554, 
+          "Rock": 52.0086
+        }, 
+        "stations": [], 
+        "subType": "Rocky Ice world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 188.044174, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:48Z", 
+          "meanAnomaly": "2026-03-01T08:01:48Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:48+00", 
+        "volcanismType": "Major Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 1.425816, 
+        "ascendingNode": -138.895059, 
+        "atmosphereType": null, 
+        "axialTilt": -0.082931, 
+        "bodyId": 54, 
+        "distanceToArrival": 2802.441833, 
+        "earthMasses": 0.003305, 
+        "gravity": 0.0957078617314163, 
+        "id64": 1945555133614963906, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 0.94904, 
+          "Cadmium": 1.214985, 
+          "Carbon": 19.193417, 
+          "Chromium": 7.036539, 
+          "Germanium": 4.487731, 
+          "Iron": 15.646029, 
+          "Mercury": 0.683236, 
+          "Nickel": 11.834, 
+          "Phosphorus": 12.287955, 
+          "Sulphur": 22.824945, 
+          "Vanadium": 3.84212
+        }, 
+        "meanAnomaly": 223.480651, 
+        "name": "Truecho NE-P c22-0 6 b", 
+        "orbitalEccentricity": 0.000737, 
+        "orbitalInclination": -0.006197, 
+        "orbitalPeriod": 2.68128210747685, 
+        "parents": [
+          {
+            "Planet": 50
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1184.6425, 
+        "rotationalPeriod": 2.68137625767361, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00782261376589337, 
+        "signals": {
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-03-01 08:01:46+00"
+        }, 
+        "solidComposition": {
+          "Ice": 42.836, 
+          "Metal": 5.1554, 
+          "Rock": 52.0086
+        }, 
+        "stations": [], 
+        "subType": "Rocky Ice world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 172.323288, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:46Z", 
+          "meanAnomaly": "2026-03-01T08:01:46Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:46+00", 
+        "volcanismType": "Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 217.821293, 
+        "ascendingNode": 104.883784, 
+        "atmosphereType": null, 
+        "axialTilt": -0.014564, 
+        "bodyId": 55, 
+        "distanceToArrival": 2799.857862, 
+        "earthMasses": 0.003803, 
+        "gravity": 0.100395023962476, 
+        "id64": 1981583930633927874, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 2.124658, 
+          "Carbon": 20.318865, 
+          "Iron": 16.563467, 
+          "Molybdenum": 1.081585, 
+          "Nickel": 12.527913, 
+          "Niobium": 1.132025, 
+          "Phosphorus": 13.008486, 
+          "Selenium": 3.781767, 
+          "Sulphur": 24.163338, 
+          "Tellurium": 1.230487, 
+          "Vanadium": 4.067411
+        }, 
+        "meanAnomaly": 253.570214, 
+        "name": "Truecho NE-P c22-0 6 c", 
+        "orbitalEccentricity": 8e-06, 
+        "orbitalInclination": -0.001832, 
+        "orbitalPeriod": 4.19850578462963, 
+        "parents": [
+          {
+            "Planet": 50
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1240.794625, 
+        "rotationalPeriod": 4.19865378340278, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0105484028504229, 
+        "signals": {}, 
+        "solidComposition": {
+          "Ice": 42.836, 
+          "Metal": 5.1554, 
+          "Rock": 52.0086
+        }, 
+        "stations": [], 
+        "subType": "Rocky Ice world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 159.880096, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:44Z", 
+          "meanAnomaly": "2026-03-01T08:01:44Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:44+00"
+      }, 
+      {
+        "argOfPeriapsis": 352.463214, 
+        "ascendingNode": -93.73588, 
+        "atmosphereComposition": {
+          "Argon": 12.485979, 
+          "Nitrogen": 87.51403
+        }, 
+        "atmosphereType": "Argon-rich", 
+        "axialTilt": 0.212456, 
+        "bodyId": 57, 
+        "distanceToArrival": 2737.474191, 
+        "earthMasses": 0.111589, 
+        "gravity": 0.260061384725196, 
+        "id64": 2053641524671855810, 
+        "isLandable": false, 
+        "meanAnomaly": 75.016568, 
+        "name": "Truecho NE-P c22-0 6 d", 
+        "orbitalEccentricity": 0.0, 
+        "orbitalInclination": -83.717895, 
+        "orbitalPeriod": 271.222354085359, 
+        "parents": [
+          {
+            "Planet": 50
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 4175.998, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 6890400.0, 
+            "mass": 1897.8, 
+            "name": "Truecho NE-P c22-0 6 d A Ring", 
+            "outerRadius": 17525000.0, 
+            "type": "Icy"
+          }
+        ], 
+        "rotationalPeriod": 2.6904132709838, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.16982717822404, 
+        "solidComposition": {
+          "Ice": 87.8546, 
+          "Metal": 1.7063, 
+          "Rock": 10.4391
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.275502694764372, 
+        "surfaceTemperature": 103.457077, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:01:42Z", 
+          "meanAnomaly": "2026-03-01T08:01:42Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:01:42+00"
+      }, 
+      {
+        "argOfPeriapsis": 355.23958, 
+        "ascendingNode": 57.140393, 
+        "atmosphereComposition": {
+          "Ammonia": 33.215481, 
+          "Methane": 33.215481, 
+          "Nitrogen": 33.215481
+        }, 
+        "atmosphereType": "Hot thick Methane-rich", 
+        "axialTilt": -0.048386, 
+        "bodyId": 68, 
+        "distanceToArrival": 2799.836798, 
+        "earthMasses": 14.027763, 
+        "gravity": 2.19709788926277, 
+        "id64": 2449958291880459458, 
+        "isLandable": false, 
+        "meanAnomaly": 311.627451, 
+        "name": "Truecho NE-P c22-0 7", 
+        "orbitalEccentricity": 0.001362, 
+        "orbitalInclination": -0.875237, 
+        "orbitalPeriod": 5199.37670065297, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 16108.538, 
+        "rotationalPeriod": 1.29684679043981, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 5.61591537457029, 
+        "solidComposition": {
+          "Ice": 68.4058, 
+          "Metal": 10.461, 
+          "Rock": 21.1332
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 57552.660528004, 
+        "surfaceTemperature": 547.880981, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-03-01T08:16:30Z", 
+          "meanAnomaly": "2026-03-01T08:16:30Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-03-01 08:16:30+00", 
+        "volcanismType": "Water Geysers"
+      }
+    ], 
+    "bodyCount": 28, 
+    "coords": {
+      "x": 6399.65625, 
+      "y": 1158.59375, 
+      "z": 53657.6875
+    }, 
+    "date": "2026-03-01 08:02:09+00", 
+    "government": "None", 
+    "id64": 94590909634, 
+    "name": "Truecho NE-P c22-0", 
+    "population": 0, 
+    "primaryEconomy": "None", 
+    "region": {
+      "name": "Formorian Frontier", 
+      "region": 24
+    }, 
+    "secondaryEconomy": "None", 
+    "security": "Anarchy", 
+    "stations": []
+  }
+}

--- a/e2e/trojan-lagrange.spec.ts
+++ b/e2e/trojan-lagrange.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect, type Page } from '@playwright/test';
+import { loadFixtureSystem, type FixtureOptions } from './support/system-fixture';
+
+/**
+ * Trojan / Lagrange badge rendering, end-to-end, from saved biostats payloads.
+ *
+ * The unit suite (`orbital-relations.service.spec.ts`) pins the detection maths; these
+ * tests close the loop by proving the full pipeline — biostats parse → body-tree build →
+ * co-orbital detection → header badge — lights up the right badge on the right body for
+ * five real systems. They are genuine same-radius ±60° Trojans (not 180° binaries), each
+ * encoding the entire offset in `argOfPeriapsis` with ascendingNode/meanAnomaly held equal
+ * across siblings — see the fixtures under `e2e/fixtures/` and the service-spec rationale.
+ *
+ * A body's own header carries the badge as `<span class="badge badge-blue">` with text
+ * "L4"/"L5" (a Trojan) or "Host" (the co-orbital primary, companions at both L4 and L5).
+ */
+
+interface TrojanBadge {
+  /** `bodyId` from the fixture → DOM id `#body-<bodyId>`. */
+  bodyId: number;
+  /** Human label for the test title. */
+  name: string;
+  /** Badge text: a Lagrange point a body occupies, or 'Host' for the primary. */
+  badge: 'L1' | 'L2' | 'L3' | 'L4' | 'L5' | 'Host';
+  /** Expected tooltip on the badge (asserted by hover when given). */
+  tooltip?: string;
+}
+
+interface TrojanSystem extends FixtureOptions {
+  badges: TrojanBadge[];
+}
+
+const HOST_TOOLTIP =
+  'Co-orbital primary: this body has companions at its L4 and L5 Lagrange points — click for the diagram';
+
+const SYSTEMS: TrojanSystem[] = [
+  {
+    fixture: 'pro-eurl-jf-a-d88.json',
+    systemName: 'Pro Eurl JF-A d88',
+    id64: 3034587351427,
+    badges: [
+      { bodyId: 30, name: 'Pro Eurl JF-A d88 B 2', badge: 'L5' },
+      { bodyId: 33, name: 'Pro Eurl JF-A d88 B 3', badge: 'L4' },
+    ],
+  },
+  {
+    fixture: 'prooe-bli-fq-r-c19-2.json',
+    systemName: 'Prooe Bli FQ-R c19-2',
+    id64: 646492666282,
+    badges: [
+      { bodyId: 18, name: 'Prooe Bli FQ-R c19-2 2', badge: 'L5' },
+      { bodyId: 25, name: 'Prooe Bli FQ-R c19-2 3', badge: 'L4' },
+    ],
+  },
+  {
+    fixture: 'truecho-ne-p-c22-0.json',
+    systemName: 'Truecho NE-P c22-0',
+    id64: 94590909634,
+    badges: [
+      { bodyId: 50, name: 'Truecho NE-P c22-0 6', badge: 'L4' },
+      { bodyId: 68, name: 'Truecho NE-P c22-0 7', badge: 'L5' },
+    ],
+  },
+  {
+    fixture: 'pipe-stem-sector-dl-y-d17.json',
+    systemName: 'Pipe (stem) Sector DL-Y d17',
+    id64: 594592926107,
+    badges: [
+      { bodyId: 34, name: 'Pipe (stem) Sector DL-Y d17 barycentre', badge: 'L4' },
+      { bodyId: 44, name: 'Pipe (stem) Sector DL-Y d17 11', badge: 'L5' },
+    ],
+  },
+  {
+    fixture: 'eorld-byio-aa-a-h539.json',
+    systemName: 'Eorld Byio AA-A h539',
+    id64: 4524375383,
+    badges: [
+      // The barycentre is the co-orbital primary: companions at both L4 (A 18) and L5 (A 19).
+      { bodyId: 35, name: 'Eorld Byio AA-A h539 barycentre', badge: 'Host', tooltip: HOST_TOOLTIP },
+      { bodyId: 38, name: 'Eorld Byio AA-A h539 A 18', badge: 'L4', tooltip: 'Trojan at Lagrange L4 — click for the diagram' },
+      { bodyId: 39, name: 'Eorld Byio AA-A h539 A 19', badge: 'L5', tooltip: 'Trojan at Lagrange L5 — click for the diagram' },
+    ],
+  },
+];
+
+/**
+ * Asserts the expected blue Trojan/Host badge is present in a body's *own* header
+ * (`#body-<id> > .body-title`, so nested child bodies never bleed in), with exact text.
+ * When a `tooltip` is given, hovers the badge and checks the overlay text too.
+ */
+async function expectTrojanBadge(page: Page, b: TrojanBadge): Promise<void> {
+  const header = page.locator(`#body-${b.bodyId} > .body-title`);
+  await expect(header, `#body-${b.bodyId} ("${b.name}") header should render`).toBeVisible();
+
+  const badge = header
+    .locator('.badge.badge-blue')
+    .filter({ hasText: new RegExp(`^${b.badge}$`) });
+  await expect(badge, `"${b.name}" should show the ${b.badge} badge`).toHaveCount(1);
+
+  if (b.tooltip) {
+    await badge.scrollIntoViewIfNeeded();
+    await badge.hover();
+    await expect(
+      page.locator('.mat-mdc-tooltip-show'),
+      `"${b.name}" ${b.badge} badge tooltip`,
+    ).toHaveText(b.tooltip);
+    // Move away and wait for it to hide so the next hover's tooltip is unambiguous.
+    await page.mouse.move(0, 0);
+    await expect(page.locator('.mat-mdc-tooltip-show')).toHaveCount(0);
+  }
+}
+
+for (const system of SYSTEMS) {
+  test.describe(`${system.systemName} Trojan/Lagrange badges (fixture)`, () => {
+    test.beforeEach(async ({ page }) => {
+      await loadFixtureSystem(page, system);
+    });
+
+    for (const b of system.badges) {
+      test(`renders the ${b.badge} badge on ${b.name}`, async ({ page }) => {
+        await expectTrojanBadge(page, b);
+      });
+    }
+  });
+}
+
+const byName = (name: string): TrojanSystem => SYSTEMS.find(s => s.systemName === name)!;
+
+test.describe('Lagrange points dialog', () => {
+  test('Host badge opens the diagram with the host highlighted and L4/L5 companions', async ({ page }) => {
+    await loadFixtureSystem(page, byName('Eorld Byio AA-A h539'));
+
+    await page.locator('#body-35 > .body-title .badge.badge-blue', { hasText: 'Host' }).click();
+
+    const svg = page.locator('app-lagrange-dialog svg');
+    await expect(page.locator('app-lagrange-dialog').getByRole('heading', { name: 'Lagrange points' })).toBeVisible();
+    // Real companions are placed at L4 and L5, and all five points are captioned.
+    await expect(svg).toContainText('A 18');
+    await expect(svg).toContainText('A 19');
+    // The repeated system-name prefix is stripped from the body names.
+    await expect(svg).not.toContainText('Eorld Byio AA-A h539 A 18');
+    for (const id of ['L1', 'L2', 'L3', 'L4', 'L5']) {
+      await expect(svg).toContainText(id);
+    }
+    // The clicked body (the host) is the single highlighted marker.
+    await expect(svg.locator('circle.body.focus')).toHaveCount(1);
+    // Three real bodies (host + L4 + L5); the remaining points are placeholders.
+    await expect(svg.locator('circle.body')).toHaveCount(3);
+    await expect(svg.locator('circle.placeholder')).toHaveCount(3);
+  });
+
+  test('Trojan badge on a lone pair opens the diagram with a placeholder secondary', async ({ page }) => {
+    await loadFixtureSystem(page, byName('Pro Eurl JF-A d88'));
+
+    // Body 33 (B 3) is labelled L4; clicking it focuses it in the diagram.
+    await page.locator('#body-33 > .body-title .badge.badge-blue', { hasText: 'L4' }).click();
+
+    const svg = page.locator('app-lagrange-dialog svg');
+    await expect(page.locator('app-lagrange-dialog').getByRole('heading', { name: 'Lagrange points' })).toBeVisible();
+    await expect(svg).toContainText('B 2');
+    await expect(svg).toContainText('B 3');
+    // No recorded host → the secondary slot is a placeholder with its caption.
+    await expect(svg).toContainText('secondary');
+    await expect(svg.locator('circle.body.focus')).toHaveCount(1);
+    // L4 + L5 bodies; L1/L2/L3 + the empty secondary slot are placeholders.
+    await expect(svg.locator('circle.body')).toHaveCount(2);
+    await expect(svg.locator('circle.placeholder')).toHaveCount(4);
+  });
+});

--- a/e2e/trojan-lagrange.spec.ts
+++ b/e2e/trojan-lagrange.spec.ts
@@ -81,19 +81,20 @@ const SYSTEMS: TrojanSystem[] = [
       { bodyId: 39, name: 'Eorld Byio AA-A h539 A 19', badge: 'L5', tooltip: 'Trojan at Lagrange L5 — click for the diagram' },
     ],
   },
-  {
-    // C and D share an exact semi-major axis and orbital period but sit 180° apart in
-    // argOfPeriapsis (201.54° vs 21.54°) with ascendingNode and meanAnomaly held equal —
-    // the classic L3 opposition. Each body therefore carries an L3 badge.
-    fixture: 'cloomoo-il-y-e1.json',
-    systemName: 'Cloomoo IL-Y e1',
-    id64: 6033516940,
-    badges: [
-      { bodyId: 6, name: 'Cloomoo IL-Y e1 C', badge: 'L3', tooltip: 'Trojan at Lagrange L3 — click for the diagram' },
-      { bodyId: 7, name: 'Cloomoo IL-Y e1 D', badge: 'L3', tooltip: 'Trojan at Lagrange L3 — click for the diagram' },
-    ],
-  },
 ];
+
+/**
+ * Cloomoo IL-Y e1 C/D share an exact semi-major axis and orbital period but sit 180° apart in
+ * argOfPeriapsis — geometrically a textbook L3 opposition. They are NOT badged, though: the pair
+ * orbits a barycentre (their mutual centre of mass), and a Lagrange configuration needs a real
+ * central body, so the detector deliberately suppresses any status here. See the suppression test
+ * below and the orbital-relations spec's barycentre case.
+ */
+const CLOOMOO_BARYCENTRE_BINARY: FixtureOptions = {
+  fixture: 'cloomoo-il-y-e1.json',
+  systemName: 'Cloomoo IL-Y e1',
+  id64: 6033516940,
+};
 
 /**
  * Asserts the expected blue Trojan/Host badge is present in a body's *own* header
@@ -179,24 +180,21 @@ test.describe('Lagrange points dialog', () => {
     await expect(svg.locator('circle.placeholder')).toHaveCount(4);
   });
 
-  test('L3 badge opens the diagram with both opposed bodies sharing the L3 point', async ({ page }) => {
-    await loadFixtureSystem(page, byName('Cloomoo IL-Y e1'));
+  test('shows no Lagrange badge for a 180° binary orbiting a barycentre', async ({ page }) => {
+    await loadFixtureSystem(page, CLOOMOO_BARYCENTRE_BINARY);
 
-    // Body 6 (C) is labelled L3; clicking it opens the diagram with C focused.
-    await page.locator('#body-6 > .body-title .badge.badge-blue', { hasText: 'L3' }).click();
-
-    const svg = page.locator('app-lagrange-dialog svg');
-    await expect(page.locator('app-lagrange-dialog').getByRole('heading', { name: 'Lagrange points' })).toBeVisible();
-    // Both opposed siblings occupy the single L3 slot, captioned together with the prefix stripped.
-    await expect(svg).toContainText('C, D');
-    await expect(svg).not.toContainText('Cloomoo IL-Y e1 C');
-    for (const id of ['L1', 'L2', 'L3', 'L4', 'L5']) {
-      await expect(svg).toContainText(id);
+    // C (body 6) and D (body 7) are a 180° pair, but they orbit a barycentre — not a real
+    // central body — so the detector suppresses any Lagrange status: no blue badge appears.
+    for (const bodyId of [6, 7]) {
+      const header = page.locator(`#body-${bodyId} > .body-title`);
+      await expect(header, `#body-${bodyId} header should render`).toBeVisible();
+      // Scope to Lagrange badge text — badge-blue is also used by Odyssey/Shepherd badges.
+      await expect(
+        header.locator('.badge.badge-blue').filter({ hasText: /^(L[1-5]|Host)$/ }),
+        `#body-${bodyId} should carry no Trojan/Lagrange badge`,
+      ).toHaveCount(0);
     }
-    // The two bodies share one L3 marker, drawn once and highlighted (the clicked body is among them).
-    await expect(svg.locator('circle.body.focus')).toHaveCount(1);
-    await expect(svg.locator('circle.body')).toHaveCount(1);
-    // L1/L2/L4/L5 + the empty secondary slot (no recorded host) are placeholders.
-    await expect(svg.locator('circle.placeholder')).toHaveCount(5);
+    // With nothing to click, the diagram is never created.
+    await expect(page.locator('app-lagrange-dialog')).toHaveCount(0);
   });
 });

--- a/e2e/trojan-lagrange.spec.ts
+++ b/e2e/trojan-lagrange.spec.ts
@@ -81,6 +81,18 @@ const SYSTEMS: TrojanSystem[] = [
       { bodyId: 39, name: 'Eorld Byio AA-A h539 A 19', badge: 'L5', tooltip: 'Trojan at Lagrange L5 — click for the diagram' },
     ],
   },
+  {
+    // C and D share an exact semi-major axis and orbital period but sit 180° apart in
+    // argOfPeriapsis (201.54° vs 21.54°) with ascendingNode and meanAnomaly held equal —
+    // the classic L3 opposition. Each body therefore carries an L3 badge.
+    fixture: 'cloomoo-il-y-e1.json',
+    systemName: 'Cloomoo IL-Y e1',
+    id64: 6033516940,
+    badges: [
+      { bodyId: 6, name: 'Cloomoo IL-Y e1 C', badge: 'L3', tooltip: 'Trojan at Lagrange L3 — click for the diagram' },
+      { bodyId: 7, name: 'Cloomoo IL-Y e1 D', badge: 'L3', tooltip: 'Trojan at Lagrange L3 — click for the diagram' },
+    ],
+  },
 ];
 
 /**
@@ -165,5 +177,26 @@ test.describe('Lagrange points dialog', () => {
     // L4 + L5 bodies; L1/L2/L3 + the empty secondary slot are placeholders.
     await expect(svg.locator('circle.body')).toHaveCount(2);
     await expect(svg.locator('circle.placeholder')).toHaveCount(4);
+  });
+
+  test('L3 badge opens the diagram with both opposed bodies sharing the L3 point', async ({ page }) => {
+    await loadFixtureSystem(page, byName('Cloomoo IL-Y e1'));
+
+    // Body 6 (C) is labelled L3; clicking it opens the diagram with C focused.
+    await page.locator('#body-6 > .body-title .badge.badge-blue', { hasText: 'L3' }).click();
+
+    const svg = page.locator('app-lagrange-dialog svg');
+    await expect(page.locator('app-lagrange-dialog').getByRole('heading', { name: 'Lagrange points' })).toBeVisible();
+    // Both opposed siblings occupy the single L3 slot, captioned together with the prefix stripped.
+    await expect(svg).toContainText('C, D');
+    await expect(svg).not.toContainText('Cloomoo IL-Y e1 C');
+    for (const id of ['L1', 'L2', 'L3', 'L4', 'L5']) {
+      await expect(svg).toContainText(id);
+    }
+    // The two bodies share one L3 marker, drawn once and highlighted (the clicked body is among them).
+    await expect(svg.locator('circle.body.focus')).toHaveCount(1);
+    await expect(svg.locator('circle.body')).toHaveCount(1);
+    // L1/L2/L4/L5 + the empty secondary slot (no recorded host) are placeholders.
+    await expect(svg.locator('circle.placeholder')).toHaveCount(5);
   });
 });

--- a/e2e/trojan-lagrange.spec.ts
+++ b/e2e/trojan-lagrange.spec.ts
@@ -81,6 +81,19 @@ const SYSTEMS: TrojanSystem[] = [
       { bodyId: 39, name: 'Eorld Byio AA-A h539 A 19', badge: 'L5', tooltip: 'Trojan at Lagrange L5 — click for the diagram' },
     ],
   },
+  {
+    // B 3 a / B 3 b share an exact semi-major axis and period but sit ~180° apart in
+    // argOfPeriapsis around the real planet B 3 — a genuine L3 opposition with a massive
+    // central body (unlike Cloomoo's barycentre binary below, which is suppressed). Both
+    // members read as L3.
+    fixture: 'pro-eurl-hw-w-e1-1.json',
+    systemName: 'Pro Eurl HW-W e1-1',
+    id64: 5651842260,
+    badges: [
+      { bodyId: 31, name: 'Pro Eurl HW-W e1-1 B 3 a', badge: 'L3', tooltip: 'Trojan at Lagrange L3 — click for the diagram' },
+      { bodyId: 32, name: 'Pro Eurl HW-W e1-1 B 3 b', badge: 'L3', tooltip: 'Trojan at Lagrange L3 — click for the diagram' },
+    ],
+  },
 ];
 
 /**
@@ -178,6 +191,26 @@ test.describe('Lagrange points dialog', () => {
     // L4 + L5 bodies; L1/L2/L3 + the empty secondary slot are placeholders.
     await expect(svg.locator('circle.body')).toHaveCount(2);
     await expect(svg.locator('circle.placeholder')).toHaveCount(4);
+  });
+
+  test('L3 opposition draws one body as the secondary and the other at L3', async ({ page }) => {
+    await loadFixtureSystem(page, byName('Pro Eurl HW-W e1-1'));
+
+    // B 3 a (body 31) is one half of the L3 pair; clicking its badge focuses it in the diagram.
+    await page.locator('#body-31 > .body-title .badge.badge-blue', { hasText: 'L3' }).click();
+
+    const svg = page.locator('app-lagrange-dialog svg');
+    await expect(page.locator('app-lagrange-dialog').getByRole('heading', { name: 'Lagrange points' })).toBeVisible();
+    // The opposed pair is split across the orbit: one promoted to the secondary slot, the
+    // other left on the L3 marker — so neither the placeholder secondary nor a stacked L3.
+    await expect(svg).toContainText('B 3 a');
+    await expect(svg).toContainText('B 3 b');
+    await expect(svg).not.toContainText('secondary');
+    // Two real bodies (secondary + L3); L1/L2/L4/L5 stay placeholders.
+    await expect(svg.locator('circle.body')).toHaveCount(2);
+    await expect(svg.locator('circle.placeholder')).toHaveCount(4);
+    // The clicked body stays on the labelled L3 marker as the single highlighted one.
+    await expect(svg.locator('circle.body.focus')).toHaveCount(1);
   });
 
   test('shows no Lagrange badge for a 180° binary orbiting a barycentre', async ({ page }) => {

--- a/src/app/data/orbital-diagrams.spec.ts
+++ b/src/app/data/orbital-diagrams.spec.ts
@@ -3,6 +3,7 @@ import {
   arcPath,
   axialTiltDiagram,
   inclinationDiagram,
+  lagrangeDiagram,
   periapsisDiagram,
 } from './orbital-diagrams';
 
@@ -171,6 +172,56 @@ describe('orbital-diagrams', () => {
       // High eccentricity is clamped (rx > ry, finite) and a missing value still draws an ellipse.
       expect(high.ellipse.rx).toBeGreaterThan(high.ellipse.ry);
       expect(def.ellipse.rx).toBeGreaterThan(0);
+    });
+  });
+
+  describe('lagrangeDiagram', () => {
+    const d = lagrangeDiagram();
+
+    it('centres the primary and puts the secondary on the orbit to the right', () => {
+      expect(d.center).toEqual({ x: CENTER, y: CENTER });
+      // Secondary sits one orbit-radius to the right, on the axis.
+      expect(d.secondary).toEqual({ x: CENTER + d.orbitRadius, y: CENTER });
+      expect(dist(d.center, d.secondary)).toBeCloseTo(d.orbitRadius, 6);
+    });
+
+    it('exposes all five Lagrange points in L1…L5 order', () => {
+      expect(d.markers.map(m => m.id)).toEqual(['L1', 'L2', 'L3', 'L4', 'L5']);
+    });
+
+    it('places L4 leading (above the axis) and L5 trailing (below), 60° off, on the orbit', () => {
+      const l4 = d.markers.find(m => m.id === 'L4')!;
+      const l5 = d.markers.find(m => m.id === 'L5')!;
+      // Screen "up" is -y: the leading point sits above the axis, the trailing one below.
+      expect(l4.point.y).toBeLessThan(CENTER);
+      expect(l5.point.y).toBeGreaterThan(CENTER);
+      // Both ride the reference orbit and mirror each other across the axis.
+      expect(dist(d.center, l4.point)).toBeCloseTo(d.orbitRadius, 3);
+      expect(dist(d.center, l5.point)).toBeCloseTo(d.orbitRadius, 3);
+      expect(l4.point.x).toBeCloseTo(l5.point.x, 6);
+      expect(l4.point.y - CENTER).toBeCloseTo(CENTER - l5.point.y, 6);
+    });
+
+    it('orders L1 inside the orbit, L3 opposite the secondary, L2 beyond it', () => {
+      const x = (id: string) => d.markers.find(m => m.id === id)!.point.x;
+      // L3 opposite < primary < L1 inside < secondary < L2 beyond, all on the axis (y = CENTER).
+      expect(x('L3')).toBeLessThan(CENTER);
+      expect(x('L1')).toBeGreaterThan(CENTER);
+      expect(x('L1')).toBeLessThan(d.secondary.x);
+      expect(x('L2')).toBeGreaterThan(d.secondary.x);
+      for (const id of ['L1', 'L2', 'L3']) {
+        expect(d.markers.find(m => m.id === id)!.point.y).toBe(CENTER);
+      }
+    });
+
+    it('keeps every drawn point within the view box', () => {
+      const pts = [d.center, d.secondary, ...d.markers.map(m => m.point)];
+      for (const p of pts) {
+        expect(p.x).toBeGreaterThanOrEqual(0);
+        expect(p.x).toBeLessThanOrEqual(VIEW_BOX_SIZE);
+        expect(p.y).toBeGreaterThanOrEqual(0);
+        expect(p.y).toBeLessThanOrEqual(VIEW_BOX_SIZE);
+      }
     });
   });
 });

--- a/src/app/data/orbital-diagrams.spec.ts
+++ b/src/app/data/orbital-diagrams.spec.ts
@@ -214,6 +214,16 @@ describe('orbital-diagrams', () => {
       }
     });
 
+    it('drops the L3 occupant name below its marker, onto the secondary name band', () => {
+      const l3 = d.markers.find(m => m.id === 'L3')!;
+      // The "L3" caption stays above the marker; the body name goes below it…
+      expect(l3.label.y).toBeLessThan(l3.point.y);
+      expect(l3.nameLabel.y).toBeGreaterThan(l3.point.y);
+      // …onto the same horizontal band as the secondary's name on the opposite side.
+      expect(l3.nameLabel.y).toBeCloseTo(d.secondaryLabel.y, 6);
+      expect(l3.nameLabel.x).toBeCloseTo(l3.point.x, 6);
+    });
+
     it('keeps every drawn point within the view box', () => {
       const pts = [d.center, d.secondary, ...d.markers.map(m => m.point)];
       for (const p of pts) {

--- a/src/app/data/orbital-diagrams.ts
+++ b/src/app/data/orbital-diagrams.ts
@@ -51,6 +51,23 @@ export interface PeriapsisDiagram {
   arc: string;
 }
 
+/** One Lagrange point's marker position and the anchor for its "Lx" label. */
+export interface LagrangeMarker {
+  id: 'L1' | 'L2' | 'L3' | 'L4' | 'L5';
+  point: Point;  // where the marker (and any occupying body) is drawn
+  label: Point;  // anchor for the "Lx" caption, nudged clear of the marker
+}
+
+export interface LagrangeDiagram {
+  center: Point;         // the primary, at the centre of the orbit
+  primaryRadius: number;
+  primaryLabel: Point;   // anchor for the primary's caption
+  orbitRadius: number;   // radius of the (circular) reference orbit
+  secondary: Point;      // the secondary body, on the orbit at angle 0 (to the right)
+  secondaryLabel: Point; // anchor for the secondary's caption
+  markers: LagrangeMarker[];
+}
+
 const DEG = Math.PI / 180;
 
 /** Round to 3 decimals so bound SVG attributes stay tidy and tests stay stable.
@@ -218,4 +235,48 @@ export function periapsisDiagram(argDeg: number, eccentricity?: number): Periaps
   const arc = arcPath(focus.x, focus.y, 16, 0, arg);
 
   return { focus, focusRadius: 4, ellipse, referenceLine, periapsisPoint, parentLabel, bodyLabel, arc };
+}
+
+/** Round a point's coordinates for tidy, test-stable SVG attributes. */
+function roundPoint(p: Point): Point {
+  return { x: r(p.x), y: r(p.y) };
+}
+
+/**
+ * The canonical five-point Lagrange schematic of a two-body system: a primary at the
+ * centre, a secondary on a circular reference orbit to the right (angle 0), and the five
+ * Lagrange points in their textbook positions — L1 between the bodies, L2 just beyond the
+ * secondary, L3 opposite, and L4 / L5 leading / trailing by 60°.
+ *
+ * The layout is fixed (it illustrates the configuration, not any one body's live angles);
+ * callers drop actual bodies onto the secondary slot and the L-points, or leave them as
+ * placeholders. Screen "up" is -y, so L4 (leading, +60°) sits above the axis and L5 below.
+ */
+export function lagrangeDiagram(): LagrangeDiagram {
+  const center = { x: CENTER, y: CENTER };
+  const orbitRadius = 34;
+
+  const secondary = pointAt(center.x, center.y, orbitRadius, 0);
+  const l1: Point = { x: center.x + orbitRadius - 12, y: center.y };
+  const l2: Point = { x: center.x + orbitRadius + 11, y: center.y };
+
+  const markers: LagrangeMarker[] = [
+    { id: 'L1', point: roundPoint(l1), label: { x: r(l1.x), y: r(center.y - 9) } },
+    { id: 'L2', point: roundPoint(l2), label: { x: r(l2.x), y: r(center.y - 9) } },
+    { id: 'L3', point: roundPoint(pointAt(center.x, center.y, orbitRadius, 180)), label: { x: r(center.x - orbitRadius), y: r(center.y - 9) } },
+    { id: 'L4', point: roundPoint(pointAt(center.x, center.y, orbitRadius, 60)), label: roundPoint(pointAt(center.x, center.y, orbitRadius + 13, 60)) },
+    { id: 'L5', point: roundPoint(pointAt(center.x, center.y, orbitRadius, -60)), label: roundPoint(pointAt(center.x, center.y, orbitRadius + 13, -60)) },
+  ];
+
+  return {
+    center,
+    primaryRadius: 7,
+    // Primary caption sits well below the centre and the secondary's just below its marker, so
+    // the two names land on separate bands and never overlap even when both are long.
+    primaryLabel: { x: center.x, y: r(center.y + 18) },
+    orbitRadius,
+    secondary: roundPoint(secondary),
+    secondaryLabel: { x: r(secondary.x), y: r(center.y + 11) },
+    markers,
+  };
 }

--- a/src/app/data/orbital-diagrams.ts
+++ b/src/app/data/orbital-diagrams.ts
@@ -51,11 +51,12 @@ export interface PeriapsisDiagram {
   arc: string;
 }
 
-/** One Lagrange point's marker position and the anchor for its "Lx" label. */
+/** One Lagrange point's marker position and the anchors for its "Lx" label and body name. */
 export interface LagrangeMarker {
   id: 'L1' | 'L2' | 'L3' | 'L4' | 'L5';
-  point: Point;  // where the marker (and any occupying body) is drawn
-  label: Point;  // anchor for the "Lx" caption, nudged clear of the marker
+  point: Point;     // where the marker (and any occupying body) is drawn
+  label: Point;     // anchor for the "Lx" caption, nudged clear of the marker
+  nameLabel: Point; // anchor for an occupying body's name, on the far side from the caption
 }
 
 export interface LagrangeDiagram {
@@ -259,13 +260,21 @@ export function lagrangeDiagram(): LagrangeDiagram {
   const secondary = pointAt(center.x, center.y, orbitRadius, 0);
   const l1: Point = { x: center.x + orbitRadius - 12, y: center.y };
   const l2: Point = { x: center.x + orbitRadius + 11, y: center.y };
+  const l3 = pointAt(center.x, center.y, orbitRadius, 180);
+  const l4 = pointAt(center.x, center.y, orbitRadius, 60);
+  const l5 = pointAt(center.x, center.y, orbitRadius, -60);
+  const l4Label = pointAt(center.x, center.y, orbitRadius + 13, 60);
+  const l5Label = pointAt(center.x, center.y, orbitRadius + 13, -60);
 
   const markers: LagrangeMarker[] = [
-    { id: 'L1', point: roundPoint(l1), label: { x: r(l1.x), y: r(center.y - 9) } },
-    { id: 'L2', point: roundPoint(l2), label: { x: r(l2.x), y: r(center.y - 9) } },
-    { id: 'L3', point: roundPoint(pointAt(center.x, center.y, orbitRadius, 180)), label: { x: r(center.x - orbitRadius), y: r(center.y - 9) } },
-    { id: 'L4', point: roundPoint(pointAt(center.x, center.y, orbitRadius, 60)), label: roundPoint(pointAt(center.x, center.y, orbitRadius + 13, 60)) },
-    { id: 'L5', point: roundPoint(pointAt(center.x, center.y, orbitRadius, -60)), label: roundPoint(pointAt(center.x, center.y, orbitRadius + 13, -60)) },
+    { id: 'L1', point: roundPoint(l1), label: { x: r(l1.x), y: r(center.y - 9) }, nameLabel: { x: r(l1.x), y: r(center.y - 3) } },
+    { id: 'L2', point: roundPoint(l2), label: { x: r(l2.x), y: r(center.y - 9) }, nameLabel: { x: r(l2.x), y: r(center.y - 3) } },
+    // L3 sits opposite the secondary, on the left. Its "L3" caption goes above the marker but
+    // the occupant's name drops *below* it — onto the same band as the secondary's name on the
+    // right — so an L3-opposition pair reads as two names mirrored across the primary.
+    { id: 'L3', point: roundPoint(l3), label: { x: r(center.x - orbitRadius), y: r(center.y - 9) }, nameLabel: { x: r(l3.x), y: r(center.y + 11) } },
+    { id: 'L4', point: roundPoint(l4), label: roundPoint(l4Label), nameLabel: { x: r(l4Label.x), y: r(l4Label.y + 6) } },
+    { id: 'L5', point: roundPoint(l5), label: roundPoint(l5Label), nameLabel: { x: r(l5Label.x), y: r(l5Label.y + 6) } },
   ];
 
   return {

--- a/src/app/data/orbital-relations.service.spec.ts
+++ b/src/app/data/orbital-relations.service.spec.ts
@@ -71,6 +71,163 @@ describe('OrbitalRelationsService', () => {
       expect(service.detectTrojanStatus(inner).lagrangePoint).toBe('L1');
       expect(service.detectTrojanStatus(outer).lagrangePoint).toBe('L2');
     });
+
+    it('matches Elite\'s convention: ED encodes the co-orbital offset in argOfPeriapsis alone', () => {
+      // The true along-orbit position is mean longitude λ = Ω + ω + M, so comparing
+      // argOfPeriapsis (ω) alone is only exact when siblings share ascendingNode (Ω) and
+      // meanAnomaly (M). Real game data does exactly that: ED holds Ω and M identical across
+      // co-orbital siblings and varies only argOfPeriapsis. These are the verbatim orbital
+      // elements of Alpha Centauri's "2045 PC2" / "Lagrange" pair (e2e fixture) — a genuine
+      // same-radius L3 co-orbital, the partner literally named "Lagrange". Ω and M match to
+      // full precision; only argOfPeriapsis differs (by 180°).
+      const [pc2, lagrange] = makeFamily([
+        { orbitalPeriod: 9348.90664562031, semiMajorAxis: 9.56568437539316,
+          argOfPeriapsis: 269.999997, ascendingNode: 0.0, meanAnomaly: 36.634872 },
+        { orbitalPeriod: 9348.90664562031, semiMajorAxis: 9.56568437539316,
+          argOfPeriapsis: 89.999999, ascendingNode: 0.0, meanAnomaly: 36.634872 },
+      ]);
+      expect(service.detectTrojanStatus(pc2).lagrangePoint).toBe('L3');
+      expect(service.detectTrojanStatus(lagrange).lagrangePoint).toBe('L3');
+
+      // Because ΔΩ = ΔM = 0 in ED's data, adding the shared Ω/M back into a full
+      // mean-longitude comparison would not change the verdict: Δλ = Δω. Re-running the
+      // same geometry without any Ω/M gives the identical L3 result, proving the
+      // argOfPeriapsis-only comparison loses nothing for real game data.
+      const [bareA, bareB] = makeFamily([
+        { orbitalPeriod: 9348.90664562031, semiMajorAxis: 9.56568437539316, argOfPeriapsis: 269.999997 },
+        { orbitalPeriod: 9348.90664562031, semiMajorAxis: 9.56568437539316, argOfPeriapsis: 89.999999 },
+      ]);
+      expect(service.detectTrojanStatus(bareA).lagrangePoint).toBe('L3');
+      expect(service.detectTrojanStatus(bareB).lagrangePoint).toBe('L3');
+    });
+
+    // Real same-radius Trojan/Lagrange systems (genuine ±60° co-orbitals, not 180° binaries),
+    // pulled verbatim from the committed biostats fixtures under e2e/fixtures/. Each pair shares
+    // an identical orbitalPeriod and semiMajorAxis; ascendingNode (Ω) and meanAnomaly (M) are
+    // identical between siblings (or absent on both), and the entire ±60° along-orbit offset is
+    // carried by argOfPeriapsis — so the argOfPeriapsis-only test reproduces ED's own placement
+    // exactly. These lock in that real Trojan data is detected, and confirm the empirical finding
+    // generalises beyond the 180° binaries above. (Values verified against the fixtures.)
+    describe('real game fixtures (e2e/fixtures/*.json)', () => {
+      it('Pro Eurl JF-A d88 B 2/B 3 — ±60° in argOfPeriapsis, no Ω/M recorded', () => {
+        // pro-eurl-jf-a-d88.json: bodies 30 & 33, asc/meanAnomaly absent on both.
+        const [b2, b3] = makeFamily([
+          { orbitalPeriod: 2756.17222222222, semiMajorAxis: 2.36276632726164, argOfPeriapsis: 256.983124 },
+          { orbitalPeriod: 2756.17222222222, semiMajorAxis: 2.36276632726164, argOfPeriapsis: 316.983124 },
+        ]);
+        expect(service.detectTrojanStatus(b2).lagrangePoint).toBe('L5');
+        expect(service.detectTrojanStatus(b3).lagrangePoint).toBe('L4');
+      });
+
+      it('Prooe Bli FQ-R c19-2 2/3 — ±60° in argOfPeriapsis, no Ω/M recorded', () => {
+        // prooe-bli-fq-r-c19-2.json: bodies 18 & 25, asc/meanAnomaly absent on both.
+        const [two, three] = makeFamily([
+          { orbitalPeriod: 1323.52527777778, semiMajorAxis: 1.90290777597278, argOfPeriapsis: 213.138443 },
+          { orbitalPeriod: 1323.52527777778, semiMajorAxis: 1.90290777597278, argOfPeriapsis: 273.138428 },
+        ]);
+        expect(service.detectTrojanStatus(two).lagrangePoint).toBe('L5');
+        expect(service.detectTrojanStatus(three).lagrangePoint).toBe('L4');
+      });
+
+      it('Truecho NE-P c22-0 6/7 — ±60° across the 0° seam, shared Ω and M', () => {
+        // truecho-ne-p-c22-0.json: bodies 50 & 68. Ω = 57.140393 on both; M matches to ~1e-4.
+        const [six, seven] = makeFamily([
+          { orbitalPeriod: 5199.37670065297, semiMajorAxis: 5.61591537457029,
+            argOfPeriapsis: 55.239595, ascendingNode: 57.140393, meanAnomaly: 311.627298 },
+          { orbitalPeriod: 5199.37670065297, semiMajorAxis: 5.61591537457029,
+            argOfPeriapsis: 355.23958, ascendingNode: 57.140393, meanAnomaly: 311.627451 },
+        ]);
+        expect(service.detectTrojanStatus(six).lagrangePoint).toBe('L4');
+        expect(service.detectTrojanStatus(seven).lagrangePoint).toBe('L5');
+      });
+
+      it('Pipe (stem) Sector DL-Y d17 barycentre/11 — ±60° in argOfPeriapsis, shared Ω and M', () => {
+        // pipe-stem-sector-dl-y-d17.json: bodies 34 & 44. Ω = -148.301524 on both; M matches to ~1e-4.
+        const [bary, eleven] = makeFamily([
+          { orbitalPeriod: 2239.87114926179, semiMajorAxis: 3.56427210739919,
+            argOfPeriapsis: 135.846247, ascendingNode: -148.301524, meanAnomaly: 271.037909 },
+          { orbitalPeriod: 2239.87114926179, semiMajorAxis: 3.56427210739919,
+            argOfPeriapsis: 75.846249, ascendingNode: -148.301524, meanAnomaly: 271.038015 },
+        ]);
+        expect(service.detectTrojanStatus(bary).lagrangePoint).toBe('L4');
+        expect(service.detectTrojanStatus(eleven).lagrangePoint).toBe('L5');
+      });
+
+      it('Eorld Byio AA-A h539 — a host barycentre with Trojans at both L4 and L5', () => {
+        // eorld-byio-aa-a-h539.json: barycentre 35 sits between A 18 (+60°) and A 19 (-60°), all
+        // at the same radius with identical Ω = 128.746136 and M ≈ 280.54. The barycentre is the
+        // co-orbital primary (host), not itself a Trojan.
+        const [bary, a18, a19] = makeFamily([
+          { orbitalPeriod: 78.8197259384144, semiMajorAxis: 1.24773884117624,
+            argOfPeriapsis: 255.841558, ascendingNode: 128.746136, meanAnomaly: 280.536448 },
+          { orbitalPeriod: 78.8197259384144, semiMajorAxis: 1.24773884117624,
+            argOfPeriapsis: 315.841556, ascendingNode: 128.746136, meanAnomaly: 280.540582 },
+          { orbitalPeriod: 78.8197259384144, semiMajorAxis: 1.24773884117624,
+            argOfPeriapsis: 195.84156, ascendingNode: 128.746136, meanAnomaly: 280.539129 },
+        ]);
+        const host = service.detectTrojanStatus(bary);
+        expect(host.isHost).toBe(true);
+        expect(host.lagrangePoint).toBeNull();
+        expect(service.detectTrojanStatus(a18).lagrangePoint).toBe('L4');
+        expect(service.detectTrojanStatus(a19).lagrangePoint).toBe('L5');
+      });
+    });
+  });
+
+  describe('lagrangeConfiguration', () => {
+    it('returns null when the body has no parent or no orbital period', () => {
+      const [orphan] = makeFamily([{ argOfPeriapsis: 0, semiMajorAxis: 5 }]);
+      orphan.parent = null;
+      expect(service.lagrangeConfiguration(orphan)).toBeNull();
+
+      const [noPeriod] = makeFamily([{ argOfPeriapsis: 0, semiMajorAxis: 5 }]);
+      expect(service.lagrangeConfiguration(noPeriod)).toBeNull();
+    });
+
+    it('returns null when the body has no co-orbital relationships', () => {
+      const [lonely] = makeFamily([{ orbitalPeriod: 10, semiMajorAxis: 5, argOfPeriapsis: 0 }]);
+      expect(service.lagrangeConfiguration(lonely)).toBeNull();
+    });
+
+    it('resolves a host + L4/L5 family (Eorld Byio AA-A h539), flagging the focus', () => {
+      // The same real host configuration used above: barycentre (host) between A 18 (L4) and A 19 (L5).
+      const [bary, a18, a19] = makeFamily([
+        { orbitalPeriod: 78.8197259384144, semiMajorAxis: 1.24773884117624,
+          argOfPeriapsis: 255.841558, ascendingNode: 128.746136, meanAnomaly: 280.536448 },
+        { orbitalPeriod: 78.8197259384144, semiMajorAxis: 1.24773884117624,
+          argOfPeriapsis: 315.841556, ascendingNode: 128.746136, meanAnomaly: 280.540582 },
+        { orbitalPeriod: 78.8197259384144, semiMajorAxis: 1.24773884117624,
+          argOfPeriapsis: 195.84156, ascendingNode: 128.746136, meanAnomaly: 280.539129 },
+      ]);
+
+      // Opened from the host: it occupies the secondary slot (focused), Trojans fill L4 and L5.
+      const fromHost = service.lagrangeConfiguration(bary)!;
+      expect(fromHost.primaryName).toBe('Parent');
+      expect(fromHost.secondary).toEqual({ name: 'Child 1', bodyId: 1, isFocus: true });
+      expect(fromHost.points.L4).toEqual([{ name: 'Child 2', bodyId: 2, isFocus: false }]);
+      expect(fromHost.points.L5).toEqual([{ name: 'Child 3', bodyId: 3, isFocus: false }]);
+      expect(fromHost.points.L1).toEqual([]);
+      expect(fromHost.points.L2).toEqual([]);
+      expect(fromHost.points.L3).toEqual([]);
+
+      // Opened from the L4 Trojan: same configuration, but the focus moves to the L4 occupant.
+      const fromL4 = service.lagrangeConfiguration(a18)!;
+      expect(fromL4.secondary).toEqual({ name: 'Child 1', bodyId: 1, isFocus: false });
+      expect(fromL4.points.L4).toEqual([{ name: 'Child 2', bodyId: 2, isFocus: true }]);
+      expect(service.lagrangeConfiguration(a19)!.points.L5[0].isFocus).toBe(true);
+    });
+
+    it('resolves a lone ±60° pair with no host as a placeholder secondary', () => {
+      // Pro Eurl JF-A d88 B 2 / B 3: a 60°-apart pair labelled L5 / L4, with no recorded host.
+      const [b2, b3] = makeFamily([
+        { orbitalPeriod: 2756.17222222222, semiMajorAxis: 2.36276632726164, argOfPeriapsis: 256.983124 },
+        { orbitalPeriod: 2756.17222222222, semiMajorAxis: 2.36276632726164, argOfPeriapsis: 316.983124 },
+      ]);
+      const config = service.lagrangeConfiguration(b2)!;
+      expect(config.secondary).toBeNull(); // → drawn as a placeholder
+      expect(config.points.L5).toEqual([{ name: 'Child 1', bodyId: 1, isFocus: true }]);
+      expect(config.points.L4).toEqual([{ name: 'Child 2', bodyId: 2, isFocus: false }]);
+    });
   });
 
   describe('detectRosetteStatus', () => {

--- a/src/app/data/orbital-relations.service.spec.ts
+++ b/src/app/data/orbital-relations.service.spec.ts
@@ -246,6 +246,26 @@ describe('OrbitalRelationsService', () => {
       expect(config.points.L5).toEqual([{ name: 'Child 1', bodyId: 1, isFocus: true }]);
       expect(config.points.L4).toEqual([{ name: 'Child 2', bodyId: 2, isFocus: false }]);
     });
+
+    it('promotes one of an L3 opposition to the secondary slot, keeping the focus at L3', () => {
+      // Pro Eurl HW-W e1-1 B 3 a / B 3 b: a ~180° pair around the real planet B 3, both L3.
+      // With no host, one is drawn as the secondary on the orbit and the other on L3 opposite,
+      // so the diagram shows the genuine opposition instead of two dots on a single marker.
+      const [a, b] = makeFamily([
+        { orbitalPeriod: 2.66276909722222, semiMajorAxis: 0.00100000075736372, argOfPeriapsis: 111.912498 },
+        { orbitalPeriod: 2.66276909722222, semiMajorAxis: 0.00100000075736372, argOfPeriapsis: 291.153168 },
+      ]);
+
+      // Opened from B 3 a: its sibling fills the secondary slot, the focused body stays at L3.
+      const fromA = service.lagrangeConfiguration(a)!;
+      expect(fromA.secondary).toEqual({ name: 'Child 2', bodyId: 2, isFocus: false });
+      expect(fromA.points.L3).toEqual([{ name: 'Child 1', bodyId: 1, isFocus: true }]);
+
+      // Opened from B 3 b: the focus moves with the clicked body, again kept on the L3 marker.
+      const fromB = service.lagrangeConfiguration(b)!;
+      expect(fromB.secondary).toEqual({ name: 'Child 1', bodyId: 1, isFocus: false });
+      expect(fromB.points.L3).toEqual([{ name: 'Child 2', bodyId: 2, isFocus: true }]);
+    });
   });
 
   describe('detectRosetteStatus', () => {

--- a/src/app/data/orbital-relations.service.spec.ts
+++ b/src/app/data/orbital-relations.service.spec.ts
@@ -1,5 +1,6 @@
 import { OrbitalRelationsService } from './orbital-relations.service';
 import { SystemBody, CanonnBiostatsBody } from '../home/home.component';
+import { BODY_TYPE } from './body-types';
 
 describe('OrbitalRelationsService', () => {
   let service: OrbitalRelationsService;
@@ -51,6 +52,23 @@ describe('OrbitalRelationsService', () => {
         { orbitalPeriod: 10, semiMajorAxis: 5, argOfPeriapsis: 180 },
       ]);
       expect(service.detectTrojanStatus(opposite).lagrangePoint).toBe('L3');
+    });
+
+    it('suppresses any status when the shared parent is a barycentre', () => {
+      // A barycentre is the centre of mass of a binary, not a real central body, so its
+      // children orbiting it (here a 180° pair that would otherwise read as L3) have no
+      // Lagrange host and therefore no Trojan/Lagrange status.
+      const [a, b] = makeFamily([
+        { orbitalPeriod: 10, semiMajorAxis: 5, argOfPeriapsis: 0 },
+        { orbitalPeriod: 10, semiMajorAxis: 5, argOfPeriapsis: 180 },
+      ]);
+      // With the default (Star) parent the pair is detected as L3…
+      expect(service.detectTrojanStatus(a).lagrangePoint).toBe('L3');
+      // …but under a barycentre parent the status — and the whole diagram — is suppressed.
+      a.parent!.bodyData.type = BODY_TYPE.Barycentre;
+      expect(service.detectTrojanStatus(a).lagrangePoint).toBeNull();
+      expect(service.detectTrojanStatus(b).lagrangePoint).toBeNull();
+      expect(service.lagrangeConfiguration(a)).toBeNull();
     });
 
     it('distinguishes L1 (inner) from L2 (outer) for aligned same-period bodies', () => {

--- a/src/app/data/orbital-relations.service.ts
+++ b/src/app/data/orbital-relations.service.ts
@@ -323,6 +323,20 @@ export class OrbitalRelationsService {
       }
     }
 
+    // An L3 opposition has no host (neither body has companions at both L4 and L5), so the
+    // pair both read as L3 and the secondary slot would be left empty — stacking the two
+    // opposed bodies on the single L3 marker. But L3 is defined as the point 180° across the
+    // primary *from the secondary*, so one of the opposed pair plays the secondary's role:
+    // promote it into the secondary slot and the diagram draws them on opposite sides of the
+    // orbit (secondary at 0°, the other at L3), exactly the geometry the configuration is.
+    // Promote a non-focused member when possible, so a dialog opened from an L3 badge keeps
+    // the clicked body on the labelled L3 marker.
+    if (secondary === null && points.L3.length > 1) {
+      const focusIndex = points.L3.findIndex(o => o.isFocus);
+      const promoteIndex = focusIndex === 0 ? 1 : 0;
+      [secondary] = points.L3.splice(promoteIndex, 1);
+    }
+
     const hasOccupant = secondary !== null || Object.values(points).some(slot => slot.length > 0);
     if (!hasOccupant) {
       return null;

--- a/src/app/data/orbital-relations.service.ts
+++ b/src/app/data/orbital-relations.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CanonnBiostatsBody, SystemBody } from '../home/home.component';
+import { BODY_TYPE } from './body-types';
 
 /** The five Lagrange points of a two-body system. */
 export type LagrangePointId = 'L1' | 'L2' | 'L3' | 'L4' | 'L5';
@@ -196,6 +197,14 @@ export class OrbitalRelationsService {
       return result;
     }
 
+    // A Lagrange configuration needs a real massive central body to define the points
+    // relative to. When the shared parent is a barycentre, the "co-orbital" siblings are
+    // really the components of a binary orbiting their own centre of mass — there is no
+    // third central body hosting Lagrange points — so there is no Trojan/Lagrange status.
+    if (body.parent.bodyData.type === BODY_TYPE.Barycentre) {
+      return result;
+    }
+
     // L3, L4, L5 candidates share the same orbital distance (semi-major axis).
     //
     // A body's true along-orbit position is its mean longitude λ = Ω + ω + M
@@ -278,6 +287,13 @@ export class OrbitalRelationsService {
     const parent = body.parent;
     const bd = body.bodyData;
     if (!parent || !bd.orbitalPeriod) {
+      return null;
+    }
+
+    // The centre of a Lagrange diagram is the body the family orbits; a barycentre is the
+    // centre of mass of a binary, not a real central body, so it can't host Lagrange points.
+    // Mirrors the guard in detectTrojanStatus, which already suppresses the badges here.
+    if (parent.bodyData.type === BODY_TYPE.Barycentre) {
       return null;
     }
 

--- a/src/app/data/orbital-relations.service.ts
+++ b/src/app/data/orbital-relations.service.ts
@@ -1,12 +1,39 @@
 import { Injectable } from '@angular/core';
 import { CanonnBiostatsBody, SystemBody } from '../home/home.component';
 
+/** The five Lagrange points of a two-body system. */
+export type LagrangePointId = 'L1' | 'L2' | 'L3' | 'L4' | 'L5';
+
 /** Result of Trojan/Lagrange analysis for a body relative to its co-orbital siblings. */
 export interface TrojanStatus {
   /** Lagrange point the body occupies ('L1'–'L5'), or null when it is not a Trojan. */
-  lagrangePoint: string | null;
+  lagrangePoint: LagrangePointId | null;
   /** True when this body hosts Trojans at both L4 and L5 (it is the reference body, not a Trojan). */
   isHost: boolean;
+}
+
+/** A body sitting at one of the slots of a Lagrange configuration. */
+export interface LagrangeOccupant {
+  /** The body's name (raw — callers may map it to a display name). */
+  name: string;
+  /** Its `bodyId`, for DOM ids / de-duplication. */
+  bodyId: number;
+  /** True for the body the configuration was requested for (so the UI can highlight it). */
+  isFocus: boolean;
+}
+
+/**
+ * A co-orbital family expressed as a Lagrange diagram: the central primary they orbit,
+ * the secondary (a host with companions at L4 & L5, when one exists), and whichever
+ * bodies occupy each Lagrange point. Built by {@link OrbitalRelationsService.lagrangeConfiguration}.
+ */
+export interface LagrangeConfiguration {
+  /** Name of the shared parent the family orbits (the central primary), or null. */
+  primaryName: string | null;
+  /** The co-orbital secondary (host), or null when none is recorded → drawn as a placeholder. */
+  secondary: LagrangeOccupant | null;
+  /** Bodies at each Lagrange point — usually 0 or 1 per point. */
+  points: Record<LagrangePointId, LagrangeOccupant[]>;
 }
 
 /** A future periapsis/apoapsis passage: when it occurs and how many days away it is. */
@@ -170,6 +197,19 @@ export class OrbitalRelationsService {
     }
 
     // L3, L4, L5 candidates share the same orbital distance (semi-major axis).
+    //
+    // A body's true along-orbit position is its mean longitude λ = Ω + ω + M
+    // (ascendingNode + argOfPeriapsis + meanAnomaly), so the angular separation of two
+    // co-orbital siblings is Δλ = ΔΩ + Δω + ΔM. We compare argOfPeriapsis (Δω) alone.
+    // That is exact — not merely a heuristic — for Elite's data, because the game holds
+    // Ω and M *identical* across co-orbital siblings and encodes the entire along-orbit
+    // offset in argOfPeriapsis, so ΔΩ = ΔM = 0 and Δλ = Δω. Verified against every real
+    // co-orbital pair in the fixtures — both 180° binaries (Alpha Centauri's "2045 PC2" /
+    // "Lagrange" L3 pair, Merope 1 a/b, …) and genuine ±60° Trojans (Pro Eurl JF-A d88,
+    // Pipe (stem) Sector DL-Y d17, Prooe Bli FQ-R c19-2, Truecho NE-P c22-0, and the
+    // Eorld Byio AA-A h539 host with companions at both L4 and L5): in each, ascendingNode
+    // and meanAnomaly match between siblings (or are absent on both) and only argOfPeriapsis
+    // differs. See the orbital-relations spec's "real game fixtures" block for the pinned values.
     const sameSMABodies = this.coOrbitalSiblings(body, sibling =>
       sibling.bodyData.semiMajorAxis === bd.semiMajorAxis,
     );
@@ -222,6 +262,57 @@ export class OrbitalRelationsService {
     }
 
     return result;
+  }
+
+  /**
+   * Resolves the whole co-orbital family `body` belongs to into a Lagrange diagram: the
+   * shared parent (central primary), the secondary host (if any), and which bodies occupy
+   * each Lagrange point. Every family member is classified with {@link detectTrojanStatus},
+   * so the assignment matches the badges shown on each body. `body` itself is flagged as the
+   * focus so the UI can highlight it.
+   *
+   * Returns null when there is nothing meaningful to draw — no parent, no shared orbital
+   * period, or no co-orbital relationships detected anywhere in the family.
+   */
+  lagrangeConfiguration(body: SystemBody): LagrangeConfiguration | null {
+    const parent = body.parent;
+    const bd = body.bodyData;
+    if (!parent || !bd.orbitalPeriod) {
+      return null;
+    }
+
+    // The co-orbital family: every sibling sharing this body's orbital period (so L1/L2
+    // partners at a different radius are included too), plus `body` itself — it already
+    // lives in `parent.subBodies`. Members without an argOfPeriapsis can't be classified.
+    const family = parent.subBodies.filter(member =>
+      member.bodyData.orbitalPeriod === bd.orbitalPeriod &&
+      member.bodyData.argOfPeriapsis !== undefined,
+    );
+
+    const points: Record<LagrangePointId, LagrangeOccupant[]> = { L1: [], L2: [], L3: [], L4: [], L5: [] };
+    let secondary: LagrangeOccupant | null = null;
+
+    for (const member of family) {
+      const status = this.detectTrojanStatus(member);
+      if (!status.isHost && !status.lagrangePoint) { continue; }
+      const occupant: LagrangeOccupant = {
+        name: member.bodyData.name,
+        bodyId: member.bodyData.bodyId,
+        isFocus: member === body,
+      };
+      if (status.isHost) {
+        secondary = occupant;
+      } else if (status.lagrangePoint) {
+        points[status.lagrangePoint].push(occupant);
+      }
+    }
+
+    const hasOccupant = secondary !== null || Object.values(points).some(slot => slot.length > 0);
+    if (!hasOccupant) {
+      return null;
+    }
+
+    return { primaryName: parent.bodyData.name, secondary, points };
   }
 
   /**

--- a/src/app/dialogs/lagrange-dialog/lagrange-dialog.component.html
+++ b/src/app/dialogs/lagrange-dialog/lagrange-dialog.component.html
@@ -18,7 +18,7 @@
           <text class="point-label" [attr.x]="m.label.x" [attr.y]="m.label.y" text-anchor="middle">{{ m.id }}</text>
           @if (m.occupants.length) {
             <text class="body-name" [class.focus]="hasFocus(m.occupants)"
-              [attr.x]="m.label.x" [attr.y]="m.label.y + 6" text-anchor="middle">{{ shortNames(m.occupants) }}</text>
+              [attr.x]="m.nameLabel.x" [attr.y]="m.nameLabel.y" text-anchor="middle">{{ shortNames(m.occupants) }}</text>
           }
         }
 

--- a/src/app/dialogs/lagrange-dialog/lagrange-dialog.component.html
+++ b/src/app/dialogs/lagrange-dialog/lagrange-dialog.component.html
@@ -1,0 +1,59 @@
+<app-dialog-shell [heading]="title">
+  <div class="lagrange-dialog">
+    <div class="diagram">
+      <svg [attr.viewBox]="viewBox" class="lagrange-diagram" role="img" aria-label="Lagrange points diagram">
+        <!-- Reference orbit + primary–secondary axis -->
+        <circle class="orbit" [attr.cx]="diagram.center.x" [attr.cy]="diagram.center.y" [attr.r]="diagram.orbitRadius" />
+        <line class="axis-reference" [attr.x1]="diagram.center.x - diagram.orbitRadius" [attr.y1]="diagram.center.y"
+          [attr.x2]="diagram.markers[1].point.x" [attr.y2]="diagram.center.y" />
+
+        <!-- The five Lagrange points: a body marker when occupied, a dashed placeholder otherwise -->
+        @for (m of markers(); track m.id) {
+          @if (m.occupants.length) {
+            <circle class="body" [class.focus]="hasFocus(m.occupants)"
+              [attr.cx]="m.point.x" [attr.cy]="m.point.y" r="4" />
+          } @else {
+            <circle class="placeholder" [attr.cx]="m.point.x" [attr.cy]="m.point.y" r="3.5" />
+          }
+          <text class="point-label" [attr.x]="m.label.x" [attr.y]="m.label.y" text-anchor="middle">{{ m.id }}</text>
+          @if (m.occupants.length) {
+            <text class="body-name" [class.focus]="hasFocus(m.occupants)"
+              [attr.x]="m.label.x" [attr.y]="m.label.y + 6" text-anchor="middle">{{ shortNames(m.occupants) }}</text>
+          }
+        }
+
+        <!-- Secondary (the co-orbital host) -->
+        @if (data.config.secondary; as secondary) {
+          <circle class="body" [class.focus]="secondary.isFocus"
+            [attr.cx]="diagram.secondary.x" [attr.cy]="diagram.secondary.y" r="4" />
+          <text class="body-name" [class.focus]="secondary.isFocus"
+            [attr.x]="diagram.secondaryLabel.x" [attr.y]="diagram.secondaryLabel.y" text-anchor="middle">{{ short(secondary.name) }}</text>
+        } @else {
+          <circle class="placeholder" [attr.cx]="diagram.secondary.x" [attr.cy]="diagram.secondary.y" r="3.5" />
+          <text class="point-label" [attr.x]="diagram.secondaryLabel.x" [attr.y]="diagram.secondaryLabel.y" text-anchor="middle">secondary</text>
+        }
+
+        <!-- Primary (the body the family orbits) -->
+        <circle class="primary" [attr.cx]="diagram.center.x" [attr.cy]="diagram.center.y" [attr.r]="diagram.primaryRadius" />
+        @if (data.config.primaryName) {
+          <text class="primary-name" [attr.x]="diagram.primaryLabel.x" [attr.y]="diagram.primaryLabel.y" text-anchor="middle">{{ short(data.config.primaryName) }}</text>
+        }
+      </svg>
+    </div>
+
+    <div class="explanation">
+      <p>
+        <strong>Lagrange points</strong> are the five positions where a small body can keep pace with two
+        larger ones — here
+        @if (data.config.primaryName) { <strong>{{ data.config.primaryName }}</strong> } @else { the primary }
+        at the centre and the secondary on its orbit. <strong>L4</strong> and <strong>L5</strong> lead and
+        trail the secondary by 60° and are the stable points where Trojan bodies gather; <strong>L1</strong>,
+        <strong>L2</strong> and <strong>L3</strong> lie along the primary–secondary line.
+      </p>
+      <p>
+        Filled dots are real bodies in this system@if (focusedNote) {, with <strong>{{ focusedNote }}</strong> highlighted};
+        dashed circles are unoccupied points shown for reference.
+      </p>
+    </div>
+  </div>
+</app-dialog-shell>

--- a/src/app/dialogs/lagrange-dialog/lagrange-dialog.component.scss
+++ b/src/app/dialogs/lagrange-dialog/lagrange-dialog.component.scss
@@ -1,0 +1,100 @@
+.lagrange-dialog {
+    .diagram {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 16px;
+    }
+
+    .lagrange-diagram {
+        width: 420px;
+        max-width: 100%;
+        height: auto;
+        // Subtle backdrop so light strokes stay legible on any theme.
+        background: var(--color-surface-2);
+        border-radius: 8px;
+        // Generous padding + visible overflow so edge labels are never clipped.
+        padding: 20px;
+        overflow: visible;
+
+        line,
+        circle {
+            vector-effect: non-scaling-stroke;
+        }
+
+        .orbit {
+            fill: none;
+            stroke: var(--color-text-muted);
+            stroke-width: 1;
+            opacity: 0.6;
+        }
+
+        .axis-reference {
+            stroke: var(--color-text-muted);
+            stroke-width: 1;
+            stroke-dasharray: 4 3;
+            opacity: 0.6;
+        }
+
+        .primary {
+            fill: var(--color-warning);
+            stroke: var(--color-text-bright);
+            stroke-width: 1;
+        }
+
+        // A real body occupying a Lagrange point or the secondary slot.
+        .body {
+            fill: var(--color-info);
+            stroke: var(--color-text-bright);
+            stroke-width: 1;
+
+            &.focus {
+                fill: var(--color-accent);
+                stroke-width: 1.5;
+            }
+        }
+
+        // An unoccupied Lagrange point / missing secondary.
+        .placeholder {
+            fill: none;
+            stroke: var(--color-text-muted);
+            stroke-width: 1.25;
+            stroke-dasharray: 3 2;
+        }
+
+        // The "Lx" caption on each point (and the "secondary" placeholder caption).
+        .point-label {
+            fill: var(--color-text-muted);
+            font-size: 5px;
+            font-weight: 700;
+            paint-order: stroke;
+            stroke: var(--color-surface-2);
+            stroke-width: 1.75px;
+            stroke-linejoin: round;
+        }
+
+        // Real body names dropped onto the diagram.
+        .body-name,
+        .primary-name {
+            fill: var(--color-text-bright);
+            font-size: 4.5px;
+            font-weight: 600;
+            paint-order: stroke;
+            stroke: var(--color-surface-2);
+            stroke-width: 1.5px;
+            stroke-linejoin: round;
+        }
+
+        .body-name.focus {
+            fill: var(--color-accent);
+            font-weight: 700;
+        }
+    }
+
+    .explanation {
+        line-height: 1.6;
+
+        p {
+            margin-bottom: 8px;
+        }
+    }
+}

--- a/src/app/dialogs/lagrange-dialog/lagrange-dialog.component.spec.ts
+++ b/src/app/dialogs/lagrange-dialog/lagrange-dialog.component.spec.ts
@@ -1,0 +1,105 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+import { LagrangeConfiguration } from '../../data/orbital-relations.service';
+import { LagrangeDialogComponent, LagrangeDialogData } from './lagrange-dialog.component';
+
+function setup(config: LagrangeConfiguration, systemName = ''): ComponentFixture<LagrangeDialogComponent> {
+  const data: LagrangeDialogData = { config, systemName };
+  TestBed.configureTestingModule({
+    imports: [LagrangeDialogComponent],
+    providers: [provideZonelessChangeDetection(), { provide: MAT_DIALOG_DATA, useValue: data }],
+  });
+  const fixture = TestBed.createComponent(LagrangeDialogComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+const EORLD_SYSTEM = 'Eorld Byio AA-A h539';
+
+/**
+ * A host configuration: a focused secondary with Trojans at L4 and L5 (Eorld Byio shape).
+ * Names are full (system-prefixed) display names, as the caller passes them.
+ */
+function hostConfig(): LagrangeConfiguration {
+  return {
+    primaryName: 'Eorld Byio AA-A h539 A',
+    secondary: { name: 'Eorld Byio AA-A h539 barycentre 35', bodyId: 35, isFocus: true },
+    points: {
+      L1: [], L2: [], L3: [],
+      L4: [{ name: 'Eorld Byio AA-A h539 A 18', bodyId: 38, isFocus: false }],
+      L5: [{ name: 'Eorld Byio AA-A h539 A 19', bodyId: 39, isFocus: false }],
+    },
+  };
+}
+
+/** A lone ±60° pair with no host: secondary slot is a placeholder, focus on the L5 body. */
+function lonePairConfig(): LagrangeConfiguration {
+  return {
+    primaryName: 'Pro Eurl JF-A d88 B',
+    secondary: null,
+    points: {
+      L1: [], L2: [], L3: [],
+      L4: [{ name: 'Pro Eurl JF-A d88 B 3', bodyId: 33, isFocus: false }],
+      L5: [{ name: 'Pro Eurl JF-A d88 B 2', bodyId: 30, isFocus: true }],
+    },
+  };
+}
+
+describe('LagrangeDialogComponent', () => {
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('renders a viewBox and all five Lagrange markers in order', () => {
+    const c = setup(hostConfig(), EORLD_SYSTEM).componentInstance;
+    expect(c.title).toBe('Lagrange points');
+    expect(c.viewBox).toBe('0 0 120 120');
+    expect(c.markers().map(m => m.id)).toEqual(['L1', 'L2', 'L3', 'L4', 'L5']);
+    // The computed fuses occupancy onto the geometry.
+    expect(c.markers().find(m => m.id === 'L4')!.occupants).toHaveLength(1);
+    expect(c.markers().find(m => m.id === 'L1')!.occupants).toHaveLength(0);
+  });
+
+  it('draws real bodies as filled markers and empty points as placeholders', () => {
+    const el = setup(hostConfig(), EORLD_SYSTEM).nativeElement as HTMLElement;
+    // Secondary + L4 + L5 are occupied (3 bodies); L1/L2/L3 are placeholders (3).
+    expect(el.querySelectorAll('circle.body')).toHaveLength(3);
+    expect(el.querySelectorAll('circle.placeholder')).toHaveLength(3);
+    // The focused (clicked) body — the secondary host here — is highlighted exactly once.
+    expect(el.querySelectorAll('.focus')).not.toHaveLength(0);
+    expect(el.querySelectorAll('circle.body.focus')).toHaveLength(1);
+  });
+
+  it('uses short (system-stripped) names in the diagram but full names in the description', () => {
+    const el = setup(hostConfig(), EORLD_SYSTEM).nativeElement as HTMLElement;
+    const svgText = el.querySelector('svg')!.textContent ?? '';
+    const explanation = el.querySelector('.explanation')!.textContent ?? '';
+
+    // Diagram: short names, with the repeated system prefix dropped.
+    expect(svgText).toContain('A 18');
+    expect(svgText).toContain('barycentre 35');
+    expect(svgText).not.toContain('Eorld Byio AA-A h539 A 18');
+    // Description: the full (system-prefixed) name of the focused body.
+    expect(explanation).toContain('Eorld Byio AA-A h539 barycentre 35');
+  });
+
+  it('shows a placeholder secondary (with caption) when no host is recorded', () => {
+    const el = setup(lonePairConfig(), 'Pro Eurl JF-A d88').nativeElement as HTMLElement;
+    // L1/L2/L3 + the empty secondary slot = 4 placeholders; L4 + L5 are bodies.
+    expect(el.querySelectorAll('circle.placeholder')).toHaveLength(4);
+    expect(el.querySelectorAll('circle.body')).toHaveLength(2);
+    const svgText = el.querySelector('svg')!.textContent ?? '';
+    expect(svgText).toContain('secondary');
+    expect(svgText).toContain('B 2'); // short
+  });
+
+  it('reports the focused body full name for the explanatory note', () => {
+    expect(setup(hostConfig(), EORLD_SYSTEM).componentInstance.focusedNote)
+      .toBe('Eorld Byio AA-A h539 barycentre 35');
+  });
+
+  it('reports the focused Lagrange-point body full name for the explanatory note', () => {
+    expect(setup(lonePairConfig(), 'Pro Eurl JF-A d88').componentInstance.focusedNote)
+      .toBe('Pro Eurl JF-A d88 B 2');
+  });
+});

--- a/src/app/dialogs/lagrange-dialog/lagrange-dialog.component.ts
+++ b/src/app/dialogs/lagrange-dialog/lagrange-dialog.component.ts
@@ -1,0 +1,83 @@
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { DialogShellComponent } from '../dialog-shell/dialog-shell.component';
+import { LagrangeConfiguration, LagrangeOccupant, LagrangePointId } from '../../data/orbital-relations.service';
+import { LagrangeMarker, VIEW_BOX_SIZE, lagrangeDiagram } from '../../data/orbital-diagrams';
+
+export interface LagrangeDialogData {
+  /** The resolved co-orbital family, names already mapped to display names by the caller. */
+  config: LagrangeConfiguration;
+  /**
+   * The system name, stripped from body names for the cramped diagram only. The
+   * description below the diagram keeps the full names.
+   */
+  systemName: string;
+}
+
+/** A diagram marker fused with whichever bodies occupy that Lagrange point. */
+export interface RenderedMarker extends LagrangeMarker {
+  occupants: LagrangeOccupant[];
+}
+
+/**
+ * Standalone modal that draws the five Lagrange points of a co-orbital family on the
+ * canonical schematic (primary at the centre, secondary on the orbit, L1–L5 in their
+ * textbook positions). Real bodies are dropped onto the points they occupy — with the
+ * body the dialog was opened from highlighted — and unoccupied points are drawn as
+ * dashed placeholders. Opened from the Trojan / Host badges via MatDialog.
+ */
+@Component({
+  selector: 'app-lagrange-dialog',
+  templateUrl: './lagrange-dialog.component.html',
+  styleUrls: ['./lagrange-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DialogShellComponent],
+})
+export class LagrangeDialogComponent {
+  readonly data = inject<LagrangeDialogData>(MAT_DIALOG_DATA);
+  readonly diagram = lagrangeDiagram();
+  readonly viewBox = `0 0 ${VIEW_BOX_SIZE} ${VIEW_BOX_SIZE}`;
+  readonly title = 'Lagrange points';
+
+  /** Each diagram marker fused with the bodies occupying that point, in L1…L5 order. */
+  readonly markers = computed<RenderedMarker[]>(() =>
+    this.diagram.markers.map(marker => ({
+      ...marker,
+      occupants: this.data.config.points[marker.id as LagrangePointId] ?? [],
+    })),
+  );
+
+  /**
+   * The compact name for the diagram: the display name with the (repeated) system-name
+   * prefix dropped — e.g. "Eorld Byio AA-A h539 A 18" → "A 18". Falls back to the full name
+   * when it doesn't carry the prefix (or stripping would leave nothing).
+   */
+  short(name: string): string {
+    const system = this.data.systemName;
+    if (system && name.toLowerCase().startsWith(system.toLowerCase())) {
+      return name.slice(system.length).trim() || name;
+    }
+    return name;
+  }
+
+  /** Comma-separated short occupant names for a diagram slot (empty for a placeholder). */
+  shortNames(occupants: LagrangeOccupant[]): string {
+    return occupants.map(o => this.short(o.name)).join(', ');
+  }
+
+  /** True when any occupant of a slot is the focused (clicked) body. */
+  hasFocus(occupants: LagrangeOccupant[]): boolean {
+    return occupants.some(o => o.isFocus);
+  }
+
+  /** Display name of the focused (clicked) body, for the explanatory note — '' if none. */
+  get focusedNote(): string {
+    const { secondary, points } = this.data.config;
+    if (secondary?.isFocus) { return secondary.name; }
+    for (const slot of Object.values(points)) {
+      const focused = slot.find(o => o.isFocus);
+      if (focused) { return focused.name; }
+    }
+    return '';
+  }
+}

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -67,11 +67,12 @@
       <span class="badge badge-gray">Terraformable</span>
       }
       @if (trojanHostStatus) {
-      <span class="badge badge-blue"
-        matTooltip="Co-orbital primary: this body has companions at its L4 and L5 Lagrange points">Host</span>
+      <span class="badge badge-blue clickable" (click)="showLagrangeDialog()"
+        matTooltip="Co-orbital primary: this body has companions at its L4 and L5 Lagrange points — click for the diagram">Host</span>
       }
       @if (trojanStatus) {
-      <span class="badge badge-blue" [matTooltip]="'Trojan at Lagrange ' + trojanStatus">{{
+      <span class="badge badge-blue clickable" (click)="showLagrangeDialog()"
+        [matTooltip]="'Trojan at Lagrange ' + trojanStatus + ' — click for the diagram'">{{
         trojanStatus }}</span>
       }
       @if (rosetteStatus) {

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -12,7 +12,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ClickableDirective } from '../clickable.directive';
 import { BodyPhysicsService, RingDynamics, ShepherdingHillLimit, BodyRocheLimits, PlanetaryDensity, MassStabilityAlert, SPEED_OF_LIGHT } from '../data/body-physics.service';
 import { StellarPhysicsService } from '../data/stellar-physics.service';
-import { OrbitalRelationsService, CollisionStatus } from '../data/orbital-relations.service';
+import { OrbitalRelationsService, CollisionStatus, LagrangeConfiguration, LagrangeOccupant } from '../data/orbital-relations.service';
 import { RocheChartData, HillChartData } from '../data/chart-rendering.service';
 import { BODY_TYPE } from '../data/body-types';
 import { WHITE_DWARF_CLASSES, whiteDwarfSpectralCode, whiteDwarfSpectralTypeKey } from '../data/white-dwarf';
@@ -27,6 +27,7 @@ import type { CollisionBodyInfo, CollisionDialogData } from '../dialogs/collisio
 import type { SynodicDiagramInput } from '../data/collision-diagram';
 import type { JsonDialogData } from '../dialogs/json-dialog/json-dialog.component';
 import { formatBodyJson } from '../dialogs/json-dialog/format-body-json';
+import type { LagrangeDialogData } from '../dialogs/lagrange-dialog/lagrange-dialog.component';
 import type { OnFootSafetyDialogData } from '../dialogs/on-foot-safety-dialog/on-foot-safety-dialog.component';
 import { StellarAgeAssessment, assessStellarAge, isPlottableStarClass } from '../data/stellar-reference';
 
@@ -1481,6 +1482,42 @@ export class SystemBodyComponent implements OnChanges {
   public collisionStatus: CollisionStatus | null = null;
   /** The body `collisionStatus` was last computed for, to skip recompute on unrelated re-renders. */
   private collisionBody: SystemBody | null = null;
+
+  /**
+   * Opens the Lagrange-points diagram for this body's co-orbital family. Resolves the
+   * configuration from the service, maps every body name to its display name (stripping the
+   * system prefix), and hands it to the dialog. No-op when the body isn't part of a
+   * detectable Trojan/Lagrange configuration.
+   */
+  public async showLagrangeDialog(): Promise<void> {
+    const config = this.orbitalRelations.lagrangeConfiguration(this.body());
+    if (!config) { return; }
+
+    // Map raw names to full display names. The dialog drops the (repeated) system-name
+    // prefix for the cramped diagram itself but keeps the full names in its description.
+    const toDisplay = (occupant: LagrangeOccupant): LagrangeOccupant =>
+      ({ ...occupant, name: this.getBodyDisplayName(occupant.name) });
+    const points = { L1: [], L2: [], L3: [], L4: [], L5: [] } as LagrangeConfiguration['points'];
+    for (const id of ['L1', 'L2', 'L3', 'L4', 'L5'] as const) {
+      points[id] = config.points[id].map(toDisplay);
+    }
+    const displayConfig: LagrangeConfiguration = {
+      primaryName: config.primaryName ? this.getBodyDisplayName(config.primaryName) : null,
+      secondary: config.secondary ? toDisplay(config.secondary) : null,
+      points,
+    };
+    const data: LagrangeDialogData = { config: displayConfig, systemName: this.edGalaxyData()?.Name ?? '' };
+
+    const { LagrangeDialogComponent } = await import('../dialogs/lagrange-dialog/lagrange-dialog.component');
+    this.dialog.open(LagrangeDialogComponent, {
+      width: '900px',
+      maxWidth: '95vw',
+      autoFocus: 'first-heading',
+      hasBackdrop: true,
+      backdropClass: 'cdk-overlay-dark-backdrop',
+      data,
+    });
+  }
   public readonly getEstimatedTempRange = signal<{ min: number; max: number } | null>(null);
   public readonly getLandableBadgeClass = signal('badge-gray');
   public readonly getLandableTooltip = signal('');


### PR DESCRIPTION
## What

Adds an interactive **Lagrange points** dialog, opened by clicking a body's **Trojan** (L1–L5) or **Host** badge. The diagram places the real co-orbital bodies at the points they occupy and draws dashed placeholders for the rest.

<img width="1374" height="1076" alt="image" src="https://github.com/user-attachments/assets/009fb1c6-3aae-4573-9df9-35336b4c6faa" />
<img width="1384" height="1104" alt="image" src="https://github.com/user-attachments/assets/deb4ae2f-c42e-4fe4-bc3e-6f002340599b" />

## How

- **`orbital-relations.service`** — `lagrangeConfiguration()` resolves a body's co-orbital family into a `{ primaryName, secondary, points: {L1…L5} }` structure, reusing `detectTrojanStatus` so the diagram always matches the badges. Narrows `TrojanStatus.lagrangePoint` to a `LagrangePointId` union.
- **Barycentre centres are excluded** — a Lagrange configuration needs a real massive central body to define its points relative to. When a family's shared parent is a barycentre (the centre of mass of a binary, not a body that can host Lagrange points), `detectTrojanStatus`/`lagrangeConfiguration` return no status, so no badge and no diagram are shown.
- **`orbital-diagrams`** — `lagrangeDiagram()` builds the canonical five-point schematic (primary centred, secondary on the orbit, L4/L5 at ±60°). Labels are staggered so the primary and secondary captions never overlap.
- **`lagrange-dialog`** — new standalone, lazy-loaded dialog reusing `DialogShellComponent`. The diagram drops the repeated system-name prefix from body names to save space; the description below keeps the full names.
- **System-body** — Trojan/Host badges are now clickable and open the dialog.

## Empirical grounding

Real systems are added as fixtures and used in tests:

| System | Configuration |
|---|---|
| Pro Eurl JF-A d88 | L4/L5 pair |
| Prooe Bli FQ-R c19-2 | L4/L5 pair |
| Truecho NE-P c22-0 | L4/L5 pair |
| Pipe (stem) Sector DL-Y d17 | L4/L5 pair |
| Eorld Byio AA-A h539 | **Host** with companions at both L4 and L5 |
| Cloomoo IL-Y e1 | 180° L3 binary orbiting a **barycentre** → suppressed (no badge) |

The L4/L5/Host systems confirm Elite encodes the co-orbital offset entirely in `argOfPeriapsis`, holding Ω (ascendingNode) and M (meanAnomaly) equal across siblings — so the existing `argOfPeriapsis`-only detection is exact, not just a heuristic. Cloomoo IL-Y e1 C/D are a geometric 180° (L3) pair, but they orbit their mutual barycentre, so the configuration is deliberately suppressed rather than drawn around a non-body centre. The corresponding TODO item is removed.

## Tests

- **Unit**: service config resolution (incl. the barycentre-suppression case), diagram geometry, and dialog rendering (incl. short-in-diagram / full-in-description name handling). 614 unit tests pass.
- **e2e**: badge rendering + dialog interaction (host highlighted, L4/L5 companions, system-prefix stripping, lone-pair placeholder secondary) plus the barycentre-binary "no badge" case, across Chromium, Firefox, and mobile.
- `ng build` clean.

## Notes

A lone ±60° pair with no recorded host draws the secondary slot as a labelled placeholder rather than promoting one body into it — the two real Trojans still appear at L4/L5. Open to changing this if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
