### PR TITLE
Multi-body collisions and a distance-over-time diagram in the collision dialog

### DIFF
--- a/e2e/collision-multi-body.spec.ts
+++ b/e2e/collision-multi-body.spec.ts
@@ -42,17 +42,18 @@ test.describe('multi-body collisions (Eoch Flyuae YK-K c10-56 1 b)', () => {
     const dialog = await openCollisionDialog(page, BODY_1B);
     await expect(dialog.getByRole('heading', { name: /Collision/ })).toBeVisible();
 
-    // The two contacts that share the 2026-10-28 conjunction are both flagged "multi".
+    // The two contacts that share the 2026-10-28 conjunction are both flagged "multi", and each
+    // row names BOTH involved bodies (this body ↔ partner), not just the partner.
     const withC = rowAt(dialog, '2026-10-28 13:01 UTC');
     await expect(withC).toHaveClass(/multi/);
     await expect(withC.locator('.multi-tag')).toBeVisible();
-    await expect(withC).toContainText('1 c');
+    await expect(withC.locator('td.bodies')).toContainText('1 b ↔ 1 c');
     await expect(withC).toContainText('82.9%');
 
     const withA = rowAt(dialog, '2026-10-28 15:06 UTC');
     await expect(withA).toHaveClass(/multi/);
     await expect(withA.locator('.multi-tag')).toBeVisible();
-    await expect(withA).toContainText('1 a');
+    await expect(withA.locator('td.bodies')).toContainText('1 b ↔ 1 a');
     await expect(withA).toContainText('46.9%');
 
     // A neighbouring single-partner contact must NOT be flagged — the highlight discriminates.
@@ -67,5 +68,26 @@ test.describe('multi-body collisions (Eoch Flyuae YK-K c10-56 1 b)', () => {
     const cluster = section.locator('li').filter({ hasText: '2026-10-28 13:01 UTC' });
     await expect(cluster).toContainText('Eoch Flyuae YK-K c10-56 1 b, 1 a, 1 c');
     await expect(cluster).toContainText('9 days');
+  });
+
+  test('renders the distance-over-time diagram with a curve per colliding partner', async ({ page }) => {
+    await loadFixtureSystem(page, SYSTEM);
+    const dialog = await openCollisionDialog(page, BODY_1B);
+
+    const chart = dialog.locator('svg.separation-chart');
+    await expect(chart).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: 'Distance over time' })).toBeVisible();
+
+    // One separation curve, threshold line and "now" marker per directly-colliding partner
+    // (1 b collides with both 1 a and 1 c here).
+    await expect(chart.locator('polyline.curve')).toHaveCount(2);
+    await expect(chart.locator('line.threshold')).toHaveCount(2);
+    await expect(chart.locator('line.now-line')).toHaveCount(1);
+    await expect(chart.locator('path.marker').first()).toBeVisible();
+
+    // The legend pairs this body with each partner.
+    const legend = dialog.locator('.legend');
+    await expect(legend).toContainText('1 b ↔ 1 a');
+    await expect(legend).toContainText('1 b ↔ 1 c');
   });
 });

--- a/e2e/collision-multi-body.spec.ts
+++ b/e2e/collision-multi-body.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect, type Page, type Locator } from '@playwright/test';
+import { loadFixtureSystem } from './support/system-fixture';
+
+/**
+ * Multi-body collision rendering for the real system Eoch Flyuae YK-K c10-56, whose moons
+ * 1 a / 1 b / 1 c share crossing orbits. Viewed from body 1 b, two of its upcoming contacts
+ * fall in the same conjunction on 2026-10-28 — one with 1 c and one with 1 a — so both rows
+ * are flagged as a simultaneous (three-body) collision and a combined entry is listed.
+ *
+ * "Now" is pinned to 2026-10-20 — a week before that conjunction — so the simultaneous contacts
+ * fall within the first few upcoming rows (rather than ~20 rows out from an earlier date), making
+ * them visible under the dialog's 10-row cap.
+ */
+const SYSTEM = {
+  fixture: 'eoch-flyuae-yk-k-c10-56.json',
+  systemName: 'Eoch Flyuae YK-K c10-56',
+  id64: 15463257612378,
+  fixedTime: '2026-10-20T00:00:00Z',
+};
+
+/** bodyId of "Eoch Flyuae YK-K c10-56 1 b" in the fixture. */
+const BODY_1B = 10;
+
+/** Opens the collision dialog from a body's "Collision" badge and returns the dialog locator. */
+async function openCollisionDialog(page: Page, bodyId: number): Promise<Locator> {
+  // Scope to the body's OWN header (direct child) so a nested child body's badge can't match.
+  await page.locator(`#body-${bodyId} > .body-title .badge-red`).click();
+  const dialog = page.locator('app-collision-dialog');
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+/** A row in the upcoming-collisions table identified by its (unique) contact-start timestamp. */
+function rowAt(dialog: Locator, startUtc: string): Locator {
+  return dialog.locator('.upcoming-collisions tbody tr').filter({ hasText: startUtc });
+}
+
+test.describe('multi-body collisions (Eoch Flyuae YK-K c10-56 1 b)', () => {
+  test('flags coincident contacts as a simultaneous collision and lists the cluster', async ({ page }) => {
+    await loadFixtureSystem(page, SYSTEM);
+
+    const dialog = await openCollisionDialog(page, BODY_1B);
+    await expect(dialog.getByRole('heading', { name: /Collision/ })).toBeVisible();
+
+    // The two contacts that share the 2026-10-28 conjunction are both flagged "multi".
+    const withC = rowAt(dialog, '2026-10-28 13:01 UTC');
+    await expect(withC).toHaveClass(/multi/);
+    await expect(withC.locator('.multi-tag')).toBeVisible();
+    await expect(withC).toContainText('1 c');
+    await expect(withC).toContainText('82.9%');
+
+    const withA = rowAt(dialog, '2026-10-28 15:06 UTC');
+    await expect(withA).toHaveClass(/multi/);
+    await expect(withA.locator('.multi-tag')).toBeVisible();
+    await expect(withA).toContainText('1 a');
+    await expect(withA).toContainText('46.9%');
+
+    // A neighbouring single-partner contact must NOT be flagged — the highlight discriminates.
+    const lone = rowAt(dialog, '2026-10-21 18:23 UTC');
+    await expect(lone).not.toHaveClass(/multi/);
+    await expect(lone.locator('.multi-tag')).toHaveCount(0);
+    await expect(lone).toContainText('1 a');
+
+    // The dedicated "Simultaneous collisions" section names every body in the pile-up at once.
+    const section = dialog.locator('.multi-collisions');
+    await expect(section.getByRole('heading', { name: 'Simultaneous collisions' })).toBeVisible();
+    const cluster = section.locator('li').filter({ hasText: '2026-10-28 13:01 UTC' });
+    await expect(cluster).toContainText('Eoch Flyuae YK-K c10-56 1 b, 1 a, 1 c');
+    await expect(cluster).toContainText('9 days');
+  });
+});

--- a/e2e/collision-performance.spec.ts
+++ b/e2e/collision-performance.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { loadFixtureSystem } from './support/system-fixture';
+
+/**
+ * Performance guard for the 3D collision-candidate search.
+ *
+ * `OrbitalRelationsService.detectCollisionStatus` runs a synchronous orbit-to-orbit
+ * proximity scan for every crossing-orbit sibling of every body, on the main thread,
+ * during render. A past regression made the coarse sampling step adaptive down to a
+ * 0.05° floor, which for any orbit beyond ~0.1 AU exploded the inner double-loop to
+ * 7200² ≈ 52M iterations (~200 ms) *per sibling pair* — freezing the UI for seconds.
+ *
+ * This test loads {@link FIXTURE}, a synthetic system of five planets that share one
+ * orbit (so every pair is a guaranteed collision candidate) at 1 AU with small radii —
+ * exactly the geometry that drove the step to its floor. It then asserts, via the
+ * browser's Long Tasks API, that no single main-thread task during the render exceeds
+ * {@link MAX_TASK_MS}. With the regression this fixture blocks for several seconds in a
+ * single task; with the bounded grid it stays well under the budget (tens of ms of
+ * collision work). This is the "time limit for operations": rendering a collision-heavy
+ * system must never monopolise the main thread past the budget.
+ *
+ * Chromium-only: the Long Tasks API (`PerformanceObserver` with `entryType: 'longtask'`)
+ * is not implemented in Firefox.
+ */
+
+const FIXTURE = {
+  fixture: 'collision-stress.json',
+  systemName: 'Collision Stress Test',
+  id64: 1234567890123,
+};
+
+/**
+ * Budget for the longest single main-thread task. The regression produced multi-second
+ * tasks; the fixed code's collision work is tens of ms on top of normal Angular render.
+ * 1000 ms sits far above normal render (no flakiness) yet far below the seconds-long
+ * freeze a reintroduced O(N²) blow-up would cause on this many-candidate fixture.
+ */
+const MAX_TASK_MS = 1000;
+
+test.describe('collision-detection performance (fixture)', () => {
+  test.skip(({ browserName }) => browserName !== 'chromium', 'Long Tasks API is Chromium-only');
+
+  test('rendering a collision-heavy system never blocks the main thread past the budget', async ({ page }) => {
+    // Install the observer before any app code runs so the render's long tasks are captured.
+    await page.addInitScript(() => {
+      (window as unknown as { __longTasks: number[] }).__longTasks = [];
+      new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          (window as unknown as { __longTasks: number[] }).__longTasks.push(entry.duration);
+        }
+      }).observe({ entryTypes: ['longtask'] });
+    });
+
+    await loadFixtureSystem(page, FIXTURE);
+
+    // The collision badge only appears once the expensive 3D search has run for these
+    // bodies, so its presence proves the guarded operation actually executed (rather
+    // than the test passing because nothing was computed). Every planet shares an orbit,
+    // so all five are flagged.
+    const badges = page.locator('.badge-red', { hasText: 'Collision' });
+    await expect(badges.first()).toBeVisible({ timeout: 30_000 });
+    await expect(badges).toHaveCount(5);
+
+    // Long Tasks are delivered to the observer asynchronously after the task ends; poll so
+    // a late-arriving entry can still fail the assertion. The longest task only grows as
+    // entries arrive, so a stable max under budget is a genuine pass.
+    await expect
+      .poll(
+        () => page.evaluate(() => Math.max(0, ...(window as unknown as { __longTasks: number[] }).__longTasks)),
+        {
+          timeout: 5_000,
+          message: `longest main-thread task should stay under ${MAX_TASK_MS} ms during collision-heavy render`,
+        },
+      )
+      .toBeLessThan(MAX_TASK_MS);
+  });
+});

--- a/e2e/fixtures/collision-stress.json
+++ b/e2e/fixtures/collision-stress.json
@@ -1,0 +1,163 @@
+{
+ "system": {
+  "name": "Collision Stress Test",
+  "id64": 1234567890123,
+  "region": "Inner Orion Spur",
+  "bodyCount": 6,
+  "coords": {
+   "x": 0.0,
+   "y": 0.0,
+   "z": 0.0
+  },
+  "date": "2026-06-01 00:00:00+00",
+  "stations": [],
+  "bodies": [
+   {
+    "bodyId": 0,
+    "name": "Collision Stress Test A",
+    "type": "Star",
+    "subType": "G (White-Yellow) Star",
+    "mainStar": true,
+    "id64": 1234567890123,
+    "distanceToArrival": 0.0,
+    "solarMasses": 1.0,
+    "solarRadius": 1.0,
+    "surfaceTemperature": 5800.0,
+    "age": 4600,
+    "rotationalPeriod": 25.0,
+    "absoluteMagnitude": 4.83,
+    "luminosity": "V"
+   },
+   {
+    "bodyId": 1,
+    "name": "Collision Stress Test 1",
+    "type": "Planet",
+    "subType": "High metal content body",
+    "id64": 1234567890124,
+    "isLandable": false,
+    "distanceToArrival": 500.0,
+    "radius": 6000.0,
+    "gravity": 9.8,
+    "earthMasses": 1.0,
+    "surfaceTemperature": 300.0,
+    "rotationalPeriod": 1.0,
+    "axialTilt": 0.0,
+    "semiMajorAxis": 1.0,
+    "orbitalPeriod": 100.0,
+    "orbitalEccentricity": 0.05,
+    "argOfPeriapsis": 30.0,
+    "ascendingNode": 0.0,
+    "orbitalInclination": 0.5,
+    "parents": [
+     {
+      "Star": 0
+     }
+    ]
+   },
+   {
+    "bodyId": 2,
+    "name": "Collision Stress Test 2",
+    "type": "Planet",
+    "subType": "High metal content body",
+    "id64": 1234567890125,
+    "isLandable": false,
+    "distanceToArrival": 501.0,
+    "radius": 6000.0,
+    "gravity": 9.8,
+    "earthMasses": 1.0,
+    "surfaceTemperature": 300.0,
+    "rotationalPeriod": 1.0,
+    "axialTilt": 0.0,
+    "semiMajorAxis": 1.0,
+    "orbitalPeriod": 101.7,
+    "orbitalEccentricity": 0.05,
+    "argOfPeriapsis": 30.0,
+    "ascendingNode": 0.0,
+    "orbitalInclination": 0.5,
+    "parents": [
+     {
+      "Star": 0
+     }
+    ]
+   },
+   {
+    "bodyId": 3,
+    "name": "Collision Stress Test 3",
+    "type": "Planet",
+    "subType": "High metal content body",
+    "id64": 1234567890126,
+    "isLandable": false,
+    "distanceToArrival": 502.0,
+    "radius": 6000.0,
+    "gravity": 9.8,
+    "earthMasses": 1.0,
+    "surfaceTemperature": 300.0,
+    "rotationalPeriod": 1.0,
+    "axialTilt": 0.0,
+    "semiMajorAxis": 1.0,
+    "orbitalPeriod": 99.1,
+    "orbitalEccentricity": 0.05,
+    "argOfPeriapsis": 30.0,
+    "ascendingNode": 0.0,
+    "orbitalInclination": 0.5,
+    "parents": [
+     {
+      "Star": 0
+     }
+    ]
+   },
+   {
+    "bodyId": 4,
+    "name": "Collision Stress Test 4",
+    "type": "Planet",
+    "subType": "High metal content body",
+    "id64": 1234567890127,
+    "isLandable": false,
+    "distanceToArrival": 503.0,
+    "radius": 6000.0,
+    "gravity": 9.8,
+    "earthMasses": 1.0,
+    "surfaceTemperature": 300.0,
+    "rotationalPeriod": 1.0,
+    "axialTilt": 0.0,
+    "semiMajorAxis": 1.0,
+    "orbitalPeriod": 102.3,
+    "orbitalEccentricity": 0.05,
+    "argOfPeriapsis": 30.0,
+    "ascendingNode": 0.0,
+    "orbitalInclination": 0.5,
+    "parents": [
+     {
+      "Star": 0
+     }
+    ]
+   },
+   {
+    "bodyId": 5,
+    "name": "Collision Stress Test 5",
+    "type": "Planet",
+    "subType": "High metal content body",
+    "id64": 1234567890128,
+    "isLandable": false,
+    "distanceToArrival": 504.0,
+    "radius": 6000.0,
+    "gravity": 9.8,
+    "earthMasses": 1.0,
+    "surfaceTemperature": 300.0,
+    "rotationalPeriod": 1.0,
+    "axialTilt": 0.0,
+    "semiMajorAxis": 1.0,
+    "orbitalPeriod": 98.5,
+    "orbitalEccentricity": 0.05,
+    "argOfPeriapsis": 30.0,
+    "ascendingNode": 0.0,
+    "orbitalInclination": 0.5,
+    "parents": [
+     {
+      "Star": 0
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/e2e/fixtures/eoch-flyuae-yk-k-c10-56.json
+++ b/e2e/fixtures/eoch-flyuae-yk-k-c10-56.json
@@ -1,0 +1,1494 @@
+{
+  "system": {
+    "allegiance": null, 
+    "bodies": [
+      {
+        "absoluteMagnitude": 8.376114, 
+        "age": 1840, 
+        "axialTilt": 0.0, 
+        "belts": [
+          {
+            "innerRadius": 801660000.0, 
+            "mass": 98757000000000.0, 
+            "name": "Eoch Flyuae YK-K c10-56 A Belt", 
+            "outerRadius": 2057100000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "bodyId": 0, 
+        "distanceToArrival": 0.0, 
+        "id64": 15463257612378, 
+        "luminosity": "Va", 
+        "mainStar": true, 
+        "name": "Eoch Flyuae YK-K c10-56", 
+        "rotationalPeriod": 2.51640478831019, 
+        "rotationalPeriodTidallyLocked": false, 
+        "solarMasses": 0.472656, 
+        "solarRadius": 0.575134228612509, 
+        "spectralClass": "M1", 
+        "stations": [], 
+        "subType": "M (Red dwarf) Star", 
+        "surfaceTemperature": 3368.0, 
+        "timestamps": {
+          "distanceToArrival": "2026-06-23T11:53:52Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2026-06-23 11:53:52+00"
+      }, 
+      {
+        "argOfPeriapsis": 347.910906, 
+        "ascendingNode": 125.685637, 
+        "bodyId": 5, 
+        "id64": 180159448352432218, 
+        "meanAnomaly": 139.970609, 
+        "name": "Eoch Flyuae YK-K c10-56 barycentre 5", 
+        "orbitalEccentricity": 6e-06, 
+        "orbitalInclination": -0.004621, 
+        "orbitalPeriod": 1.32951243884259, 
+        "semiMajorAxis": 0.0185188091537789, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-06-23T11:53:53Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-06-23 11:53:53+00"
+      }, 
+      {
+        "argOfPeriapsis": 52.228841, 
+        "ascendingNode": 156.755936, 
+        "atmosphereComposition": {
+          "Helium": 29.718277, 
+          "Hydrogen": 70.281738
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -2.223283, 
+        "bodyId": 6, 
+        "distanceToArrival": 9.241025, 
+        "earthMasses": 28.623463, 
+        "gravity": 1.92208004486591, 
+        "id64": 216188245371396186, 
+        "isLandable": false, 
+        "meanAnomaly": 57.496016, 
+        "name": "Eoch Flyuae YK-K c10-56 1", 
+        "orbitalEccentricity": 0.197156, 
+        "orbitalInclination": -5.511762, 
+        "orbitalPeriod": 0.278850230902778, 
+        "parents": [
+          {
+            "Null": 5
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 24601.522, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "innerRadius": 36926000.0, 
+            "mass": 14780000000.0, 
+            "name": "Eoch Flyuae YK-K c10-56 1 A Ring", 
+            "outerRadius": 36930000.0, 
+            "type": "Rocky"
+          }, 
+          {
+            "innerRadius": 36930000.0, 
+            "mass": 298840000000.0, 
+            "name": "Eoch Flyuae YK-K c10-56 1 B Ring", 
+            "outerRadius": 36935000.0, 
+            "type": "Metal Rich"
+          }
+        ], 
+        "rotationalPeriod": 0.556479123148148, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 5.63669123576637e-06, 
+        "stations": [], 
+        "subType": "Class IV gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 826.045044, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-23T11:53:53Z", 
+          "meanAnomaly": "2026-06-23T11:53:53Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-23 11:53:53+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 237.157193, 
+        "ascendingNode": 113.296374, 
+        "atmosphereType": null, 
+        "axialTilt": -1.729856, 
+        "bodyId": 9, 
+        "distanceToArrival": 9.350555, 
+        "earthMasses": 0.000691, 
+        "gravity": 0.0724332619557459, 
+        "id64": 324274636428288090, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.503803, 
+          "Carbon": 15.998566, 
+          "Chromium": 8.709219, 
+          "Iron": 19.365301, 
+          "Nickel": 14.6471, 
+          "Niobium": 1.323515, 
+          "Phosphorus": 10.242557, 
+          "Selenium": 2.977668, 
+          "Sulphur": 19.025608, 
+          "Tellurium": 1.451213, 
+          "Vanadium": 4.755444
+        }, 
+        "meanAnomaly": 332.120793, 
+        "name": "Eoch Flyuae YK-K c10-56 1 a", 
+        "orbitalEccentricity": 3.3e-05, 
+        "orbitalInclination": 0.013618, 
+        "orbitalPeriod": 0.157127550081019, 
+        "parents": [
+          {
+            "Planet": 6
+          }, 
+          {
+            "Null": 5
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 622.7360625, 
+        "rotationalPeriod": -1.24575988782407, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.000251518168059788, 
+        "signals": {
+          "genuses": [], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-01-22 00:33:02+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.881, 
+          "Rock": 91.119
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 840.063477, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-23T11:53:53Z", 
+          "meanAnomaly": "2026-06-23T11:53:53Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-23 11:53:53+00", 
+        "volcanismType": "Minor Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 200.490883, 
+        "ascendingNode": 41.825083, 
+        "atmosphereComposition": {
+          "Oxygen": 2.999999, 
+          "Silicates": 5.0, 
+          "Sulphur dioxide": 90.0
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 0.08625, 
+        "bodyId": 10, 
+        "distanceToArrival": 9.146358, 
+        "earthMasses": 0.000261, 
+        "gravity": 0.0521524421331702, 
+        "id64": 360303433447252058, 
+        "isLandable": false, 
+        "meanAnomaly": 33.450288, 
+        "name": "Eoch Flyuae YK-K c10-56 1 b", 
+        "orbitalEccentricity": 0.000216, 
+        "orbitalInclination": -0.00413, 
+        "orbitalPeriod": 0.153610475914352, 
+        "parents": [
+          {
+            "Planet": 6
+          }, 
+          {
+            "Null": 5
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 450.6381875, 
+        "rotationalPeriod": 1.89127718238426, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.000247750778161951, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.8295, 
+          "Rock": 91.1705
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 839.99823, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-23T11:53:53Z", 
+          "meanAnomaly": "2026-06-23T11:53:53Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-23 11:53:53+00", 
+        "volcanismType": "Major Rocky Magma"
+      }, 
+      {
+        "argOfPeriapsis": 12.874691, 
+        "ascendingNode": 95.932804, 
+        "atmosphereType": null, 
+        "axialTilt": 0.072024, 
+        "bodyId": 11, 
+        "distanceToArrival": 9.333178, 
+        "earthMasses": 0.001476, 
+        "gravity": 0.0935663301723259, 
+        "id64": 396332230466216026, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 16.145247, 
+          "Germanium": 5.654466, 
+          "Iron": 19.522676, 
+          "Manganese": 8.062666, 
+          "Molybdenum": 1.274819, 
+          "Nickel": 14.766132, 
+          "Niobium": 1.334271, 
+          "Phosphorus": 10.336465, 
+          "Selenium": 3.004969, 
+          "Sulphur": 19.200043, 
+          "Technetium": 0.698247
+        }, 
+        "meanAnomaly": 161.468548, 
+        "name": "Eoch Flyuae YK-K c10-56 1 c", 
+        "orbitalEccentricity": 0.001125, 
+        "orbitalInclination": 0.061853, 
+        "orbitalPeriod": 0.154680379282407, 
+        "parents": [
+          {
+            "Planet": 6
+          }, 
+          {
+            "Null": 5
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 800.657125, 
+        "rotationalPeriod": 4.83592220770833, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.000248899845368514, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 8.8295, 
+          "Rock": 91.1705
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 839.880859, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-23T11:53:53Z", 
+          "meanAnomaly": "2026-06-23T11:53:53Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-23 11:53:53+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 232.228816, 
+        "ascendingNode": 156.755936, 
+        "atmosphereType": null, 
+        "axialTilt": -0.480687, 
+        "bodyId": 12, 
+        "distanceToArrival": 9.242136, 
+        "earthMasses": 0.442188, 
+        "gravity": 0.795529927602733, 
+        "id64": 432361027485179994, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 1.628216, 
+          "Carbon": 12.595892, 
+          "Chromium": 9.429751, 
+          "Iron": 20.967434, 
+          "Manganese": 8.659337, 
+          "Molybdenum": 1.369161, 
+          "Nickel": 15.858889, 
+          "Phosphorus": 8.064107, 
+          "Sulphur": 14.979124, 
+          "Technetium": 0.74992, 
+          "Zinc": 5.698164
+        }, 
+        "meanAnomaly": 57.496016, 
+        "name": "Eoch Flyuae YK-K c10-56 2", 
+        "orbitalEccentricity": 0.197156, 
+        "orbitalInclination": -5.511762, 
+        "orbitalPeriod": 0.278850230902778, 
+        "parents": [
+          {
+            "Null": 5
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 4752.9345, 
+        "rotationalPeriod": 98.9994499499884, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.000364930926435626, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 32.6251, 
+          "Rock": 67.3749
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 839.695068, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-23T11:53:53Z", 
+          "meanAnomaly": "2026-06-23T11:53:53Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-23 11:53:53+00", 
+        "volcanismType": "No volcanism"
+      }, 
+      {
+        "argOfPeriapsis": 305.368807, 
+        "ascendingNode": -120.95887, 
+        "atmosphereType": null, 
+        "axialTilt": -0.294817, 
+        "bodyId": 13, 
+        "distanceToArrival": 14.672634, 
+        "earthMasses": 0.859682, 
+        "gravity": 1.03178566330172, 
+        "id64": 468389824504143962, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 1.005451, 
+          "Arsenic": 2.126269, 
+          "Carbon": 13.575518, 
+          "Chromium": 10.163136, 
+          "Iron": 22.598146, 
+          "Mercury": 0.986824, 
+          "Molybdenum": 1.475646, 
+          "Nickel": 17.092291, 
+          "Phosphorus": 8.69128, 
+          "Sulphur": 16.144102, 
+          "Zinc": 6.14133
+        }, 
+        "meanAnomaly": 160.770633, 
+        "name": "Eoch Flyuae YK-K c10-56 3", 
+        "orbitalEccentricity": 1e-06, 
+        "orbitalInclination": -0.000127, 
+        "orbitalPeriod": 2.65997330899306, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 5819.1655, 
+        "rotationalPeriod": 2.51806993645833, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0294037682854565, 
+        "signals": {
+          "genuses": [], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 3
+          }, 
+          "updateTime": "2026-01-22 00:37:48+00"
+        }, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 32.6233, 
+          "Rock": 67.371
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 658.000488, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-06-23T11:53:52Z", 
+          "meanAnomaly": "2026-06-23T11:53:52Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-06-23 11:53:52+00", 
+        "volcanismType": "Minor Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 26.758431, 
+        "ascendingNode": 21.453252, 
+        "bodyId": 15, 
+        "id64": 540447418542071898, 
+        "meanAnomaly": 84.040685, 
+        "name": "Eoch Flyuae YK-K c10-56 barycentre 15", 
+        "orbitalEccentricity": 0.002025, 
+        "orbitalInclination": 0.002668, 
+        "orbitalPeriod": 1474.23417203956, 
+        "semiMajorAxis": 1.98394254320919, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-05-27T11:36:33Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-05-27 11:36:33+00"
+      }, 
+      {
+        "argOfPeriapsis": 304.689538, 
+        "ascendingNode": -68.347715, 
+        "atmosphereComposition": {
+          "Helium": 29.718277, 
+          "Hydrogen": 70.281738
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 0.155701, 
+        "bodyId": 16, 
+        "distanceToArrival": 987.342163, 
+        "earthMasses": 1497.867065, 
+        "gravity": 10.9488927296829, 
+        "id64": 576476215561035866, 
+        "isLandable": false, 
+        "meanAnomaly": 99.061116, 
+        "name": "Eoch Flyuae YK-K c10-56 4", 
+        "orbitalEccentricity": 0.003242, 
+        "orbitalInclination": 9.100617, 
+        "orbitalPeriod": 292.80076700228, 
+        "parents": [
+          {
+            "Null": 15
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 74565.536, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 612505012579999834, 
+            "innerRadius": 146580000.0, 
+            "mass": 2222700000000.0, 
+            "name": "Eoch Flyuae YK-K c10-56 4 A Ring", 
+            "outerRadius": 398320000.0, 
+            "signals": {
+              "signals": {
+                "Painite": 1
+              }, 
+              "updateTime": "2026-01-22 00:40:54+00"
+            }, 
+            "type": "Metal Rich"
+          }, 
+          {
+            "innerRadius": 1880500000.0, 
+            "mass": 138740000000.0, 
+            "name": "Eoch Flyuae YK-K c10-56 4 B Ring", 
+            "outerRadius": 4738600000.0, 
+            "type": "Icy"
+          }
+        ], 
+        "rotationalPeriod": 1.67545172111111, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.00651525723952686, 
+        "stations": [], 
+        "subType": "Class III gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 356.96936, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:36:45Z", 
+          "meanAnomaly": "2026-05-27T11:36:45Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:36:45+00"
+      }, 
+      {
+        "argOfPeriapsis": 26.159413, 
+        "ascendingNode": 85.334191, 
+        "atmosphereType": null, 
+        "axialTilt": -0.338433, 
+        "bodyId": 18, 
+        "distanceToArrival": 985.615026, 
+        "earthMasses": 0.005795, 
+        "gravity": 0.0965497093912511, 
+        "id64": 648533809598963802, 
+        "isLandable": true, 
+        "materials": {
+          "Arsenic": 1.629811, 
+          "Carbon": 22.280815, 
+          "Chromium": 5.662129, 
+          "Iron": 12.589973, 
+          "Manganese": 5.19953, 
+          "Mercury": 0.549783, 
+          "Nickel": 9.522529, 
+          "Niobium": 0.860458, 
+          "Phosphorus": 14.26456, 
+          "Sulphur": 26.496502, 
+          "Tellurium": 0.943898
+        }, 
+        "meanAnomaly": 283.4197, 
+        "name": "Eoch Flyuae YK-K c10-56 4 a", 
+        "orbitalEccentricity": 3e-05, 
+        "orbitalInclination": 0.026071, 
+        "orbitalPeriod": 1.40857848304398, 
+        "parents": [
+          {
+            "Planet": 16
+          }, 
+          {
+            "Null": 15
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1561.823375, 
+        "rotationalPeriod": 1.40862647072917, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00405967902008109, 
+        "signals": {
+          "genuses": [], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 2
+          }, 
+          "updateTime": "2026-05-27 11:36:49+00"
+        }, 
+        "solidComposition": {
+          "Ice": 78.491, 
+          "Metal": 1.9054, 
+          "Rock": 19.6036
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 124.764145, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:36:49Z", 
+          "meanAnomaly": "2026-05-27T11:36:49Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:36:49+00", 
+        "volcanismType": "Major Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 140.484403, 
+        "ascendingNode": -9.353893, 
+        "atmosphereType": null, 
+        "axialTilt": 0.021312, 
+        "bodyId": 19, 
+        "distanceToArrival": 988.892251, 
+        "earthMasses": 0.034887, 
+        "gravity": 0.177109003772815, 
+        "id64": 684562606617927770, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 0.964754, 
+          "Carbon": 22.946634, 
+          "Iron": 12.423663, 
+          "Nickel": 9.396738, 
+          "Niobium": 0.849091, 
+          "Phosphorus": 14.690826, 
+          "Selenium": 4.270849, 
+          "Sulphur": 27.2883, 
+          "Vanadium": 3.050819, 
+          "Yttrium": 0.742051, 
+          "Zinc": 3.376286
+        }, 
+        "meanAnomaly": 154.748166, 
+        "name": "Eoch Flyuae YK-K c10-56 4 b", 
+        "orbitalEccentricity": 1e-06, 
+        "orbitalInclination": -0.003725, 
+        "orbitalPeriod": 3.07994218612268, 
+        "parents": [
+          {
+            "Planet": 16
+          }, 
+          {
+            "Null": 15
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 2829.413, 
+        "rotationalPeriod": 3.08004723386574, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00683910719149555, 
+        "signals": {
+          "genuses": [], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 2
+          }, 
+          "updateTime": "2026-05-27 11:36:52+00"
+        }, 
+        "solidComposition": {
+          "Ice": 81.3559, 
+          "Metal": 1.6516, 
+          "Rock": 16.9925
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 112.102303, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:36:52Z", 
+          "meanAnomaly": "2026-05-27T11:36:52Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:36:52+00", 
+        "volcanismType": "Minor Carbon Dioxide Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 124.689543, 
+        "ascendingNode": -68.347715, 
+        "bodyId": 21, 
+        "id64": 756620200655855706, 
+        "meanAnomaly": 99.06094, 
+        "name": "Eoch Flyuae YK-K c10-56 barycentre 21", 
+        "orbitalEccentricity": 0.003242, 
+        "orbitalInclination": 9.100617, 
+        "orbitalPeriod": 292.80076700228, 
+        "semiMajorAxis": 0.138147607663771, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2026-05-27T11:36:33Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2026-05-27 11:36:33+00"
+      }, 
+      {
+        "argOfPeriapsis": 338.16716, 
+        "ascendingNode": 86.550255, 
+        "atmosphereComposition": {
+          "Helium": 29.718267, 
+          "Hydrogen": 70.281723
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 0.157058, 
+        "bodyId": 22, 
+        "distanceToArrival": 1045.220619, 
+        "earthMasses": 40.397766, 
+        "gravity": 0.873847965738758, 
+        "id64": 792648997674819674, 
+        "isLandable": false, 
+        "meanAnomaly": 125.820876, 
+        "name": "Eoch Flyuae YK-K c10-56 5", 
+        "orbitalEccentricity": 0.044357, 
+        "orbitalInclination": 1.318425, 
+        "orbitalPeriod": 180.208662317859, 
+        "parents": [
+          {
+            "Null": 21
+          }, 
+          {
+            "Null": 15
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 43345.836, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 828677794693783642, 
+            "innerRadius": 72568000.0, 
+            "mass": 282480000000.0, 
+            "name": "Eoch Flyuae YK-K c10-56 5 A Ring", 
+            "outerRadius": 119450000.0, 
+            "signals": {
+              "signals": {
+                "Grandidierite": 1
+              }, 
+              "updateTime": "2026-01-22 00:51:16+00"
+            }, 
+            "type": "Icy"
+          }
+        ], 
+        "rotationalPeriod": 275.430238903819, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0159421055199827, 
+        "stations": [], 
+        "subType": "Class I gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 90.282349, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:36:37Z", 
+          "meanAnomaly": "2026-05-27T11:36:37Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:36:37+00"
+      }, 
+      {
+        "argOfPeriapsis": 150.646239, 
+        "ascendingNode": 133.019799, 
+        "atmosphereType": null, 
+        "axialTilt": 0.460962, 
+        "bodyId": 24, 
+        "distanceToArrival": 1044.739927, 
+        "earthMasses": 0.002536, 
+        "gravity": 0.0714426430100948, 
+        "id64": 864706591712747610, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 22.71344, 
+          "Iron": 12.043974, 
+          "Manganese": 4.974039, 
+          "Nickel": 9.109556, 
+          "Phosphorus": 14.541533, 
+          "Selenium": 4.227448, 
+          "Sulphur": 27.010986, 
+          "Tin": 0.72522, 
+          "Tungsten": 0.661335, 
+          "Yttrium": 0.719372, 
+          "Zinc": 3.273101
+        }, 
+        "meanAnomaly": 290.620007, 
+        "name": "Eoch Flyuae YK-K c10-56 5 a", 
+        "orbitalEccentricity": 6e-06, 
+        "orbitalInclination": -0.000126, 
+        "orbitalPeriod": 1.04853624685185, 
+        "parents": [
+          {
+            "Planet": 22
+          }, 
+          {
+            "Null": 21
+          }, 
+          {
+            "Null": 15
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1201.121, 
+        "rotationalPeriod": 1.04861676636574, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00100000072121293, 
+        "signals": {
+          "genuses": [], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 2
+          }, 
+          "updateTime": "2026-05-27 11:37:14+00"
+        }, 
+        "solidComposition": {
+          "Ice": 82.604, 
+          "Metal": 1.536, 
+          "Rock": 15.8601
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 79.773689, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:37:14Z", 
+          "meanAnomaly": "2026-05-27T11:37:14Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:37:14+00", 
+        "volcanismType": "Major Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 185.006858, 
+        "ascendingNode": 58.457393, 
+        "atmosphereType": null, 
+        "axialTilt": -0.331841, 
+        "bodyId": 25, 
+        "distanceToArrival": 1045.76108, 
+        "earthMasses": 0.000992, 
+        "gravity": 0.0520074436626899, 
+        "id64": 900735388731711578, 
+        "isLandable": true, 
+        "materials": {
+          "Antimony": 0.727735, 
+          "Carbon": 22.406635, 
+          "Chromium": 5.34341, 
+          "Iron": 11.881288, 
+          "Manganese": 4.906851, 
+          "Nickel": 8.986508, 
+          "Niobium": 0.812023, 
+          "Phosphorus": 14.345113, 
+          "Sulphur": 26.646132, 
+          "Tin": 0.715424, 
+          "Zinc": 3.228889
+        }, 
+        "meanAnomaly": 41.018295, 
+        "name": "Eoch Flyuae YK-K c10-56 5 b", 
+        "orbitalEccentricity": 0.000359, 
+        "orbitalInclination": 0.071549, 
+        "orbitalPeriod": 1.9686377296875, 
+        "parents": [
+          {
+            "Planet": 22
+          }, 
+          {
+            "Null": 21
+          }, 
+          {
+            "Null": 15
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 880.6756875, 
+        "rotationalPeriod": 1.96878882875, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00152190857083594, 
+        "signals": {
+          "genuses": [], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 2
+          }, 
+          "updateTime": "2026-05-27 11:37:11+00"
+        }, 
+        "solidComposition": {
+          "Ice": 82.604, 
+          "Metal": 1.536, 
+          "Rock": 15.8601
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 79.60141, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:37:12Z", 
+          "meanAnomaly": "2026-05-27T11:37:12Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:37:12+00", 
+        "volcanismType": "Major Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 55.938102, 
+        "ascendingNode": 159.436194, 
+        "atmosphereType": null, 
+        "axialTilt": 2.956093, 
+        "bodyId": 26, 
+        "distanceToArrival": 1046.501403, 
+        "earthMasses": 0.001599, 
+        "gravity": 0.0611544814928113, 
+        "id64": 936764185750675546, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 22.699881, 
+          "Chromium": 5.431849, 
+          "Iron": 12.077937, 
+          "Mercury": 0.527424, 
+          "Nickel": 9.135244, 
+          "Phosphorus": 14.532854, 
+          "Ruthenium": 0.74589, 
+          "Selenium": 4.224924, 
+          "Sulphur": 26.99486, 
+          "Tungsten": 0.6632, 
+          "Vanadium": 2.965921
+        }, 
+        "meanAnomaly": 35.467772, 
+        "name": "Eoch Flyuae YK-K c10-56 5 c", 
+        "orbitalEccentricity": 0.000608, 
+        "orbitalInclination": 1.527327, 
+        "orbitalPeriod": 4.84107834873843, 
+        "parents": [
+          {
+            "Planet": 22
+          }, 
+          {
+            "Null": 21
+          }, 
+          {
+            "Null": 15
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1030.877125, 
+        "rotationalPeriod": -4.8414499996875, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.00277272072064501, 
+        "solidComposition": {
+          "Ice": 82.4383, 
+          "Metal": 1.5571, 
+          "Rock": 16.0046
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 79.410355, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:37:10Z", 
+          "meanAnomaly": "2026-05-27T11:37:10Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:37:10+00"
+      }, 
+      {
+        "argOfPeriapsis": 158.167165, 
+        "ascendingNode": 86.550255, 
+        "atmosphereComposition": {
+          "Helium": 29.718277, 
+          "Hydrogen": 70.281738
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 0.282312, 
+        "bodyId": 27, 
+        "distanceToArrival": 1039.62413, 
+        "earthMasses": 30.240898, 
+        "gravity": 0.795480371163455, 
+        "id64": 972792982769639514, 
+        "isLandable": false, 
+        "meanAnomaly": 125.820783, 
+        "name": "Eoch Flyuae YK-K c10-56 6", 
+        "orbitalEccentricity": 0.044357, 
+        "orbitalInclination": 1.318425, 
+        "orbitalPeriod": 180.208662317859, 
+        "parents": [
+          {
+            "Null": 21
+          }, 
+          {
+            "Null": 15
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 39306.94, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 1008821779788603482, 
+            "innerRadius": 64856000.0, 
+            "mass": 239420000000.0, 
+            "name": "Eoch Flyuae YK-K c10-56 6 A Ring", 
+            "outerRadius": 120590000.0, 
+            "type": "Icy"
+          }
+        ], 
+        "rotationalPeriod": 238.291887919931, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0212985722873464, 
+        "stations": [], 
+        "subType": "Class I gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 89.422478, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:36:33Z", 
+          "meanAnomaly": "2026-05-27T11:36:33Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:36:33+00"
+      }, 
+      {
+        "argOfPeriapsis": 31.290172, 
+        "ascendingNode": 128.622984, 
+        "atmosphereType": null, 
+        "axialTilt": 2.216574, 
+        "bodyId": 29, 
+        "distanceToArrival": 1040.15693, 
+        "earthMasses": 0.000887, 
+        "gravity": 0.0502912205567452, 
+        "id64": 1044850576807567450, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 0.948683, 
+          "Carbon": 22.641716, 
+          "Iron": 12.216717, 
+          "Manganese": 5.045379, 
+          "Nickel": 9.240212, 
+          "Niobium": 0.834947, 
+          "Phosphorus": 14.495614, 
+          "Selenium": 4.214098, 
+          "Sulphur": 26.92569, 
+          "Technetium": 0.436943, 
+          "Vanadium": 3.000001
+        }, 
+        "meanAnomaly": 185.868524, 
+        "name": "Eoch Flyuae YK-K c10-56 6 a", 
+        "orbitalEccentricity": 2.6e-05, 
+        "orbitalInclination": 0.062362, 
+        "orbitalPeriod": 1.3596076794213, 
+        "parents": [
+          {
+            "Planet": 27
+          }, 
+          {
+            "Null": 21
+          }, 
+          {
+            "Null": 15
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 846.825875, 
+        "rotationalPeriod": -1.21198743936343, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.00107965629103411, 
+        "signals": {
+          "genuses": [], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 2
+          }, 
+          "updateTime": "2026-05-27 11:37:04+00"
+        }, 
+        "solidComposition": {
+          "Ice": 81.7434, 
+          "Metal": 1.6464, 
+          "Rock": 16.6103
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 79.516708, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:37:05Z", 
+          "meanAnomaly": "2026-05-27T11:37:05Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:37:05+00", 
+        "volcanismType": "Major Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 297.942622, 
+        "ascendingNode": 167.085029, 
+        "atmosphereType": null, 
+        "axialTilt": 0.392348, 
+        "bodyId": 30, 
+        "distanceToArrival": 1040.235404, 
+        "earthMasses": 0.000307, 
+        "gravity": 0.0350223309880697, 
+        "id64": 1080879373826531418, 
+        "isLandable": true, 
+        "materials": {
+          "Cadmium": 0.94559, 
+          "Carbon": 22.964092, 
+          "Germanium": 3.526862, 
+          "Iron": 12.176885, 
+          "Nickel": 9.210085, 
+          "Phosphorus": 14.702005, 
+          "Selenium": 4.274099, 
+          "Sulphur": 27.309063, 
+          "Tellurium": 0.913464, 
+          "Tungsten": 0.668633, 
+          "Zinc": 3.309221
+        }, 
+        "meanAnomaly": 146.696446, 
+        "name": "Eoch Flyuae YK-K c10-56 6 b", 
+        "orbitalEccentricity": 6.6e-05, 
+        "orbitalInclination": 0.244379, 
+        "orbitalPeriod": 1.82024782730324, 
+        "parents": [
+          {
+            "Planet": 27
+          }, 
+          {
+            "Null": 21
+          }, 
+          {
+            "Null": 15
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 596.5953125, 
+        "rotationalPeriod": 1.65941387019676, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.001311485402065, 
+        "signals": {
+          "genuses": [], 
+          "signals": {
+            "$SAA_SignalType_Geological;": 2
+          }, 
+          "updateTime": "2026-05-27 11:37:02+00"
+        }, 
+        "solidComposition": {
+          "Ice": 82.6039, 
+          "Metal": 1.536, 
+          "Rock": 15.8601
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 79.456825, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:37:02Z", 
+          "meanAnomaly": "2026-05-27T11:37:02Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:37:02+00", 
+        "volcanismType": "Major Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 25.759181, 
+        "ascendingNode": 59.159352, 
+        "atmosphereComposition": {
+          "Helium": 29.718267, 
+          "Hydrogen": 70.281723
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -0.338008, 
+        "bodyId": 31, 
+        "distanceToArrival": 1395.548113, 
+        "earthMasses": 492.461884, 
+        "gravity": 3.52931722239217, 
+        "id64": 1116908170845495386, 
+        "isLandable": false, 
+        "meanAnomaly": 329.483797, 
+        "name": "Eoch Flyuae YK-K c10-56 7", 
+        "orbitalEccentricity": 0.003389, 
+        "orbitalInclination": 0.000965, 
+        "orbitalPeriod": 2478.19701002704, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 75305.648, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 1152936967864459354, 
+            "innerRadius": 124420000.0, 
+            "mass": 217090000000.0, 
+            "name": "Eoch Flyuae YK-K c10-56 7 A Ring", 
+            "outerRadius": 149640000.0, 
+            "type": "Rocky"
+          }, 
+          {
+            "id64": 1188965764883423322, 
+            "innerRadius": 149740000.0, 
+            "mass": 1669900000000.0, 
+            "name": "Eoch Flyuae YK-K c10-56 7 B Ring", 
+            "outerRadius": 274920000.0, 
+            "signals": {
+              "signals": {
+                "LowTemperatureDiamond": 1
+              }, 
+              "updateTime": "2026-01-22 01:06:15+00"
+            }, 
+            "type": "Icy"
+          }
+        ], 
+        "rotationalPeriod": 1.85213972488426, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 2.8048440572893, 
+        "stations": [], 
+        "subType": "Class I gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 134.011139, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:36:05Z", 
+          "meanAnomaly": "2026-05-27T11:36:05Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:36:05+00"
+      }, 
+      {
+        "argOfPeriapsis": 237.90306, 
+        "ascendingNode": 166.943999, 
+        "atmosphereComposition": {
+          "Methane": 99.989281
+        }, 
+        "atmosphereType": "Thick Methane", 
+        "axialTilt": -0.130465, 
+        "bodyId": 34, 
+        "distanceToArrival": 1392.719892, 
+        "earthMasses": 0.002659, 
+        "gravity": 0.072600693382278, 
+        "id64": 1224994561902387290, 
+        "isLandable": false, 
+        "meanAnomaly": 201.682528, 
+        "name": "Eoch Flyuae YK-K c10-56 7 a", 
+        "orbitalEccentricity": 0.001005, 
+        "orbitalInclination": 7.7e-05, 
+        "orbitalPeriod": 4.17122575972222, 
+        "parents": [
+          {
+            "Planet": 31
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1220.056875, 
+        "rotationalPeriod": 4.17133004806713, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.00577799621732551, 
+        "solidComposition": {
+          "Ice": 82.604, 
+          "Metal": 1.536, 
+          "Rock": 15.8601
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 23.3014754502837, 
+        "surfaceTemperature": 196.339584, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:36:10Z", 
+          "meanAnomaly": "2026-05-27T11:36:10Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:36:10+00"
+      }, 
+      {
+        "argOfPeriapsis": 327.172738, 
+        "ascendingNode": -137.619579, 
+        "atmosphereComposition": {
+          "Methane": 100.0
+        }, 
+        "atmosphereType": "Methane", 
+        "axialTilt": -1.424464, 
+        "bodyId": 35, 
+        "distanceToArrival": 1387.541948, 
+        "earthMasses": 0.004972, 
+        "gravity": 0.0900630162129091, 
+        "id64": 1261023358921351258, 
+        "isLandable": false, 
+        "meanAnomaly": 356.857694, 
+        "name": "Eoch Flyuae YK-K c10-56 7 b", 
+        "orbitalEccentricity": 0.001766, 
+        "orbitalInclination": 0.090789, 
+        "orbitalPeriod": 21.0838040543982, 
+        "parents": [
+          {
+            "Planet": 31
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1497.87175, 
+        "rotationalPeriod": 21.0843318119676, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0170176962063899, 
+        "solidComposition": {
+          "Ice": 82.0836, 
+          "Metal": 1.5897, 
+          "Rock": 16.3268
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.385462388976067, 
+        "surfaceTemperature": 112.376198, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:36:12Z", 
+          "meanAnomaly": "2026-05-27T11:36:12Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:36:12+00"
+      }, 
+      {
+        "argOfPeriapsis": 179.458876, 
+        "ascendingNode": 118.432577, 
+        "atmosphereComposition": {
+          "Methane": 100.0
+        }, 
+        "atmosphereType": "Methane", 
+        "axialTilt": -0.233012, 
+        "bodyId": 36, 
+        "distanceToArrival": 1374.285891, 
+        "earthMasses": 0.00828, 
+        "gravity": 0.106968185989599, 
+        "id64": 1297052155940315226, 
+        "isLandable": false, 
+        "meanAnomaly": 74.150838, 
+        "name": "Eoch Flyuae YK-K c10-56 7 c", 
+        "orbitalEccentricity": 0.012241, 
+        "orbitalInclination": 0.060761, 
+        "orbitalPeriod": 89.3709843081481, 
+        "parents": [
+          {
+            "Planet": 31
+          }, 
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 1773.72275, 
+        "rotationalPeriod": 89.3732250712384, 
+        "rotationalPeriodTidallyLocked": true, 
+        "semiMajorAxis": 0.0445723785800414, 
+        "solidComposition": {
+          "Ice": 82.6039, 
+          "Metal": 1.536, 
+          "Rock": 15.8601
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 0.547195942817666, 
+        "surfaceTemperature": 112.27684, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:36:21Z", 
+          "meanAnomaly": "2026-05-27T11:36:21Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:36:21+00"
+      }, 
+      {
+        "argOfPeriapsis": 294.678157, 
+        "ascendingNode": -20.853759, 
+        "atmosphereComposition": {
+          "Helium": 89.334976, 
+          "Hydrogen": 8.427828, 
+          "Neon": 2.237205
+        }, 
+        "atmosphereType": "Thick Helium", 
+        "axialTilt": -0.031325, 
+        "bodyId": 38, 
+        "distanceToArrival": 1942.545088, 
+        "earthMasses": 37.30843, 
+        "gravity": 3.74515590904456, 
+        "id64": 1369109749978243162, 
+        "isLandable": false, 
+        "meanAnomaly": 141.477213, 
+        "name": "Eoch Flyuae YK-K c10-56 8", 
+        "orbitalEccentricity": 0.002006, 
+        "orbitalInclination": -0.059674, 
+        "orbitalPeriod": 4042.49980217881, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 20121.258, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 1405138546997207130, 
+            "innerRadius": 33200000.0, 
+            "mass": 31383000000.0, 
+            "name": "Eoch Flyuae YK-K c10-56 8 A Ring", 
+            "outerRadius": 122150000.0, 
+            "type": "Icy"
+          }
+        ], 
+        "rotationalPeriod": 1.95794755144676, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 3.88673356215461, 
+        "solidComposition": {
+          "Ice": 66.854, 
+          "Metal": 10.7699, 
+          "Rock": 21.7458
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 7.08531334813718, 
+        "surfaceTemperature": 53.359421, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:36:16Z", 
+          "meanAnomaly": "2026-05-27T11:36:16Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:36:16+00", 
+        "volcanismType": "Water Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 23.652064, 
+        "ascendingNode": 169.50795, 
+        "atmosphereComposition": {
+          "Helium": 89.334976, 
+          "Hydrogen": 8.427828, 
+          "Neon": 2.237204
+        }, 
+        "atmosphereType": "Helium", 
+        "axialTilt": -0.121694, 
+        "bodyId": 41, 
+        "distanceToArrival": 2647.988225, 
+        "earthMasses": 9.303535, 
+        "gravity": 1.78139237279494, 
+        "id64": 1477196141035135066, 
+        "isLandable": false, 
+        "meanAnomaly": 215.981353, 
+        "name": "Eoch Flyuae YK-K c10-56 9", 
+        "orbitalEccentricity": 0.002045, 
+        "orbitalInclination": 0.325626, 
+        "orbitalPeriod": 6432.97464207367, 
+        "parents": [
+          {
+            "Star": 0
+          }
+        ], 
+        "radius": 14569.036, 
+        "reserveLevel": "Pristine", 
+        "rings": [
+          {
+            "id64": 1513224938054099034, 
+            "innerRadius": 27433000.0, 
+            "mass": 9078300.0, 
+            "name": "Eoch Flyuae YK-K c10-56 9 A Ring", 
+            "outerRadius": 73219000.0, 
+            "signals": {
+              "signals": {
+                "Alexandrite": 1, 
+                "Opal": 1, 
+                "Tritium": 1
+              }, 
+              "updateTime": "2026-01-22 01:21:39+00"
+            }, 
+            "type": "Icy"
+          }
+        ], 
+        "rotationalPeriod": 0.581242500115741, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 5.29776452054964, 
+        "solidComposition": {
+          "Ice": 68.6832, 
+          "Metal": 10.2171, 
+          "Rock": 21.0997
+        }, 
+        "stations": [], 
+        "subType": "Icy body", 
+        "surfacePressure": 1.64687746730817, 
+        "surfaceTemperature": 44.148689, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2026-05-27T11:37:21Z", 
+          "meanAnomaly": "2026-05-27T11:37:21Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2026-05-27 11:37:21+00", 
+        "volcanismType": "Water Geysers"
+      }
+    ], 
+    "bodyCount": 23, 
+    "coords": {
+      "x": -8215.5625, 
+      "y": -494.5625, 
+      "z": 17297.96875
+    }, 
+    "date": "2026-06-23 11:53:59+00", 
+    "government": "None", 
+    "id64": 15463257612378, 
+    "name": "Eoch Flyuae YK-K c10-56", 
+    "population": 0, 
+    "primaryEconomy": "None", 
+    "secondaryEconomy": "None", 
+    "security": "Anarchy", 
+    "stations": []
+  }
+}

--- a/e2e/support/system-fixture.ts
+++ b/e2e/support/system-fixture.ts
@@ -64,6 +64,12 @@ export interface FixtureOptions {
   systemName: string;
   /** The system's id64 (returned by the stubbed typeahead). */
   id64: number;
+  /**
+   * ISO timestamp to pin "now" to. Defaults to `2026-06-14T00:00:00Z`. Override when a test
+   * asserts day-counts/dates that were captured at a different reference time (e.g. collision
+   * windows months out, whose "days until" only line up from a specific now).
+   */
+  fixedTime?: string;
 }
 
 /**
@@ -93,7 +99,7 @@ export async function loadFixtureSystem(page: Page, opts: FixtureOptions): Promi
   // but pinning also guards the far-future rollover once real time passes an apsis).
   // setFixedTime pins Date.now()/new Date() but keeps timers running, so the app's
   // setTimeout-driven logic (marker scaling, etc.) still works.
-  await page.clock.setFixedTime(new Date('2026-06-14T00:00:00Z'));
+  await page.clock.setFixedTime(new Date(opts.fixedTime ?? '2026-06-14T00:00:00Z'));
 
   await page.goto('/');
   await page.getByRole('combobox').fill(opts.systemName);

--- a/src/app/data/collision-diagram.spec.ts
+++ b/src/app/data/collision-diagram.spec.ts
@@ -1,0 +1,97 @@
+import {
+  COLLISION_DIAGRAM_HEIGHT,
+  COLLISION_DIAGRAM_WIDTH,
+  SynodicDiagramInput,
+  synodicDistanceDiagram,
+} from './collision-diagram';
+
+/** A window with one partner whose separation dips from ~1e6 km to a 500 km contact. */
+function input(over: Partial<SynodicDiagramInput> = {}): SynodicDiagramInput {
+  const start = 1_000_000;
+  const end = start + 1000;
+  const samples = Array.from({ length: 11 }, (_, i) => ({
+    tMs: start + (end - start) * (i / 10),
+    // V-shaped dip whose sampled floor (5000 km) sits ABOVE the true contact, so the test can
+    // confirm the curve is threaded down to the deeper collision minimum.
+    sepKm: 5000 + Math.abs(i - 5) * 200_000,
+  }));
+  return {
+    startMs: start,
+    endMs: end,
+    nowMs: start,
+    // The true contact (500 km) is deeper than any uniform sample.
+    series: [{ partnerName: 'Test 1 c', combinedRadiiKm: 1000, samples, contacts: [{ tMs: start + 500, sepKm: 500 }] }],
+    ...over,
+  };
+}
+
+describe('synodicDistanceDiagram', () => {
+  it('lays out a plot within the view box and a polyline for the series', () => {
+    const dg = synodicDistanceDiagram(input())!;
+    expect(dg).not.toBeNull();
+    expect(dg.width).toBe(COLLISION_DIAGRAM_WIDTH);
+    expect(dg.height).toBe(COLLISION_DIAGRAM_HEIGHT);
+    // Plot rectangle sits inside the view box (margins leave room for axes).
+    expect(dg.plot.x).toBeGreaterThan(0);
+    expect(dg.plot.x + dg.plot.w).toBeLessThan(dg.width);
+    expect(dg.plot.y + dg.plot.h).toBeLessThan(dg.height);
+    // One curve whose polyline threads the contact minimum in among the 11 samples.
+    expect(dg.series.length).toBe(1);
+    expect(dg.series[0].points.split(' ').length).toBe(12);
+  });
+
+  it('threads the curve down to the collision marker (deeper than any uniform sample)', () => {
+    const dg = synodicDistanceDiagram(input())!;
+    const ys = dg.series[0].points.split(' ').map(p => Number(p.split(',')[1]));
+    // SVG y grows downward, so the deepest point is the largest y — and it must be the contact
+    // minimum, i.e. the curve reaches the marker rather than bottoming out above it.
+    const maxY = Math.max(...ys);
+    expect(dg.series[0].markers.length).toBe(1);
+    expect(dg.series[0].markers[0].cy).toBeCloseTo(maxY, 6);
+    // The contact threshold (1000 km) sits above the 500 km dip → smaller y than the marker,
+    // and within the plot bounds.
+    const tY = dg.series[0].thresholdY;
+    expect(tY).toBeLessThan(maxY);
+    expect(tY).toBeGreaterThanOrEqual(dg.plot.y);
+    expect(tY).toBeLessThanOrEqual(dg.plot.y + dg.plot.h);
+  });
+
+  it('places the now marker only when now falls within the window', () => {
+    expect(synodicDistanceDiagram(input())!.nowX).not.toBeNull();
+    const outside = synodicDistanceDiagram(input({ nowMs: 0 }))!;
+    expect(outside.nowX).toBeNull();
+  });
+
+  it('emits decade y-ticks across the distance range and four x-ticks across time', () => {
+    const dg = synodicDistanceDiagram(input())!;
+    expect(dg.xTicks.length).toBe(4);
+    expect(dg.xTicks[0].tMs).toBe(1_000_000);
+    expect(dg.xTicks[3].tMs).toBe(1_001_000);
+    // End ticks anchor inward so the dated labels don't clip at the plot edges.
+    expect(dg.xTicks[0].anchor).toBe('start');
+    expect(dg.xTicks[3].anchor).toBe('end');
+    expect(dg.xTicks[1].anchor).toBe('middle');
+    // Range ~500 km … ~1e6 km spans several decades; labels are compact.
+    expect(dg.yTicks.length).toBeGreaterThan(1);
+    expect(dg.yTicks.some(t => /km$/.test(t.label))).toBe(true);
+  });
+
+  it('assigns distinct palette colours to multiple partners', () => {
+    const base = input();
+    const two = input({
+      series: [base.series[0], { ...base.series[0], partnerName: 'Test 1 d' }],
+    });
+    const dg = synodicDistanceDiagram(two)!;
+    expect(dg.series.length).toBe(2);
+    expect(dg.series[0].color).not.toBe(dg.series[1].color);
+  });
+
+  it('returns null when there is no plottable data', () => {
+    expect(synodicDistanceDiagram(input({ endMs: 1_000_000 }))).toBeNull(); // zero-width window
+    expect(synodicDistanceDiagram(input({ series: [] }))).toBeNull();        // no series
+    // A series whose samples are all non-finite is not plottable.
+    const nan = input();
+    nan.series[0].samples = nan.series[0].samples.map(s => ({ ...s, sepKm: NaN }));
+    expect(synodicDistanceDiagram(nan)).toBeNull();
+  });
+});

--- a/src/app/data/collision-diagram.ts
+++ b/src/app/data/collision-diagram.ts
@@ -1,0 +1,178 @@
+/**
+ * Pure geometry helper that turns the centre-to-centre distance-over-time samples of a
+ * collision pair (or multi-body cluster) into SVG-ready primitives for the synodic-period
+ * diagram shown in the collision dialog. Framework-free so it stays trivially unit-testable.
+ *
+ * The chart plots separation (y, log scale) against time (x, linear). Distance oscillates
+ * once per synodic period, dipping to a minimum at each conjunction; a dip that crosses the
+ * contact threshold (the sum of the two bodies' radii) is a collision. A log y-axis is
+ * essential here: opposition separations are AU-scale (~10^8 km) while the contact threshold
+ * is only thousands of km, so a linear axis would flatten every dip onto the baseline.
+ */
+
+/** One body's distance-to-this-body curve plus its contact threshold and known collisions. */
+export interface DistanceSeriesInput {
+  /** Full name of the partner body this curve measures the distance to. */
+  partnerName: string;
+  /** Contact threshold (km) for this pair — the sum of the two bodies' radii. */
+  combinedRadiiKm: number;
+  /** Evenly-spaced (time, separation) samples spanning the diagram window. */
+  samples: { tMs: number; sepKm: number }[];
+  /** Known collision minima (from the upcoming-contacts list) to mark on the curve. */
+  contacts: { tMs: number; sepKm: number }[];
+}
+
+export interface SynodicDiagramInput {
+  /** Window start (epoch ms) — the left edge of the time axis. */
+  startMs: number;
+  /** Window end (epoch ms) — the right edge of the time axis. */
+  endMs: number;
+  /** "Now" (epoch ms); drawn as a vertical marker when it falls within the window. */
+  nowMs: number;
+  /** One entry per involved partner; each becomes a coloured curve. */
+  series: DistanceSeriesInput[];
+}
+
+/** A laid-out curve: its polyline points, threshold line, collision markers and colour. */
+export interface DiagramSeries {
+  partnerName: string;
+  /** Stroke colour for the curve, threshold line, markers and legend swatch. */
+  color: string;
+  /** SVG `points` for the distance polyline. */
+  points: string;
+  /** y of the horizontal contact-threshold line (clamped to the plot). */
+  thresholdY: number;
+  /** Marker centres for the known collisions on this curve. */
+  markers: { cx: number; cy: number }[];
+}
+
+export interface SynodicDiagram {
+  width: number;
+  height: number;
+  /** Plot rectangle (inside the axis margins). */
+  plot: { x: number; y: number; w: number; h: number };
+  series: DiagramSeries[];
+  /**
+   * Time-axis ticks: x position, the instant each represents (for date formatting) and a text
+   * anchor so the wider end labels stay inside the plot instead of clipping at the edges.
+   */
+  xTicks: { x: number; tMs: number; anchor: 'start' | 'middle' | 'end' }[];
+  /** y positions of the distance-axis ticks (log decades), with a compact label. */
+  yTicks: { y: number; label: string }[];
+  /** x of the "now" marker, or null when now is outside the window. */
+  nowX: number | null;
+}
+
+export const COLLISION_DIAGRAM_WIDTH = 360;
+export const COLLISION_DIAGRAM_HEIGHT = 200;
+const MARGIN = { left: 48, right: 14, top: 12, bottom: 26 };
+
+/** Distinct, colour-blind-friendly curve colours, cycled when there are more partners than entries. */
+const PALETTE = ['#5ab1ff', '#ffb14e', '#7ee081', '#ff6f91', '#c792ea'];
+
+/** Round to 2 decimals (and normalise -0 to 0) so bound SVG attributes stay tidy and tests stable. */
+function r(n: number): number {
+  return Math.round(n * 100) / 100 + 0;
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/** Compact label for a power-of-ten kilometre value: "100 km", "1k km", "10M km". */
+function kmLabel(km: number): string {
+  if (km >= 1e6) { return `${Math.round(km / 1e6)}M km`; }
+  if (km >= 1e3) { return `${Math.round(km / 1e3)}k km`; }
+  return `${Math.round(km)} km`;
+}
+
+/**
+ * Lays out the distance-over-time diagram. Returns null when there is nothing plottable
+ * (no series with at least two finite samples), so the caller can hide the chart entirely.
+ */
+export function synodicDistanceDiagram(input: SynodicDiagramInput): SynodicDiagram | null {
+  const { startMs, endMs, nowMs } = input;
+  if (!(endMs > startMs)) { return null; }
+
+  const plot = {
+    x: MARGIN.left,
+    y: MARGIN.top,
+    w: COLLISION_DIAGRAM_WIDTH - MARGIN.left - MARGIN.right,
+    h: COLLISION_DIAGRAM_HEIGHT - MARGIN.top - MARGIN.bottom,
+  };
+
+  // Collect every positive distance (samples, contacts and thresholds) to size the log axis.
+  const values: number[] = [];
+  let hasFiniteSample = false;
+  for (const s of input.series) {
+    for (const p of s.samples) { if (Number.isFinite(p.sepKm) && p.sepKm > 0) { values.push(p.sepKm); hasFiniteSample = true; } }
+    for (const c of s.contacts) { if (Number.isFinite(c.sepKm) && c.sepKm > 0) { values.push(c.sepKm); } }
+    if (s.combinedRadiiKm > 0) { values.push(s.combinedRadiiKm); }
+  }
+  if (!hasFiniteSample || values.length === 0) { return null; }
+
+  // Pad the range by ~10% in log space so the curve peaks and the lowest threshold aren't
+  // pinned to the plot edges.
+  let minKm = Math.min(...values) / 1.1;
+  let maxKm = Math.max(...values) * 1.1;
+  if (!(minKm > 0)) { minKm = 1; }
+  if (!(maxKm > minKm)) { maxKm = minKm * 10; }
+
+  const lo = Math.log10(minKm);
+  const hi = Math.log10(maxKm);
+  const span = hi - lo;
+
+  const xOf = (tMs: number): number => plot.x + plot.w * ((tMs - startMs) / (endMs - startMs));
+  const yOf = (km: number): number => {
+    const v = km > 0 ? Math.log10(km) : lo;
+    return plot.y + plot.h * (1 - clamp((v - lo) / span, 0, 1));
+  };
+
+  const series: DiagramSeries[] = input.series.map((s, i) => {
+    const contacts = s.contacts.filter(c => c.tMs >= startMs && c.tMs <= endMs && Number.isFinite(c.sepKm) && c.sepKm > 0);
+    // Thread the known contact minima into the sampled curve (time-sorted) so the dips reach
+    // the true closest approach. The uniform samples under-resolve the narrow conjunction
+    // valley, so without this the drawn curve bottoms out short of the collision markers.
+    const points = [...s.samples.filter(p => Number.isFinite(p.sepKm) && p.sepKm > 0), ...contacts]
+      .sort((p, q) => p.tMs - q.tMs)
+      .map(p => `${r(xOf(p.tMs))},${r(yOf(p.sepKm))}`)
+      .join(' ');
+    const markers = contacts.map(c => ({ cx: r(xOf(c.tMs)), cy: r(yOf(c.sepKm)) }));
+    return {
+      partnerName: s.partnerName,
+      color: PALETTE[i % PALETTE.length],
+      points,
+      thresholdY: r(yOf(s.combinedRadiiKm)),
+      markers,
+    };
+  });
+
+  // y ticks: one per log decade within the range; fall back to the two endpoints when the
+  // range is narrower than a single decade (so the axis is never blank).
+  const yTicks: { y: number; label: string }[] = [];
+  const firstExp = Math.ceil(lo);
+  const lastExp = Math.floor(hi);
+  if (lastExp >= firstExp) {
+    for (let exp = firstExp; exp <= lastExp; exp++) {
+      const km = Math.pow(10, exp);
+      yTicks.push({ y: r(yOf(km)), label: kmLabel(km) });
+    }
+  } else {
+    yTicks.push({ y: r(yOf(maxKm)), label: kmLabel(maxKm) });
+    yTicks.push({ y: r(yOf(minKm)), label: kmLabel(minKm) });
+  }
+
+  // x ticks: four evenly-spaced instants across the window (formatted as dates by the template).
+  // The first/last ticks anchor inward (start/end) so the dated labels don't clip at the edges.
+  const xTicks: { x: number; tMs: number; anchor: 'start' | 'middle' | 'end' }[] = [];
+  const X_TICK_COUNT = 4;
+  for (let i = 0; i < X_TICK_COUNT; i++) {
+    const tMs = startMs + ((endMs - startMs) * i) / (X_TICK_COUNT - 1);
+    const anchor = i === 0 ? 'start' : i === X_TICK_COUNT - 1 ? 'end' : 'middle';
+    xTicks.push({ x: r(xOf(tMs)), tMs, anchor });
+  }
+
+  const nowX = nowMs >= startMs && nowMs <= endMs ? r(xOf(nowMs)) : null;
+
+  return { width: COLLISION_DIAGRAM_WIDTH, height: COLLISION_DIAGRAM_HEIGHT, plot, series, xTicks, yTicks, nowX };
+}

--- a/src/app/data/orbital-relations.service.spec.ts
+++ b/src/app/data/orbital-relations.service.spec.ts
@@ -627,5 +627,51 @@ describe('OrbitalRelationsService', () => {
       // All three moons have geometrically crossing orbits → 1 b is a simultaneous partner.
       expect(r.simultaneousPartners).toContain('1 b');
     });
+
+    it('merges upcoming collisions across every crossing partner of the body', () => {
+      // The same 1 a / 1 b / 1 c trio: 1 a directly crosses BOTH 1 b and 1 c, so its upcoming
+      // list must interleave contacts with both siblings (a multi-body collision cluster),
+      // sorted chronologically, each window naming its own partner and contact radius.
+      const nowHere = Date.parse('2026-06-28T00:00:00Z');
+      const [a] = makeFamily([
+        { name: '1 a', orbitalPeriod: 0.157127550081019, semiMajorAxis: 0.000251518168059788,
+          orbitalEccentricity: 3.3e-05, orbitalInclination: 0.013618,
+          argOfPeriapsis: 237.157193, ascendingNode: 113.296374,
+          meanAnomaly: 332.120793, radius: 622.7360625,
+          timestamps: { meanAnomaly: '2026-06-23T11:53:53Z' } as any },
+        { name: '1 b', orbitalPeriod: 0.153610475914352, semiMajorAxis: 0.000247750778161951,
+          orbitalEccentricity: 0.000216, orbitalInclination: 0.00413,
+          argOfPeriapsis: 200.490883, ascendingNode: 41.825083,
+          meanAnomaly: 33.450288, radius: 450.6381875,
+          timestamps: { meanAnomaly: '2026-06-23T11:53:53Z' } as any },
+        { name: '1 c', orbitalPeriod: 0.154680379282407, semiMajorAxis: 0.000248899845368514,
+          orbitalEccentricity: 0.001125, orbitalInclination: 0.061853,
+          argOfPeriapsis: 12.874691, ascendingNode: 95.932804,
+          meanAnomaly: 161.468548, radius: 800.657125,
+          timestamps: { meanAnomaly: '2026-06-23T11:53:53Z' } as any },
+      ]);
+      const r = service.detectCollisionStatus(a, nowHere);
+      expect(r.isCandidate).toBe(true);
+
+      // The list interleaves both partners, not just the primary.
+      const partners = new Set(r.upcomingCollisions.map(w => w.partnerName));
+      expect(partners).toContain('1 b');
+      expect(partners).toContain('1 c');
+
+      // Chronologically ordered, and every window self-describes its pair.
+      for (let i = 1; i < r.upcomingCollisions.length; i++) {
+        expect(r.upcomingCollisions[i].start.getTime())
+          .toBeGreaterThanOrEqual(r.upcomingCollisions[i - 1].start.getTime());
+      }
+      for (const w of r.upcomingCollisions) {
+        expect(w.partnerName).toBeTruthy();
+        expect(w.combinedRadiiKm).toBeGreaterThan(0);
+        expect(w.minSeparationKm).toBeLessThanOrEqual(w.combinedRadiiKm!);
+      }
+
+      // The primary partner (soonest collision) owns the first window.
+      expect(r.upcomingCollisions[0].partnerName).toBe(r.partnerName);
+      expect(r.nextCollision).toBe(r.upcomingCollisions[0]);
+    });
   });
 });

--- a/src/app/data/orbital-relations.service.spec.ts
+++ b/src/app/data/orbital-relations.service.spec.ts
@@ -674,4 +674,107 @@ describe('OrbitalRelationsService', () => {
       expect(r.nextCollision).toBe(r.upcomingCollisions[0]);
     });
   });
+
+  describe('simultaneousCollisionsWithin', () => {
+    const DAY_MS = 86_400_000;
+    // The real Eoch Flyuae YK-K c10-56 moons 1 a / 1 b / 1 c, which all share crossing orbits
+    // with very short (~0.15 day) periods, so conjunctions — and multi-body pile-ups — recur
+    // often within any horizon.
+    const TRIO: Partial<CanonnBiostatsBody>[] = [
+      { name: '1 a', orbitalPeriod: 0.157127550081019, semiMajorAxis: 0.000251518168059788,
+        orbitalEccentricity: 3.3e-05, orbitalInclination: 0.013618,
+        argOfPeriapsis: 237.157193, ascendingNode: 113.296374,
+        meanAnomaly: 332.120793, radius: 622.7360625,
+        timestamps: { meanAnomaly: '2026-06-23T11:53:53Z' } as any },
+      { name: '1 b', orbitalPeriod: 0.153610475914352, semiMajorAxis: 0.000247750778161951,
+        orbitalEccentricity: 0.000216, orbitalInclination: 0.00413,
+        argOfPeriapsis: 200.490883, ascendingNode: 41.825083,
+        meanAnomaly: 33.450288, radius: 450.6381875,
+        timestamps: { meanAnomaly: '2026-06-23T11:53:53Z' } as any },
+      { name: '1 c', orbitalPeriod: 0.154680379282407, semiMajorAxis: 0.000248899845368514,
+        orbitalEccentricity: 0.001125, orbitalInclination: 0.061853,
+        argOfPeriapsis: 12.874691, ascendingNode: 95.932804,
+        meanAnomaly: 161.468548, radius: 800.657125,
+        timestamps: { meanAnomaly: '2026-06-23T11:53:53Z' } as any },
+    ];
+    const now = Date.parse('2026-06-28T00:00:00Z');
+
+    it('finds multi-body pile-ups across the whole horizon, each naming ≥ 2 distinct partners', () => {
+      const [a] = makeFamily(TRIO);
+      const clusters = service.simultaneousCollisionsWithin(a, 180, now);
+      expect(clusters.length).toBeGreaterThan(0);
+      for (const c of clusters) {
+        expect(c.partnerNames.length).toBeGreaterThanOrEqual(2);
+        for (const n of c.partnerNames) { expect(['1 b', '1 c']).toContain(n); }
+        // Within the horizon, and a real interval (end strictly after start, both after now).
+        expect(c.start.getTime()).toBeLessThanOrEqual(now + 180 * DAY_MS);
+        expect(c.end.getTime()).toBeGreaterThan(c.start.getTime());
+        expect(c.end.getTime()).toBeGreaterThan(now);
+      }
+    });
+
+    it('surfaces clusters beyond the 10-row contact cap (longer horizon finds at least as many)', () => {
+      const [a] = makeFamily(TRIO);
+      const near = service.simultaneousCollisionsWithin(a, 20, now);
+      const far = service.simultaneousCollisionsWithin(a, 180, now);
+      // A wider horizon never loses clusters and, for this fast-lapping trio, finds more.
+      expect(far.length).toBeGreaterThanOrEqual(near.length);
+      expect(far.length).toBeGreaterThan(near.length);
+    });
+
+    it('returns [] when the body has fewer than two crossing partners', () => {
+      // A 1 a / 1 b pair: 1 a has a single crossing partner, so no simultaneity is possible.
+      const [a] = makeFamily([TRIO[0], TRIO[1]]);
+      expect(service.simultaneousCollisionsWithin(a, 180, now)).toEqual([]);
+    });
+  });
+
+  describe('separationSeries', () => {
+    const sampleTime = '2026-06-01T00:00:00Z';
+    const start = Date.parse(sampleTime);
+
+    /** A body with the phase data needed to be placed in time. */
+    const body = (over: Partial<CanonnBiostatsBody>): CanonnBiostatsBody => ({
+      bodyId: 1, name: 'b', id64: 0n, subType: '', type: 'Planet',
+      semiMajorAxis: 0.01, orbitalEccentricity: 0, orbitalInclination: 0,
+      ascendingNode: 0, argOfPeriapsis: 0, meanAnomaly: 0,
+      timestamps: { meanAnomaly: sampleTime } as any, ...over,
+    } as CanonnBiostatsBody);
+
+    it('returns evenly-spaced samples spanning the requested window', () => {
+      const a = body({ orbitalPeriod: 10 });
+      const b = body({ orbitalPeriod: 13, semiMajorAxis: 0.012 });
+      const series = service.separationSeries(a, b, start, start + 20 * 86_400_000, 50);
+      expect(series.length).toBe(50);
+      expect(series[0].tMs).toBe(start);
+      expect(series[series.length - 1].tMs).toBe(start + 20 * 86_400_000);
+      // Even spacing (within float tolerance over a multi-million-ms step).
+      const step = series[1].tMs - series[0].tMs;
+      expect(Math.abs((series[2].tMs - series[1].tMs) - step)).toBeLessThan(1);
+      // Real, positive separations that actually vary as the bodies lap each other.
+      for (const s of series) { expect(s.sepKm).toBeGreaterThan(0); expect(Number.isFinite(s.sepKm)).toBe(true); }
+      const seps = series.map(s => s.sepKm);
+      expect(Math.max(...seps)).toBeGreaterThan(Math.min(...seps));
+    });
+
+    it('reports ~zero separation for two bodies sharing identical orbital elements', () => {
+      const a = body({ orbitalPeriod: 10 });
+      const b = body({ orbitalPeriod: 10, name: 'c' });
+      const series = service.separationSeries(a, b, start, start + 5 * 86_400_000, 20);
+      for (const s of series) { expect(s.sepKm).toBeCloseTo(0, 3); }
+    });
+
+    it('returns [] when either body lacks the phase data needed to place it in time', () => {
+      const a = body({ orbitalPeriod: 10 });
+      const noPhase = body({ orbitalPeriod: 13, meanAnomaly: undefined });
+      expect(service.separationSeries(a, noPhase, start, start + 86_400_000, 10)).toEqual([]);
+    });
+
+    it('returns [] for a degenerate window or sample count', () => {
+      const a = body({ orbitalPeriod: 10 });
+      const b = body({ orbitalPeriod: 13 });
+      expect(service.separationSeries(a, b, start, start, 10)).toEqual([]);       // zero-width window
+      expect(service.separationSeries(a, b, start, start + 86_400_000, 1)).toEqual([]); // too few samples
+    });
+  });
 });

--- a/src/app/data/orbital-relations.service.ts
+++ b/src/app/data/orbital-relations.service.ts
@@ -76,14 +76,18 @@ const KM_PER_AU = 149597870.7;
 /** Radians per degree, for the 3D Keplerian position maths. */
 const DEG_TO_RAD = Math.PI / 180;
 /**
- * Coarse orbit-curve sampling step (degrees of mean anomaly) for the proximity test is
- * adaptive: a fixed step that resolves a wide pair would step right over the narrow close-
- * approach valley of two tightly-nested orbits and report a wildly inflated minimum. We scale
- * the step so adjacent samples sit ~one contact-distance apart in arc length, clamped between
- * these bounds (fine for nested pairs, coarse — the historical 1° — for well-separated ones).
+ * Number of evenly-spaced mean-anomaly samples per orbit for the coarse proximity scan.
+ * The coarse grid only has to resolve the *basins* of the orbit-to-orbit distance surface
+ * (which are far wider than the contact width), not the contact arc itself: the narrow
+ * close-approach valley of two tightly-nested, tilted orbits is caught separately by the
+ * line-of-nodes seeds, and every seed is then zoomed to sub-km precision by
+ * {@link OrbitalRelationsService.refineOrbitMinimum}. So we cap the grid at a fixed sample
+ * count (0.5° spacing — four times finer than the historical 1° that missed valleys, and
+ * the node seeds now cover those valleys regardless) instead of scaling the step down to the
+ * contact arc. The old adaptive step bottomed out at 0.05° for any orbit beyond ~0.1 AU,
+ * driving the O(N²) coarse double-loop to 7200² ≈ 52M iterations (~200 ms) per sibling pair.
  */
-const ORBIT_MIN_STEP_DEG = 0.05;
-const ORBIT_MAX_STEP_DEG = 1;
+const ORBIT_COARSE_SAMPLES = 720;
 /** How many of the closest coarse cells to refine from (covers multiple close-approach basins). */
 const ORBIT_REFINE_TOPK = 6;
 /** Half-grid size (per axis) for each zoom pass refining the orbit-to-orbit minimum. */
@@ -372,22 +376,21 @@ export class OrbitalRelationsService {
    * apart — so the pair is not a collision candidate at all.
    *
    * Two near-circular orbits a few km apart approach within a sliver around their mutual
-   * node, far narrower than a uniform sweep can resolve, so a fixed coarse grid alone reports
-   * a wildly inflated minimum. We defend against that two ways: the coarse step is scaled to
-   * the geometry (`contactKm` is the resolution we care about, so adjacent samples sit ~one
-   * contact-distance apart in arc length), and we additionally seed the refinement on the
-   * orbits' mutual line of nodes — where a relative tilt brings near-coplanar orbits closest.
-   * We then refine from each seed and take the overall minimum.
+   * node, far narrower than a uniform sweep can resolve, so the closest *coarse* sample alone
+   * reports a wildly inflated minimum. We defend against that two ways that don't depend on
+   * grid fineness: we keep the K closest coarse cells (multiple basins), and we additionally
+   * seed the refinement on the orbits' mutual line of nodes — where a relative tilt brings
+   * near-coplanar orbits closest. Every seed is then zoomed to sub-km precision, so the coarse
+   * grid only needs to land each true minimum in *some* seed's catchment, not resolve it. That
+   * lets the grid stay a fixed, bounded size ({@link ORBIT_COARSE_SAMPLES}) instead of an
+   * adaptive step that exploded the O(N²) double-loop for distant orbits.
    */
-  private minOrbitDistanceKm(a: CanonnBiostatsBody, b: CanonnBiostatsBody, contactKm: number): number {
-    // Resolve the close-approach valley: step so the arc between samples on the larger orbit
-    // is roughly the contact distance. clamp keeps it cheap for wide pairs (1°, as before) and
-    // fine enough for tightly-nested ones without an unbounded grid.
-    const aMaxKm = Math.max(a.semiMajorAxis!, b.semiMajorAxis!) * KM_PER_AU;
-    const stepDeg = Math.min(
-      Math.max((contactKm / aMaxKm) * (180 / Math.PI), ORBIT_MIN_STEP_DEG),
-      ORBIT_MAX_STEP_DEG,
-    );
+  private minOrbitDistanceKm(a: CanonnBiostatsBody, b: CanonnBiostatsBody): number {
+    // Fixed coarse grid: its job is to seed the refinement into the right basin, not to
+    // resolve the contact arc, so its cost is bounded regardless of orbital scale. The
+    // refinement window below is the coarse spacing, so each ±window covers the gap to the
+    // neighbouring sample and the zoom can reach any minimum between two coarse cells.
+    const stepDeg = 360 / ORBIT_COARSE_SAMPLES;
 
     // Positions are computed once per sampled angle (per axis) and reused across the cross
     // product, so an N×N grid costs 2N state-vector evaluations, not N².
@@ -673,7 +676,7 @@ export class OrbitalRelationsService {
 
       // Exact 3D candidacy: do the orbit curves themselves come within contact distance? A
       // relative tilt can keep radially-overlapping orbits permanently apart.
-      if (this.minOrbitDistanceKm(bd, sd, contactKm) > contactKm) { continue; }
+      if (this.minOrbitDistanceKm(bd, sd) > contactKm) { continue; }
 
       const synodic = 1 / Math.abs(1 / bd.orbitalPeriod - 1 / sd.orbitalPeriod);
       partners.push({ partner: sibling, synodic, contactKm });
@@ -720,7 +723,7 @@ export class OrbitalRelationsService {
           const contactKm = (md.radius ?? 0) + (sd.radius ?? 0);
           const radialGapAu = Math.max(mRange.peri, sRange.peri) - Math.min(mRange.apo, sRange.apo);
           if (radialGapAu > contactKm / KM_PER_AU) { continue; }
-          if (this.minOrbitDistanceKm(md, sd, contactKm) > contactKm) { continue; }
+          if (this.minOrbitDistanceKm(md, sd) > contactKm) { continue; }
           groupMembers.add(sibling.bodyData.name);
           changed = true;
           break;

--- a/src/app/data/orbital-relations.service.ts
+++ b/src/app/data/orbital-relations.service.ts
@@ -27,19 +27,36 @@ export interface CollisionWindow {
   days: number;
   /** Centre-to-centre separation (km) at closest approach within the window — the deepest point of contact. */
   minSeparationKm: number;
+  /**
+   * Name of the sibling body this contact is with. Always set by {@link OrbitalRelationsService.detectCollisionStatus}
+   * (a body can have several crossing partners); optional only so hand-built test fixtures may omit it.
+   */
+  partnerName?: string;
+  /**
+   * Sum of the two bodies' radii (km) for *this* pair — the contact threshold used to gauge overlap.
+   * Distinct per partner, so it travels with the window rather than living once on the status.
+   */
+  combinedRadiiKm?: number;
 }
 
 /** Result of collision-candidate analysis for a body relative to a crossing-orbit sibling. */
 export interface CollisionStatus {
   /** True when this body shares its parent with a sibling on a crossing, near-coplanar orbit. */
   isCandidate: boolean;
-  /** Name of the sibling whose orbit crosses this body's, or null when none. */
+  /**
+   * Name of the *primary* partner — the sibling owning the soonest predicted collision (or the
+   * first geometric candidate when no pair has timing data). Null when there is no partner.
+   * A body may collide with several siblings; see {@link upcomingCollisions} for the full set.
+   */
   partnerName: string | null;
-  /** Synodic period (days) between the pair — the interval between successive conjunctions. */
+  /** Synodic period (days) with the primary partner — the interval between successive conjunctions. */
   synodicPeriodDays: number | null;
-  /** Next contact window (when the bodies are within combined radii), or null when timing data is missing. */
+  /** Next contact window (when any pair is within combined radii), or null when timing data is missing. */
   nextCollision: CollisionWindow | null;
-  /** Up to 10 upcoming contact windows in chronological order; empty when timing data is missing. */
+  /**
+   * Up to 10 upcoming contact windows in chronological order, merged across every crossing
+   * partner of this body; empty when timing data is missing. Each window names its own partner.
+   */
   upcomingCollisions: CollisionWindow[];
   /** Sum of the two bodies' radii (km) — the contact threshold; null when not a candidate. */
   combinedRadiiKm: number | null;
@@ -75,6 +92,9 @@ const ORBIT_REFINE_GRID = 4;
 const ORBIT_REFINE_ITERATIONS = 10;
 /** Upper bound on conjunctions examined before giving up on finding a collision date. */
 const MAX_CONJUNCTIONS_SCANNED = 300;
+
+/** Cap on how many upcoming contact windows are surfaced (merged across all crossing partners). */
+const MAX_UPCOMING_CONTACTS = 10;
 
 /** Angular tolerance (degrees) for matching a Lagrange geometry. */
 const ANGLE_TOLERANCE_DEG = 1;
@@ -607,7 +627,7 @@ export class OrbitalRelationsService {
       // days will be slightly negative, which CollisionWindow.days documents as intentional.
       if (endMs < now) { continue; }
 
-      results.push({ start: new Date(startMs), end: new Date(endMs), days: (startMs - now) / MS_PER_DAY, minSeparationKm: min.sepKm });
+      results.push({ start: new Date(startMs), end: new Date(endMs), days: (startMs - now) / MS_PER_DAY, minSeparationKm: min.sepKm, partnerName: b.name, combinedRadiiKm: contactKm });
     }
     return results;
   }
@@ -633,7 +653,10 @@ export class OrbitalRelationsService {
     const range = this.orbitalRadialRange(bd);
     if (!body.parent || !bd.orbitalPeriod || !range) { return none; }
 
-    let best: { partner: SystemBody; synodic: number; events: CollisionWindow[]; contactKm: number } | null = null;
+    // Collect every sibling whose orbit actually crosses this body's within the combined
+    // radius — each is a direct collision partner. Most bodies have at most one, but three or
+    // four siblings can share crossing orbits, so a body may collide with several of them.
+    const partners: { partner: SystemBody; synodic: number; contactKm: number }[] = [];
     for (const sibling of body.parent.subBodies) {
       if (sibling === body) { continue; }
       const sd = sibling.bodyData;
@@ -653,25 +676,31 @@ export class OrbitalRelationsService {
       if (this.minOrbitDistanceKm(bd, sd, contactKm) > contactKm) { continue; }
 
       const synodic = 1 / Math.abs(1 / bd.orbitalPeriod - 1 / sd.orbitalPeriod);
-      // Fetch the first contact only for partner selection; the winning partner gets the full 10.
-      const events = this.nextContacts(bd, sd, contactKm, synodic, now, 1);
-      const first = events[0] ?? null;
-      // Prefer the partner with the soonest predicted collision; keep any geometric
-      // candidate as a fallback when timing data is unavailable for an earlier one.
-      if (!best || (first && (!best.events[0] || first.days < best.events[0].days))) {
-        best = { partner: sibling, synodic, events, contactKm };
-      }
+      partners.push({ partner: sibling, synodic, contactKm });
     }
 
-    if (!best) { return none; }
+    if (partners.length === 0) { return none; }
 
-    // Expand the winning partner to the full upcoming-collisions list.
-    const upcoming = this.nextContacts(bd, best.partner.bodyData, best.contactKm, best.synodic, now, 10);
+    // Compute each partner's upcoming contact windows, then merge them into one chronological
+    // list so the soonest collisions surface regardless of which sibling they involve. Each
+    // window already carries its partner's name and contact radius (stamped in nextContacts).
+    const merged: CollisionWindow[] = [];
+    for (const p of partners) {
+      merged.push(...this.nextContacts(bd, p.partner.bodyData, p.contactKm, p.synodic, now, MAX_UPCOMING_CONTACTS));
+    }
+    merged.sort((x, y) => x.start.getTime() - y.start.getTime());
+    const upcoming = merged.slice(0, MAX_UPCOMING_CONTACTS);
+
+    // The primary partner owns the soonest collision; fall back to the first geometric
+    // candidate when no pair has usable phase/timing data (so the badge still appears).
+    const primary = (upcoming[0]
+      ? partners.find(p => p.partner.bodyData.name === upcoming[0].partnerName)
+      : null) ?? partners[0];
 
     // Identify additional siblings that are part of the same crossing-orbit group, making
-    // this a multi-body cluster. Grow the group transitively: if A crosses B and B crosses C,
-    // C is in the group even if A doesn’t directly cross C.
-    const groupMembers = new Set<string>([bd.name, best.partner.bodyData.name]);
+    // this a multi-body cluster. Grow the group transitively from every direct partner: if
+    // A crosses B and B crosses C, C is in the group even if A doesn’t directly cross C.
+    const groupMembers = new Set<string>([bd.name, ...partners.map(p => p.partner.bodyData.name)]);
     let changed = true;
     while (changed) {
       changed = false;
@@ -698,15 +727,15 @@ export class OrbitalRelationsService {
         }
       }
     }
-    const simultaneousPartners = [...groupMembers].filter(n => n !== bd.name && n !== best!.partner.bodyData.name);
+    const simultaneousPartners = [...groupMembers].filter(n => n !== bd.name && n !== primary.partner.bodyData.name);
 
     return {
       isCandidate: true,
-      partnerName: best.partner.bodyData.name,
-      synodicPeriodDays: best.synodic,
+      partnerName: primary.partner.bodyData.name,
+      synodicPeriodDays: primary.synodic,
       nextCollision: upcoming[0] ?? null,
       upcomingCollisions: upcoming,
-      combinedRadiiKm: best.contactKm,
+      combinedRadiiKm: primary.contactKm,
       simultaneousPartners,
     };
   }

--- a/src/app/data/orbital-relations.service.ts
+++ b/src/app/data/orbital-relations.service.ts
@@ -15,6 +15,14 @@ export interface OrbitalEvent {
   days: number;
 }
 
+/** A single (time, centre-to-centre distance) sample for plotting separation against time. */
+export interface SeparationSample {
+  /** Epoch milliseconds of the sample. */
+  tMs: number;
+  /** Centre-to-centre distance (km) between the two bodies at {@link tMs}. */
+  sepKm: number;
+}
+
 /**
  * The contact *window* of a collision: a collision is an interval, not an instant. `start`
  * is when the bodies' separation first drops below the sum of their radii and `end` is when
@@ -66,6 +74,22 @@ export interface CollisionStatus {
    * Empty for simple pairs.
    */
   simultaneousPartners: string[];
+}
+
+/**
+ * A timed multi-body pile-up: an interval in which a reference body is simultaneously in
+ * contact with two or more siblings. Detected over a fixed time horizon rather than from the
+ * (capped) upcoming-contacts list, so a cluster further out than the listed rows is still found.
+ */
+export interface SimultaneousCollision {
+  /** Full names of the sibling bodies the reference body contacts at once (≥ 2). */
+  partnerNames: string[];
+  /** Earliest contact start across the cluster. */
+  start: Date;
+  /** Latest contact end across the cluster. */
+  end: Date;
+  /** Days from `now` until the cluster opens (slightly negative when already in progress). */
+  days: number;
 }
 
 /** Milliseconds per day, used to convert orbital periods (days) to wall-clock time. */
@@ -502,6 +526,51 @@ export class OrbitalRelationsService {
   }
 
   /**
+   * Builds a closure giving the centre-to-centre distance (km) between two bodies at any
+   * epoch-ms time, by propagating each body's mean anomaly from its recorded sample and
+   * evaluating its 3D Keplerian position. Returns null when either body lacks the phase
+   * data (mean anomaly + timestamp) needed to place it in time. Shared by the collision
+   * search and the distance-over-time diagram so both measure separation identically.
+   */
+  private separationFunction(a: CanonnBiostatsBody, b: CanonnBiostatsBody): ((tMs: number) => number) | null {
+    if (
+      a.meanAnomaly == null || !a.orbitalPeriod || !a.timestamps?.meanAnomaly ||
+      b.meanAnomaly == null || !b.orbitalPeriod || !b.timestamps?.meanAnomaly
+    ) { return null; }
+
+    const epochA = Date.parse(a.timestamps.meanAnomaly);
+    const epochB = Date.parse(b.timestamps.meanAnomaly);
+    return (tMs: number): number => {
+      const Ma = a.meanAnomaly! + ((tMs - epochA) / MS_PER_DAY / a.orbitalPeriod!) * 360;
+      const Mb = b.meanAnomaly! + ((tMs - epochB) / MS_PER_DAY / b.orbitalPeriod!) * 360;
+      const pa = this.orbitalStateVector(a, Ma);
+      const pb = this.orbitalStateVector(b, Mb);
+      const dx = pa.x - pb.x, dy = pa.y - pb.y, dz = pa.z - pb.z;
+      return Math.sqrt(dx * dx + dy * dy + dz * dz);
+    };
+  }
+
+  /**
+   * Centre-to-centre distance (km) between two bodies sampled at `samples` evenly-spaced
+   * instants over [startMs, endMs] inclusive — the data behind the collision dialog's
+   * distance-over-time (synodic) diagram. The curve dips to a minimum at each conjunction
+   * and is deepest when that conjunction falls on the orbits' mutual node (a collision).
+   * Returns [] when either body lacks the phase data needed to place it in time, or when
+   * the window/sample count is degenerate.
+   */
+  separationSeries(a: CanonnBiostatsBody, b: CanonnBiostatsBody, startMs: number, endMs: number, samples: number): SeparationSample[] {
+    const sep = this.separationFunction(a, b);
+    if (!sep || !(endMs > startMs) || samples < 2) { return []; }
+    const step = (endMs - startMs) / (samples - 1);
+    const out: SeparationSample[] = [];
+    for (let i = 0; i < samples; i++) {
+      const tMs = startMs + i * step;
+      out.push({ tMs, sepKm: sep(tMs) });
+    }
+    return out;
+  }
+
+  /**
    * Finds the time of minimum separation between two bodies within
    * [centerMs − halfWindowMs, centerMs + halfWindowMs] using iterative zoom: 40 samples
    * per pass, window halved and recentred on the running best each pass, until the
@@ -523,23 +592,9 @@ export class OrbitalRelationsService {
    * Not every close approach is a collision — many conjunctions miss the orbits' mutual node
    * — so each synodic event is evaluated individually rather than assumed to collide.
    */
-  private nextContacts(a: CanonnBiostatsBody, b: CanonnBiostatsBody, contactKm: number, synodicDays: number, now: number, count: number): CollisionWindow[] {
-    if (
-      a.meanAnomaly == null || !a.orbitalPeriod || !a.timestamps?.meanAnomaly ||
-      b.meanAnomaly == null || !b.orbitalPeriod || !b.timestamps?.meanAnomaly ||
-      !Number.isFinite(synodicDays)
-    ) { return []; }
-
-    const epochA = Date.parse(a.timestamps!.meanAnomaly!);
-    const epochB = Date.parse(b.timestamps!.meanAnomaly!);
-    const sep = (tMs: number): number => {
-      const Ma = a.meanAnomaly! + ((tMs - epochA) / MS_PER_DAY / a.orbitalPeriod!) * 360;
-      const Mb = b.meanAnomaly! + ((tMs - epochB) / MS_PER_DAY / b.orbitalPeriod!) * 360;
-      const pa = this.orbitalStateVector(a, Ma);
-      const pb = this.orbitalStateVector(b, Mb);
-      const dx = pa.x - pb.x, dy = pa.y - pb.y, dz = pa.z - pb.z;
-      return Math.sqrt(dx * dx + dy * dy + dz * dz);
-    };
+  private nextContacts(a: CanonnBiostatsBody, b: CanonnBiostatsBody, contactKm: number, synodicDays: number, now: number, count: number, horizonMs: number = Infinity): CollisionWindow[] {
+    const sep = this.separationFunction(a, b);
+    if (!sep || !Number.isFinite(synodicDays)) { return []; }
 
     const synodicMs = synodicDays * MS_PER_DAY;
     // 2000 steps keeps the first-pass resolution (≈ synodic/2000 per step) comfortably
@@ -593,6 +648,9 @@ export class OrbitalRelationsService {
 
     for (let k = 0; k < MAX_CONJUNCTIONS_SCANNED && results.length < count; k++) {
       const candidateMs = t0 + k * synodicMs;
+      // Stop once conjunctions march past the caller's time horizon (later ones only recede
+      // further). Used by the simultaneity scan to bound work to the next N days.
+      if (candidateMs - now > horizonMs) { break; }
       const min = zoomMin(candidateMs, synodicMs / 2);
       // Allow min.t to be slightly before now: a contact whose minimum lands at now±ε
       // (e.g. bodies aligned at the reference epoch) must not be discarded. We only skip
@@ -648,17 +706,17 @@ export class OrbitalRelationsService {
    * phase). The two agree for near-coplanar pairs but diverge on inclined pairs, where the 3D
    * model defers the collision to the next conjunction that actually falls on the mutual node.
    */
-  detectCollisionStatus(body: SystemBody, now: number = Date.now()): CollisionStatus {
-    const none: CollisionStatus = {
-      isCandidate: false, partnerName: null, synodicPeriodDays: null, nextCollision: null, upcomingCollisions: [], combinedRadiiKm: null, simultaneousPartners: [],
-    };
+  /**
+   * Every sibling under the same parent whose orbit actually crosses this body's within the
+   * combined radius — each a direct collision partner — with the pair's synodic period and
+   * contact threshold. Most bodies have at most one, but three or four siblings can share
+   * crossing orbits. Returns [] when this body itself isn't on a bound, recurring orbit.
+   */
+  private collisionPartners(body: SystemBody): { partner: SystemBody; synodic: number; contactKm: number }[] {
     const bd = body.bodyData;
     const range = this.orbitalRadialRange(bd);
-    if (!body.parent || !bd.orbitalPeriod || !range) { return none; }
+    if (!body.parent || !bd.orbitalPeriod || !range) { return []; }
 
-    // Collect every sibling whose orbit actually crosses this body's within the combined
-    // radius — each is a direct collision partner. Most bodies have at most one, but three or
-    // four siblings can share crossing orbits, so a body may collide with several of them.
     const partners: { partner: SystemBody; synodic: number; contactKm: number }[] = [];
     for (const sibling of body.parent.subBodies) {
       if (sibling === body) { continue; }
@@ -681,7 +739,101 @@ export class OrbitalRelationsService {
       const synodic = 1 / Math.abs(1 / bd.orbitalPeriod - 1 / sd.orbitalPeriod);
       partners.push({ partner: sibling, synodic, contactKm });
     }
+    return partners;
+  }
 
+  /**
+   * Every contact window for `body` across all its crossing partners that opens within the next
+   * `horizonDays`, in chronological order — uncapped, unlike {@link detectCollisionStatus}'s
+   * 10-row {@link CollisionStatus.upcomingCollisions}. Each window names its own partner. Lets the
+   * dialog mark *all* collisions inside the distance diagram's window, not just the first ten, so
+   * no in-view collision dip is left without a marker. Empty when the body has no crossing
+   * partners or lacks the phase data to time them.
+   */
+  upcomingContactsWithin(body: SystemBody, horizonDays: number, now: number = Date.now()): CollisionWindow[] {
+    return this.contactWindowsWithin(this.collisionPartners(body), body.bodyData, horizonDays * MS_PER_DAY, now)
+      .sort((a, b) => a.start.getTime() - b.start.getTime());
+  }
+
+  /**
+   * Contact windows opening within `horizonMs` for each given partner, merged (unsorted). The
+   * forward march is bounded both by the horizon and by MAX_CONJUNCTIONS_SCANNED, so tightly
+   * spaced pairs stay cheap.
+   */
+  private contactWindowsWithin(
+    partners: { partner: SystemBody; synodic: number; contactKm: number }[],
+    bodyData: CanonnBiostatsBody,
+    horizonMs: number,
+    now: number,
+  ): CollisionWindow[] {
+    const windows: CollisionWindow[] = [];
+    for (const p of partners) {
+      windows.push(...this.nextContacts(bodyData, p.partner.bodyData, p.contactKm, p.synodic, now, MAX_CONJUNCTIONS_SCANNED, horizonMs)
+        .filter(w => w.start.getTime() <= now + horizonMs));
+    }
+    return windows;
+  }
+
+  /**
+   * Timed multi-body pile-ups for `body` over the next `horizonDays`: intervals in which it is
+   * simultaneously within contact of two or more siblings. Unlike the simultaneity derived from
+   * {@link detectCollisionStatus}'s capped upcoming-contacts list, this scans every direct
+   * partner's contacts across the whole horizon, so a cluster beyond the listed rows is still
+   * found. Empty when the body has fewer than two crossing partners.
+   */
+  simultaneousCollisionsWithin(body: SystemBody, horizonDays: number, now: number = Date.now()): SimultaneousCollision[] {
+    const partners = this.collisionPartners(body);
+    if (partners.length < 2) { return []; }
+    return this.groupSimultaneous(this.contactWindowsWithin(partners, body.bodyData, horizonDays * MS_PER_DAY, now), now);
+  }
+
+  /**
+   * Groups contact windows that overlap in time; a group spanning two or more distinct partners
+   * is a simultaneous multi-body collision. Mirrors the time-overlap clustering the dialog does
+   * on its visible rows, but over the full horizon set.
+   */
+  private groupSimultaneous(windows: CollisionWindow[], now: number): SimultaneousCollision[] {
+    const sorted = [...windows].sort((a, b) => a.start.getTime() - b.start.getTime());
+    const out: SimultaneousCollision[] = [];
+    let group: CollisionWindow[] = [];
+    let maxEnd = -Infinity;
+
+    const flush = (): void => {
+      const partnerNames = new Set(group.map(w => w.partnerName).filter((n): n is string => !!n));
+      if (partnerNames.size >= 2) {
+        out.push({
+          partnerNames: [...partnerNames].sort(),
+          start: new Date(Math.min(...group.map(w => w.start.getTime()))),
+          end: new Date(Math.max(...group.map(w => w.end.getTime()))),
+          days: Math.min(...group.map(w => w.days)),
+        });
+      }
+      group = [];
+    };
+
+    for (const w of sorted) {
+      if (group.length === 0 || w.start.getTime() <= maxEnd) {
+        group.push(w);
+        maxEnd = Math.max(maxEnd, w.end.getTime());
+      } else {
+        flush();
+        group = [w];
+        maxEnd = w.end.getTime();
+      }
+    }
+    flush();
+    return out;
+  }
+
+  detectCollisionStatus(body: SystemBody, now: number = Date.now()): CollisionStatus {
+    const none: CollisionStatus = {
+      isCandidate: false, partnerName: null, synodicPeriodDays: null, nextCollision: null, upcomingCollisions: [], combinedRadiiKm: null, simultaneousPartners: [],
+    };
+    const bd = body.bodyData;
+    const range = this.orbitalRadialRange(bd);
+    if (!body.parent || !bd.orbitalPeriod || !range) { return none; }
+
+    const partners = this.collisionPartners(body);
     if (partners.length === 0) { return none; }
 
     // Compute each partner's upcoming contact windows, then merge them into one chronological

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.html
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.html
@@ -5,7 +5,7 @@
     <div class="values">
       <ul>
         <li><strong>Bodies:</strong> {{ data.bodyName }}
-          @if (data.partnerName) { &amp; {{ data.partnerName }} }
+          @if (collisionPartners.length) { &amp; {{ collisionPartners.join(', ') }} }
         </li>
         @if (data.synodicPeriodDays !== null) {
         <li><strong>Synodic period:</strong>
@@ -20,9 +20,9 @@
         @if (data.nextCollision; as c) {
         <li>
           @if (c.days < 0) {
-            <strong>Status:</strong> <span class="hint">Collision in progress now</span>
+            <strong>Status:</strong> <span class="hint">Collision in progress now with {{ windowPartner(c) }}</span>
           } @else {
-            <strong>Next collision in:</strong>
+            <strong>Next collision</strong> (with {{ windowPartner(c) }}) <strong>in:</strong>
             {{ c.days | number:'1.0-0' }} days
             @if (yearsUntil !== null && yearsUntil >= 1) { ({{ yearsUntil | number:'1.1-1' }} years) }
           }
@@ -65,6 +65,7 @@
         <thead>
           <tr>
             <th>#</th>
+            <th>With</th>
             <th>Contact start (UTC)</th>
             <th>Days until</th>
             <th>Duration</th>
@@ -72,9 +73,10 @@
           </tr>
         </thead>
         <tbody>
-          @for (w of data.upcomingCollisions; track w.start.getTime(); let i = $index) {
+          @for (w of data.upcomingCollisions; track w.start.getTime() + (w.partnerName ?? ''); let i = $index) {
           <tr>
             <td class="num">{{ i + 1 }}</td>
+            <td>{{ windowPartner(w) }}</td>
             <td class="date">{{ w.start | date:'yyyy-MM-dd HH:mm':'UTC' }} UTC</td>
             <td class="num">
               @if (w.days < 0) {

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.html
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.html
@@ -26,12 +26,12 @@
           }
         </li>
         <li><strong>Contact starts:</strong><br>
-          <span class="time">{{ c.start | date:'yyyy-MM-dd HH:mm:ss' }} <span class="tz">{{ c.start | date:'zzzz' }}
+          <span class="time">{{ localDateTime(c.start) }} <span class="tz">{{ localZoneLabel(c.start) }}
               (your time)</span></span><br>
           <span class="time">{{ c.start | date:'yyyy-MM-dd HH:mm:ss':'UTC' }} <span class="tz">UTC</span></span>
         </li>
         <li><strong>Contact ends:</strong><br>
-          <span class="time">{{ c.end | date:'yyyy-MM-dd HH:mm:ss' }} <span class="tz">{{ c.end | date:'zzzz' }} (your
+          <span class="time">{{ localDateTime(c.end) }} <span class="tz">{{ localZoneLabel(c.end) }} (your
               time)</span></span><br>
           <span class="time">{{ c.end | date:'yyyy-MM-dd HH:mm:ss':'UTC' }} <span class="tz">UTC</span></span>
         </li>
@@ -56,6 +56,61 @@
       </ul>
     </div>
 
+    @if (diagram; as dg) {
+    <div class="distance-diagram">
+      <h3>Distance over time</h3>
+      <p class="hint">
+        Centre-to-centre separation through the synodic cycle (log scale). The curve dips at each
+        conjunction; a dip below the dashed contact threshold — marked &times; — is a collision.
+      </p>
+      <svg [attr.viewBox]="'0 0 ' + dg.width + ' ' + dg.height" class="separation-chart" role="img"
+        aria-label="Distance between the bodies over time">
+        <!-- Plot frame -->
+        <rect class="plot-frame" [attr.x]="dg.plot.x" [attr.y]="dg.plot.y"
+          [attr.width]="dg.plot.w" [attr.height]="dg.plot.h" />
+
+        <!-- y-axis (distance) gridlines and labels -->
+        @for (t of dg.yTicks; track t.y) {
+        <line class="gridline" [attr.x1]="dg.plot.x" [attr.y1]="t.y"
+          [attr.x2]="dg.plot.x + dg.plot.w" [attr.y2]="t.y" />
+        <text class="axis-label y" [attr.x]="dg.plot.x - 4" [attr.y]="t.y + 3" text-anchor="end">{{ t.label }}</text>
+        }
+
+        <!-- x-axis (time) ticks and date labels -->
+        @for (t of dg.xTicks; track t.tMs) {
+        <line class="tick" [attr.x1]="t.x" [attr.y1]="dg.plot.y + dg.plot.h"
+          [attr.x2]="t.x" [attr.y2]="dg.plot.y + dg.plot.h + 3" />
+        <text class="axis-label x" [attr.x]="t.x" [attr.y]="dg.plot.y + dg.plot.h + 14" [attr.text-anchor]="t.anchor">{{
+          t.tMs | date:'MMM d, y':'UTC' }}</text>
+        }
+
+        <!-- "Now" marker -->
+        @if (dg.nowX !== null) {
+        <line class="now-line" [attr.x1]="dg.nowX" [attr.y1]="dg.plot.y"
+          [attr.x2]="dg.nowX" [attr.y2]="dg.plot.y + dg.plot.h" />
+        <text class="now-label" [attr.x]="dg.nowX" [attr.y]="dg.plot.y - 3" text-anchor="middle">now</text>
+        }
+
+        <!-- One curve per partner: contact threshold, distance polyline, collision markers -->
+        @for (s of dg.series; track s.partnerName) {
+        <line class="threshold" [attr.x1]="dg.plot.x" [attr.y1]="s.thresholdY"
+          [attr.x2]="dg.plot.x + dg.plot.w" [attr.y2]="s.thresholdY" [attr.stroke]="s.color" />
+        <polyline class="curve" [attr.points]="s.points" [attr.stroke]="s.color" />
+        @for (m of s.markers; track $index) {
+        <path class="marker" [attr.transform]="'translate(' + m.cx + ' ' + m.cy + ')'"
+          [attr.stroke]="s.color" d="M -2.6 -2.6 L 2.6 2.6 M -2.6 2.6 L 2.6 -2.6" />
+        }
+        }
+      </svg>
+
+      <ul class="legend">
+        @for (s of dg.series; track s.partnerName) {
+        <li><span class="swatch" [style.background]="s.color"></span>{{ shortName(data.bodyName) }} ↔ {{ shortName(s.partnerName) }}</li>
+        }
+      </ul>
+    </div>
+    }
+
     @if (data.upcomingCollisions.length > 0) {
     <div class="upcoming-collisions">
       <h3>Upcoming collisions</h3>
@@ -63,7 +118,7 @@
         <thead>
           <tr>
             <th>#</th>
-            <th>With</th>
+            <th>Bodies</th>
             <th>Contact start (UTC)</th>
             <th>Days until</th>
             <th>Duration</th>
@@ -74,7 +129,7 @@
           @for (w of data.upcomingCollisions; track w.start.getTime() + (w.partnerName ?? ''); let i = $index) {
           <tr [class.multi]="isMultiCollision(w)">
             <td class="num">{{ i + 1 }}</td>
-            <td>{{ windowPartner(w) }}
+            <td class="bodies">{{ shortName(data.bodyName) }} &harr; {{ windowPartner(w) }}
               @if (isMultiCollision(w)) { <span class="multi-tag" title="Multiple bodies collide at this time">multi</span> }
             </td>
             <td class="date">{{ w.start | date:'yyyy-MM-dd HH:mm':'UTC' }} UTC</td>
@@ -97,12 +152,13 @@
     </div>
     }
 
-    @if (multiCollisions.length > 0) {
+    @if (sectionMultiCollisions.length > 0) {
     <div class="multi-collisions">
       <h3>Simultaneous collisions</h3>
-      <p class="hint">Conjunctions where {{ data.bodyName }} is in contact with more than one sibling at once.</p>
+      <p class="hint">Conjunctions where {{ data.bodyName }} is in contact with more than one sibling at once,
+        including any within the next 180 days beyond the contacts listed above.</p>
       <ul>
-        @for (m of multiCollisions; track m.start.getTime()) {
+        @for (m of sectionMultiCollisions; track m.start.getTime()) {
         <li>
           <strong>{{ data.bodyName }}, {{ m.partners.join(', ') }}</strong> —
           @if (m.days < 0) {

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.html
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.html
@@ -4,9 +4,7 @@
 
     <div class="values">
       <ul>
-        <li><strong>Bodies:</strong> {{ data.bodyName }}
-          @if (collisionPartners.length) { &amp; {{ collisionPartners.join(', ') }} }
-        </li>
+        <li><strong>Bodies:</strong> {{ joinNames(involvedBodyNames) }}</li>
         @if (data.synodicPeriodDays !== null) {
         <li><strong>Synodic period:</strong>
           {{ data.synodicPeriodDays | number:'1.0-0' }} days
@@ -74,9 +72,11 @@
         </thead>
         <tbody>
           @for (w of data.upcomingCollisions; track w.start.getTime() + (w.partnerName ?? ''); let i = $index) {
-          <tr>
+          <tr [class.multi]="isMultiCollision(w)">
             <td class="num">{{ i + 1 }}</td>
-            <td>{{ windowPartner(w) }}</td>
+            <td>{{ windowPartner(w) }}
+              @if (isMultiCollision(w)) { <span class="multi-tag" title="Multiple bodies collide at this time">multi</span> }
+            </td>
             <td class="date">{{ w.start | date:'yyyy-MM-dd HH:mm':'UTC' }} UTC</td>
             <td class="num">
               @if (w.days < 0) {
@@ -94,6 +94,26 @@
           }
         </tbody>
       </table>
+    </div>
+    }
+
+    @if (multiCollisions.length > 0) {
+    <div class="multi-collisions">
+      <h3>Simultaneous collisions</h3>
+      <p class="hint">Conjunctions where {{ data.bodyName }} is in contact with more than one sibling at once.</p>
+      <ul>
+        @for (m of multiCollisions; track m.start.getTime()) {
+        <li>
+          <strong>{{ data.bodyName }}, {{ m.partners.join(', ') }}</strong> —
+          @if (m.days < 0) {
+            <span class="hint">in progress now</span>
+          } @else {
+            around {{ m.start | date:'yyyy-MM-dd HH:mm':'UTC' }} UTC
+            ({{ m.days | number:'1.0-0' }} days)
+          }
+        </li>
+        }
+      </ul>
     </div>
     }
 

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.scss
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.scss
@@ -35,6 +35,107 @@
         line-height: 1.6;
     }
 
+    .distance-diagram {
+        margin-bottom: 20px;
+
+        h3 {
+            margin: 0 0 6px;
+            font-size: 1em;
+            font-weight: 600;
+        }
+
+        p {
+            margin: 0 0 10px;
+        }
+
+        .separation-chart {
+            display: block;
+            width: 100%;
+            max-width: 540px;
+            height: auto;
+            margin: 0 auto;
+
+            .plot-frame {
+                fill: none;
+                stroke: var(--color-surface-border, rgba(255, 255, 255, 0.18));
+                stroke-width: 1;
+            }
+
+            .gridline {
+                stroke: var(--color-surface-border, rgba(255, 255, 255, 0.08));
+                stroke-width: 0.5;
+            }
+
+            .tick {
+                stroke: var(--color-surface-border, rgba(255, 255, 255, 0.18));
+                stroke-width: 1;
+            }
+
+            .axis-label {
+                fill: currentColor;
+                opacity: 0.65;
+                font-size: 8px;
+                font-variant-numeric: tabular-nums;
+            }
+
+            .now-line {
+                stroke: var(--color-text, rgba(255, 255, 255, 0.55));
+                stroke-width: 1;
+                stroke-dasharray: 2 2;
+                opacity: 0.6;
+            }
+
+            .now-label {
+                fill: currentColor;
+                opacity: 0.7;
+                font-size: 8px;
+            }
+
+            .threshold {
+                stroke-width: 1;
+                stroke-dasharray: 4 3;
+                opacity: 0.7;
+            }
+
+            .curve {
+                fill: none;
+                stroke-width: 1.4;
+                stroke-linejoin: round;
+                stroke-linecap: round;
+            }
+
+            .marker {
+                stroke-width: 1.4;
+                stroke-linecap: round;
+                fill: none;
+            }
+        }
+
+        .legend {
+            list-style: none;
+            padding-left: 0;
+            margin: 8px 0 0;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px 16px;
+            justify-content: center;
+            font-size: 0.85em;
+
+            li {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+            }
+
+            .swatch {
+                display: inline-block;
+                width: 12px;
+                height: 3px;
+                border-radius: 2px;
+            }
+        }
+    }
+
     .upcoming-collisions {
         margin-bottom: 20px;
 

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.scss
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.scss
@@ -76,6 +76,52 @@
             tbody tr:hover {
                 background: var(--color-surface-hover, rgba(255, 255, 255, 0.05));
             }
+
+            // Rows whose contact coincides with another sibling's — a multi-body pile-up.
+            tbody tr.multi {
+                background: var(--color-warning-surface, rgba(255, 170, 60, 0.12));
+
+                &:hover {
+                    background: var(--color-warning-surface, rgba(255, 170, 60, 0.18));
+                }
+            }
+        }
+    }
+
+    .multi-tag {
+        margin-left: 6px;
+        padding: 0 6px;
+        border-radius: 8px;
+        font-size: 0.75em;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        background: var(--color-warning-surface, rgba(255, 170, 60, 0.18));
+        color: var(--color-warning, #ffaa3c);
+    }
+
+    .multi-collisions {
+        margin-bottom: 20px;
+
+        h3 {
+            margin: 0 0 6px;
+            font-size: 1em;
+            font-weight: 600;
+        }
+
+        p {
+            margin: 0 0 10px;
+        }
+
+        ul {
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+        }
+
+        li {
+            padding: 4px 0;
+            line-height: 1.5;
         }
     }
 }

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.spec.ts
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 
-import { CollisionDialogComponent, CollisionDialogData } from './collision-dialog.component';
+import { CollisionDialogComponent, CollisionDialogData, CollisionBodyInfo } from './collision-dialog.component';
 
 function setup(data: CollisionDialogData): ComponentFixture<CollisionDialogComponent> {
   TestBed.configureTestingModule({
@@ -115,6 +115,10 @@ describe('CollisionDialogComponent', () => {
     const c = fixture.componentInstance;
     // Both crossing partners are surfaced for the "Bodies" line.
     expect(c.collisionPartners).toEqual(['Test 1 c', 'Test 1 d']);
+    // The "Bodies" line joins consistently (commas, single "&" before the last), no mixed separators.
+    expect(c.involvedBodyNames).toEqual(['Test 1 b', 'Test 1 c', 'Test 1 d']);
+    expect(c.joinNames(c.involvedBodyNames)).toBe('Test 1 b, Test 1 c & Test 1 d');
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('Test 1 b, Test 1 c & Test 1 d');
     // Each window names its own partner (system prefix stripped).
     expect(c.windowPartner(windows[0])).toBe('1 c');
     expect(c.windowPartner(windows[1])).toBe('1 d');
@@ -124,6 +128,138 @@ describe('CollisionDialogComponent', () => {
     const el: HTMLElement = fixture.nativeElement;
     expect(el.textContent).toContain('1 c');
     expect(el.textContent).toContain('1 d');
+  });
+
+  it('builds the prose summary for a same-type, inhabited, three-body cluster', () => {
+    const rocky = (moonCount: number, hasRings: boolean, period: number): CollisionBodyInfo => ({
+      subType: 'Rocky body', atmosphereType: 'Carbon dioxide', orbitalPeriodDays: period, moonCount, hasRings,
+    });
+    const windows = [
+      { start: new Date(), end: new Date(), days: 3, minSeparationKm: 200, partnerName: 'Test 1 c', combinedRadiiKm: 1000 },
+      { start: new Date(), end: new Date(), days: 7, minSeparationKm: 400, partnerName: 'Test 1 d', combinedRadiiKm: 1000 },
+    ];
+    const desc = setup({
+      bodyName: 'Test 1 b', partnerName: 'Test 1 c', synodicPeriodDays: 6.2, combinedRadiiKm: 1000,
+      upcomingCollisions: windows, bodyInfo: rocky(2, true, 5.0),
+      partnerInfo: rocky(1, false, 5.02),
+      partnerInfos: [
+        { name: 'Test 1 c', info: rocky(1, false, 5.02) },
+        { name: 'Test 1 d', info: rocky(0, false, 5.04) },
+      ],
+      systemPopulation: 1_500_000, systemName: 'Test', simultaneousPartners: ['Test 1 d'], nextCollision: windows[0],
+    }).componentInstance.description;
+
+    expect(desc).toContain('inhabited system (1,500,000 inhabitants)');
+    expect(desc).toContain('three Rocky bodies (1 b, 1 c and 1 d)');   // all candidates listed by type
+    expect(desc).toContain('carbon dioxide atmospheres');             // shared-atmosphere branch
+    expect(desc).toContain('periods of 5.00, 5.02 and 5.04 days');    // >2 bodies: list all periods
+    expect(desc).toContain('1 b has 2 moons');                        // moons feature
+    expect(desc).toContain('1 b has rings');                          // rings feature
+    expect(desc).toContain('1 c has 1 moon');                         // singular moon
+    expect(desc).toContain('pass each other every 6 days');           // sub-year synodic phrasing
+    expect(desc).toContain('2 collisions are predicted');             // frequency from upcoming list
+    expect(desc).toContain('1 b, 1 c and 1 d all have crossing orbits'); // multi-body sentence
+  });
+
+  it('builds the prose summary for an uninhabited pair of differing types', () => {
+    const bi: CollisionBodyInfo = {
+      subType: 'High metal content world', atmosphereType: 'Sulphur dioxide', orbitalPeriodDays: 100, moonCount: 0, hasRings: false,
+    };
+    const pi: CollisionBodyInfo = {
+      subType: 'Icy body', atmosphereType: null, orbitalPeriodDays: 110, moonCount: 0, hasRings: false,
+    };
+    const windows = Array.from({ length: 3 }, (_, i) => ({
+      start: new Date(), end: new Date(), days: (i + 1) * 400, minSeparationKm: 100, partnerName: 'Test 1 c', combinedRadiiKm: 1000,
+    }));
+    const desc = setup({
+      bodyName: 'Test 1 b', partnerName: 'Test 1 c', synodicPeriodDays: 1100, combinedRadiiKm: 1000,
+      upcomingCollisions: windows, bodyInfo: bi, partnerInfo: pi, systemPopulation: 0,
+      systemName: 'Test', simultaneousPartners: [], nextCollision: windows[0],
+    }).componentInstance.description;
+
+    expect(desc).toContain('uninhabited system');
+    expect(desc).toContain('a High metal content world (1 b) with sulphur dioxide atmosphere'); // differing-type branch
+    expect(desc).toContain('and a Icy body (1 c)');
+    expect(desc).toContain('They orbit with periods of 100.00 and 110.00 days');
+    expect(desc).toContain('pass each other every 3.0 years');      // multi-year synodic phrasing
+  });
+
+  it('labels overlap severity across the threshold bands', () => {
+    const make = (minSeparationKm: number) => { TestBed.resetTestingModule(); return setup({
+      bodyName: 'A', partnerName: 'B', synodicPeriodDays: 10, combinedRadiiKm: 1000,
+      upcomingCollisions: [], bodyInfo: null, partnerInfo: null, systemPopulation: 0, systemName: '', simultaneousPartners: [],
+      nextCollision: { start: new Date(), end: new Date(), days: 1, minSeparationKm },
+    }).componentInstance; };
+
+    expect(make(990).overlapLabel).toBe('Glancing blow');   //  1% overlap (<2)
+    expect(make(700).overlapLabel).toBe('Minor impact');    // 30% overlap (<50)
+    expect(make(100).overlapLabel).toBe('Major impact');    // 90% overlap (<98)
+    expect(make(5).overlapLabel).toBe('Head-on collision'); // 99.5% overlap (>=98)
+  });
+
+  it('formats contact-window durations and degrades gracefully for sub-minute windows', () => {
+    const c = setup({
+      bodyName: 'A', partnerName: 'B', synodicPeriodDays: 10, combinedRadiiKm: 1000,
+      upcomingCollisions: [], bodyInfo: null, partnerInfo: null, systemPopulation: 0, systemName: '', simultaneousPartners: [],
+      nextCollision: { start: new Date(), end: new Date(), days: 1, minSeparationKm: 100 },
+    }).componentInstance;
+
+    const win = (ms: number) => ({ start: new Date(0), end: new Date(ms), days: 0, minSeparationKm: 0 });
+    // 2 days 4 hours 5 minutes → Oxford-comma join of three units.
+    expect(c.formatDuration(win((2 * 1440 + 4 * 60 + 5) * 60000))).toBe('2 days, 4 hours and 5 minutes');
+    // Exactly one hour → single unit, no conjunction.
+    expect(c.formatDuration(win(60 * 60000))).toBe('1 hour');
+    // Two units → joined with "and".
+    expect(c.formatDuration(win((60 + 1) * 60000))).toBe('1 hour and 1 minute');
+    // Under a minute → fallback string.
+    expect(c.formatDuration(win(20_000))).toBe('less than 1 minute');
+  });
+
+  it('groups time-overlapping windows from different partners into a simultaneous collision', () => {
+    // Two partners (1 c, 1 d) whose contact windows overlap in time → a 3-body pile-up;
+    // a later, isolated 1 c contact is a plain pairwise event and must not be flagged.
+    const cMulti = { start: new Date('2026-07-01T00:00:00Z'), end: new Date('2026-07-01T02:00:00Z'),
+      days: 3, minSeparationKm: 200, partnerName: 'Test 1 c', combinedRadiiKm: 1000 };
+    const dMulti = { start: new Date('2026-07-01T01:00:00Z'), end: new Date('2026-07-01T03:00:00Z'),
+      days: 3, minSeparationKm: 300, partnerName: 'Test 1 d', combinedRadiiKm: 1000 };
+    const cLone = { start: new Date('2026-08-01T00:00:00Z'), end: new Date('2026-08-01T01:00:00Z'),
+      days: 34, minSeparationKm: 250, partnerName: 'Test 1 c', combinedRadiiKm: 1000 };
+    const fixture = setup({
+      bodyName: 'Test 1 b', partnerName: 'Test 1 c', synodicPeriodDays: 6, combinedRadiiKm: 1000,
+      upcomingCollisions: [cMulti, dMulti, cLone], bodyInfo: null, partnerInfo: null,
+      systemPopulation: 0, systemName: 'Test', simultaneousPartners: ['Test 1 d'], nextCollision: cMulti,
+    });
+    const c = fixture.componentInstance;
+
+    expect(c.multiCollisions.length).toBe(1);
+    expect(c.multiCollisions[0].partners).toEqual(['1 c', '1 d']);
+    expect(c.multiCollisions[0].start).toEqual(cMulti.start); // earliest start in the cluster
+    expect(c.multiCollisions[0].end).toEqual(dMulti.end);     // latest end in the cluster
+
+    // The overlapping rows are flagged; the lone later contact is not.
+    expect(c.isMultiCollision(cMulti)).toBe(true);
+    expect(c.isMultiCollision(dMulti)).toBe(true);
+    expect(c.isMultiCollision(cLone)).toBe(false);
+
+    // The "multi" marker and the simultaneous-collisions section render.
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('tr.multi')).not.toBeNull();
+    expect(el.textContent).toContain('Simultaneous collisions');
+    expect(el.textContent).toContain('Test 1 b, 1 c, 1 d');
+  });
+
+  it('reports no simultaneous collisions for a plain pairwise sequence', () => {
+    const windows = Array.from({ length: 3 }, (_, i) => ({
+      start: new Date(2026, 6, 1 + i * 5), end: new Date(2026, 6, 1 + i * 5, 1),
+      days: i * 5, minSeparationKm: 200, partnerName: 'Test 1 c', combinedRadiiKm: 1000,
+    }));
+    const c = setup({
+      bodyName: 'Test 1 b', partnerName: 'Test 1 c', synodicPeriodDays: 6, combinedRadiiKm: 1000,
+      upcomingCollisions: windows, bodyInfo: null, partnerInfo: null, systemPopulation: 0,
+      systemName: 'Test', simultaneousPartners: [], nextCollision: windows[0],
+    }).componentInstance;
+    expect(c.multiCollisions).toEqual([]);
+    expect(c.isMultiCollision(windows[0])).toBe(false);
   });
 
   it('shows the candidate heading and an explanatory note when timing data is missing', () => {

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.spec.ts
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.spec.ts
@@ -99,7 +99,7 @@ describe('CollisionDialogComponent', () => {
     expect(fixture.componentInstance.description).toContain('5 collisions are predicted over the next 5 years.');
   });
 
-  it('lists every crossing partner and renders a per-partner "With" column for multi-body clusters', () => {
+  it('lists every crossing partner and names both involved bodies per row for multi-body clusters', () => {
     const windows = [
       { start: new Date('2026-07-01T00:00:00Z'), end: new Date('2026-07-01T01:00:00Z'),
         days: 3, minSeparationKm: 200, partnerName: 'Test 1 c', combinedRadiiKm: 1000 },
@@ -124,10 +124,11 @@ describe('CollisionDialogComponent', () => {
     expect(c.windowPartner(windows[1])).toBe('1 d');
     // Overlap uses the window's own combined radii, not the status-level value.
     expect(c.overlapPercentFor(windows[1])).toBeCloseTo((1 - 400 / 800) * 100, 6);
-    // Both partners appear in the rendered table.
+    // Each row names BOTH involved bodies (this body ↔ partner), not just the partner.
     const el: HTMLElement = fixture.nativeElement;
-    expect(el.textContent).toContain('1 c');
-    expect(el.textContent).toContain('1 d');
+    const bodyCells = [...el.querySelectorAll('.upcoming-collisions td.bodies')].map(td => td.textContent ?? '');
+    expect(bodyCells[0]).toContain('1 b ↔ 1 c');
+    expect(bodyCells[1]).toContain('1 b ↔ 1 d');
   });
 
   it('builds the prose summary for a same-type, inhabited, three-body cluster', () => {
@@ -260,6 +261,85 @@ describe('CollisionDialogComponent', () => {
     }).componentInstance;
     expect(c.multiCollisions).toEqual([]);
     expect(c.isMultiCollision(windows[0])).toBe(false);
+  });
+
+  it('lists simultaneous collisions from the 180-day scan, beyond the visible contact rows', () => {
+    // A single visible contact (no in-table coincidence), but the service-supplied scan found a
+    // pile-up further out — the section must show it, using short names sorted.
+    const lone = { start: new Date('2026-07-01T00:00:00Z'), end: new Date('2026-07-01T01:00:00Z'),
+      days: 3, minSeparationKm: 200, partnerName: 'Test 1 c', combinedRadiiKm: 1000 };
+    const fixture = setup({
+      bodyName: 'Test 1 b', partnerName: 'Test 1 c', synodicPeriodDays: 6, combinedRadiiKm: 1000,
+      upcomingCollisions: [lone], bodyInfo: null, partnerInfo: null, systemPopulation: 0,
+      systemName: 'Test', simultaneousPartners: ['Test 1 a'], nextCollision: lone,
+      simultaneousCollisions: [{
+        partnerNames: ['Test 1 c', 'Test 1 a'],
+        start: new Date('2026-09-15T08:00:00Z'), end: new Date('2026-09-15T10:00:00Z'), days: 79,
+      }],
+    });
+    const c = fixture.componentInstance;
+    // The row-derived clustering sees no coincidence (one lone contact)…
+    expect(c.multiCollisions).toEqual([]);
+    // …but the section prefers the scanned clusters, with short, sorted partner names.
+    expect(c.sectionMultiCollisions.length).toBe(1);
+    expect(c.sectionMultiCollisions[0].partners).toEqual(['1 a', '1 c']);
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('Simultaneous collisions');
+    expect(el.textContent).toContain('Test 1 b, 1 a, 1 c');
+    expect(el.textContent).toContain('2026-09-15 08:00 UTC');
+  });
+
+  it('renders local contact times in the viewer zone with a DST-aware offset label', () => {
+    const c = setup({
+      bodyName: 'A', partnerName: 'B', synodicPeriodDays: 10, combinedRadiiKm: 1000,
+      upcomingCollisions: [], bodyInfo: null, partnerInfo: null, systemPopulation: 0, systemName: '', simultaneousPartners: [],
+      nextCollision: { start: new Date('2026-07-15T12:00:00Z'), end: new Date('2026-07-15T13:00:00Z'), days: 1, minSeparationKm: 100 },
+    }).componentInstance;
+    // Local wall-clock string is always "yyyy-MM-dd HH:mm:ss", regardless of the runner's zone.
+    expect(c.localDateTime(new Date('2026-07-15T12:00:00Z'))).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    // The offset label is non-empty and derived per-date (DST), e.g. "GMT+2"/"GMT+1"/"UTC".
+    const summer = c.localZoneLabel(new Date('2026-07-15T12:00:00Z'));
+    const winter = c.localZoneLabel(new Date('2026-01-15T12:00:00Z'));
+    expect(summer).toBeTruthy();
+    expect(winter).toBeTruthy();
+    // In any DST-observing zone the summer and winter offsets differ; in a fixed zone (e.g. UTC on
+    // CI) they match — both are valid, so we only assert the labels are produced.
+  });
+
+  it('renders the distance-over-time diagram when separation samples are supplied', () => {
+    const start = Date.parse('2026-07-01T00:00:00Z');
+    const samples = Array.from({ length: 11 }, (_, i) => ({
+      tMs: start + i * 86_400_000,
+      sepKm: 1000 + Math.abs(i - 5) * 200_000, // dips to the contact threshold at the midpoint
+    }));
+    const fixture = setup({
+      bodyName: 'Test 1 b', partnerName: 'Test 1 c', synodicPeriodDays: 10, combinedRadiiKm: 1000,
+      upcomingCollisions: [], bodyInfo: null, partnerInfo: null, systemPopulation: 0,
+      systemName: 'Test', simultaneousPartners: [],
+      nextCollision: { start: new Date(start), end: new Date(start + 3_600_000), days: 3, minSeparationKm: 800 },
+      separationDiagram: {
+        startMs: start, endMs: start + 10 * 86_400_000, nowMs: start,
+        series: [{ partnerName: 'Test 1 c', combinedRadiiKm: 1000, samples, contacts: [{ tMs: start + 5 * 86_400_000, sepKm: 1000 }] }],
+      },
+    });
+    const c = fixture.componentInstance;
+    expect(c.diagram).not.toBeNull();
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('svg.separation-chart')).not.toBeNull();
+    expect(el.querySelector('polyline.curve')).not.toBeNull();
+    expect(el.textContent).toContain('Distance over time');
+    // Legend pairs this body with the partner (short names).
+    expect(el.querySelector('.legend')?.textContent).toContain('1 b ↔ 1 c');
+  });
+
+  it('omits the distance diagram when no separation samples are supplied', () => {
+    const fixture = setup({
+      bodyName: 'A', partnerName: 'B', synodicPeriodDays: 10, combinedRadiiKm: 1000,
+      upcomingCollisions: [], bodyInfo: null, partnerInfo: null, systemPopulation: 0, systemName: '', simultaneousPartners: [],
+      nextCollision: { start: new Date(), end: new Date(), days: 1, minSeparationKm: 100 },
+    });
+    expect(fixture.componentInstance.diagram).toBeNull();
+    expect((fixture.nativeElement as HTMLElement).querySelector('svg.separation-chart')).toBeNull();
   });
 
   it('shows the candidate heading and an explanatory note when timing data is missing', () => {

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.spec.ts
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.spec.ts
@@ -99,6 +99,33 @@ describe('CollisionDialogComponent', () => {
     expect(fixture.componentInstance.description).toContain('5 collisions are predicted over the next 5 years.');
   });
 
+  it('lists every crossing partner and renders a per-partner "With" column for multi-body clusters', () => {
+    const windows = [
+      { start: new Date('2026-07-01T00:00:00Z'), end: new Date('2026-07-01T01:00:00Z'),
+        days: 3, minSeparationKm: 200, partnerName: 'Test 1 c', combinedRadiiKm: 1000 },
+      { start: new Date('2026-07-05T00:00:00Z'), end: new Date('2026-07-05T01:00:00Z'),
+        days: 7, minSeparationKm: 400, partnerName: 'Test 1 d', combinedRadiiKm: 800 },
+    ];
+    const fixture = setup({
+      bodyName: 'Test 1 b', partnerName: 'Test 1 c', synodicPeriodDays: 5, combinedRadiiKm: 1000,
+      upcomingCollisions: windows, bodyInfo: null, partnerInfo: null, systemPopulation: 0,
+      systemName: 'Test', simultaneousPartners: ['Test 1 d'],
+      nextCollision: windows[0],
+    });
+    const c = fixture.componentInstance;
+    // Both crossing partners are surfaced for the "Bodies" line.
+    expect(c.collisionPartners).toEqual(['Test 1 c', 'Test 1 d']);
+    // Each window names its own partner (system prefix stripped).
+    expect(c.windowPartner(windows[0])).toBe('1 c');
+    expect(c.windowPartner(windows[1])).toBe('1 d');
+    // Overlap uses the window's own combined radii, not the status-level value.
+    expect(c.overlapPercentFor(windows[1])).toBeCloseTo((1 - 400 / 800) * 100, 6);
+    // Both partners appear in the rendered table.
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('1 c');
+    expect(el.textContent).toContain('1 d');
+  });
+
   it('shows the candidate heading and an explanatory note when timing data is missing', () => {
     const fixture = setup({
       bodyName: 'A', partnerName: 'B', synodicPeriodDays: 10, combinedRadiiKm: 1000,

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.ts
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.ts
@@ -23,9 +23,16 @@ export interface CollisionDialogData {
   upcomingCollisions: CollisionWindow[];
   /** Sum of the two bodies' radii (km) — the contact threshold. */
   combinedRadiiKm: number | null;
-  /** Per-body descriptive info used to build the summary paragraph. */
+  /** Descriptive info for this body, used to build the summary paragraph. */
   bodyInfo: CollisionBodyInfo | null;
+  /** Descriptive info for the primary partner. Retained for the simple-pair path and as a fallback. */
   partnerInfo: CollisionBodyInfo | null;
+  /**
+   * Descriptive info for every collision candidate beyond this body (each crossing partner and
+   * simultaneous-cluster member), so the summary can enumerate all involved bodies — not just the
+   * primary pair. Optional: when absent the prose falls back to {@link partnerInfo} for the pair.
+   */
+  partnerInfos?: { name: string; info: CollisionBodyInfo | null }[];
   /** System population; 0 when uninhabited or unknown. */
   systemPopulation: number;
   /** System name, used to strip the prefix from body names in the description. */
@@ -34,8 +41,30 @@ export interface CollisionDialogData {
   simultaneousPartners: string[];
 }
 
+/**
+ * A simultaneous multi-body collision: a cluster of overlapping contact windows in which this
+ * body is within contact of two or more siblings at the same time (a three- or four-body pile-up).
+ */
+export interface MultiCollision {
+  /** Short names of the sibling bodies involved (this body is always implicitly present too). */
+  partners: string[];
+  /** Earliest contact start across the cluster. */
+  start: Date;
+  /** Latest contact end across the cluster. */
+  end: Date;
+  /** Days from now until the cluster opens (negative when already in progress). */
+  days: number;
+}
+
 /** Days in a Julian year, used to express long intervals (synodic period, time-to-collision) in years. */
 const DAYS_PER_YEAR = 365.25;
+
+/** Cardinal-number words for small counts (collisions involve at most a handful of bodies). */
+const NUMBER_WORDS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight'];
+/** "two", "three"… for small counts, falling back to the digit string for larger ones. */
+function numberWord(n: number): string {
+  return NUMBER_WORDS[n] ?? String(n);
+}
 
 /**
  * Details of a predicted collision between two sibling bodies: when the contact window opens
@@ -119,6 +148,97 @@ export class CollisionDialogComponent {
   }
 
   /**
+   * Every body involved in the collision, this one first: drawn from the upcoming windows, the
+   * primary partner, and the simultaneous-cluster members (deduplicated, full names). This is the
+   * single source of truth for both the "Bodies" line and the prose, so they never disagree.
+   */
+  public get involvedBodyNames(): string[] {
+    const names = new Set<string>([this.data.bodyName]);
+    for (const w of this.data.upcomingCollisions) {
+      if (w.partnerName) { names.add(w.partnerName); }
+    }
+    if (this.data.partnerName) { names.add(this.data.partnerName); }
+    for (const n of this.data.simultaneousPartners) { names.add(n); }
+    return [...names];
+  }
+
+  /** Descriptive info for a body by full name, from bodyInfo / partnerInfos / partnerInfo. Null when unknown. */
+  private infoFor(name: string): CollisionBodyInfo | null {
+    if (name === this.data.bodyName) { return this.data.bodyInfo; }
+    const match = this.data.partnerInfos?.find(p => p.name === name);
+    if (match) { return match.info; }
+    if (name === this.data.partnerName) { return this.data.partnerInfo; }
+    return null;
+  }
+
+  /** The involved bodies paired with their short name and descriptive info, for the prose builder. */
+  private get involvedBodies(): { name: string; short: string; info: CollisionBodyInfo | null }[] {
+    return this.involvedBodyNames.map(name => ({ name, short: this.shortName(name), info: this.infoFor(name) }));
+  }
+
+  /** Joins names as "A", "A & B", or "A, B & C" using the given conjunction ("&" or "and"). */
+  public joinNames(names: string[], conjunction = '&'): string {
+    const list = names.filter(Boolean);
+    if (list.length <= 1) { return list[0] ?? ''; }
+    if (list.length === 2) { return `${list[0]} ${conjunction} ${list[1]}`; }
+    return `${list.slice(0, -1).join(', ')} ${conjunction} ${list[list.length - 1]}`;
+  }
+
+  /**
+   * Groups the upcoming contact windows by time overlap. When two windows with *different*
+   * partners overlap, this body is touching both siblings at once — a simultaneous multi-body
+   * collision. Cached because both {@link multiCollisions} and {@link isMultiCollision} read it.
+   */
+  private clusterCache: { multi: MultiCollision[]; flagged: Set<CollisionWindow> } | null = null;
+  private get clusters(): { multi: MultiCollision[]; flagged: Set<CollisionWindow> } {
+    if (this.clusterCache) { return this.clusterCache; }
+    const windows = [...this.data.upcomingCollisions].sort((a, b) => a.start.getTime() - b.start.getTime());
+    const multi: MultiCollision[] = [];
+    const flagged = new Set<CollisionWindow>();
+    let group: CollisionWindow[] = [];
+    let maxEnd = -Infinity;
+
+    const flush = (): void => {
+      const partners = new Set(group.map(w => w.partnerName ?? this.data.partnerName ?? ''));
+      // Two or more distinct partners overlapping in time = a genuine multi-body pile-up.
+      if (partners.size >= 2) {
+        group.forEach(w => flagged.add(w));
+        multi.push({
+          partners: [...partners].map(n => this.shortName(n)).sort(),
+          start: new Date(Math.min(...group.map(w => w.start.getTime()))),
+          end: new Date(Math.max(...group.map(w => w.end.getTime()))),
+          days: Math.min(...group.map(w => w.days)),
+        });
+      }
+      group = [];
+    };
+
+    for (const w of windows) {
+      if (group.length === 0 || w.start.getTime() <= maxEnd) {
+        group.push(w);
+        maxEnd = Math.max(maxEnd, w.end.getTime());
+      } else {
+        flush();
+        group = [w];
+        maxEnd = w.end.getTime();
+      }
+    }
+    flush();
+    this.clusterCache = { multi, flagged };
+    return this.clusterCache;
+  }
+
+  /** Simultaneous multi-body collisions among the upcoming windows (empty for simple pairs). */
+  public get multiCollisions(): MultiCollision[] {
+    return this.clusters.multi;
+  }
+
+  /** True when this contact window coincides with another partner's — part of a multi-body collision. */
+  public isMultiCollision(w: CollisionWindow): boolean {
+    return this.clusters.flagged.has(w);
+  }
+
+  /**
    * Prose summary of the collision pair: population, body types, atmospheres, moons/rings,
    * period difference, synodic interval, and a rough collision-frequency hint.
    */
@@ -136,9 +256,6 @@ export class CollisionDialogComponent {
       return [...words.slice(0, -1), plural].join(' ');
     };
 
-    /** Body name with the system-name prefix stripped (e.g. "Foo System 1 a" → "1 a"). */
-    const shortName = (name: string): string => this.shortName(name);
-
     /** Atmosphere description, or empty string when there is none. */
     const atmoStr = (info: CollisionBodyInfo | null): string => {
       const a = info?.atmosphereType;
@@ -153,53 +270,54 @@ export class CollisionDialogComponent {
       parts.push('This uninhabited system');
     }
 
-    // Body types and atmospheres.
-    const bi = d.bodyInfo, pi = d.partnerInfo;
+    // Body types and atmospheres across every involved body — not just the primary pair.
+    const involved = this.involvedBodies;
+    const shorts = involved.map(b => b.short);
+    const allKnown = involved.length >= 2 && involved.every(b => b.info);
+    const sameType = allKnown && involved.every(b => b.info!.subType === involved[0].info!.subType);
 
-    if (bi && pi && bi.subType === pi.subType) {
-      // Both the same type: "contains two Rocky bodies"
-      parts[0] += ` contains two ${pluralise(bi.subType)}`;
-      const atmoA = atmoStr(bi), atmoB = atmoStr(pi);
-      if (atmoA && atmoA === atmoB) {
-        parts[0] += ` with ${atmoA}s`;           // "with carbon dioxide atmospheres"
-      } else if (atmoA && atmoB) {
-        parts[0] += `, one with ${atmoA} and one with ${atmoB}`;
-      } else if (atmoA) {
-        parts[0] += `, one with ${atmoA}`;
+    if (sameType) {
+      // All the same type: "contains three Rocky bodies (1 a, 1 b and 1 c)".
+      parts[0] += ` contains ${numberWord(involved.length)} ${pluralise(involved[0].info!.subType)}` +
+        ` (${this.joinNames(shorts, 'and')})`;
+      const atmos = involved.map(b => atmoStr(b.info));
+      if (atmos.every(a => a && a === atmos[0])) {
+        parts[0] += ` with ${atmos[0]}s`;               // "with carbon dioxide atmospheres"
       }
-    } else if (bi && pi) {
-      // Different types: list each separately.
-      const aA = atmoStr(bi), aB = atmoStr(pi);
-      parts[0] += ` contains a ${bi.subType} (${shortName(d.bodyName)})`;
-      if (aA) { parts[0] += ` with ${aA}`; }
-      parts[0] += ` and a ${pi.subType} (${shortName(d.partnerName ?? '')})`;
-      if (aB) { parts[0] += ` with ${aB}`; }
+    } else if (allKnown) {
+      // Mixed types: list each body with its type, name and atmosphere.
+      const items = involved.map(b => {
+        const a = atmoStr(b.info);
+        return `a ${b.info!.subType} (${b.short})` + (a ? ` with ${a}` : '');
+      });
+      parts[0] += ` contains ${this.joinNames(items, 'and')}`;
     } else {
-      parts[0] += ` contains two bodies`;
-    }
-
-    if (d.partnerName) {
-      parts[0] += ` (${shortName(d.bodyName)} and ${shortName(d.partnerName)})`;
+      // Some types unknown: still enumerate the bodies by name.
+      parts[0] += ` contains ${numberWord(involved.length)} bodies (${this.joinNames(shorts, 'and')})`;
     }
     parts[0] += '.';
 
-    // Orbital periods and how close they are.
-    if (bi && pi) {
-      const pA = bi.orbitalPeriodDays, pB = pi.orbitalPeriodDays;
+    // Orbital periods. For a pair, quantify how close they are; for more, just list them.
+    const withPeriods = involved.filter(b => b.info?.orbitalPeriodDays);
+    if (withPeriods.length === 2) {
+      const pA = withPeriods[0].info!.orbitalPeriodDays, pB = withPeriods[1].info!.orbitalPeriodDays;
       const diffMin = Math.abs(pA - pB) * 24 * 60;
       const diffPct = (Math.abs(pA - pB) / Math.min(pA, pB)) * 100;
       parts.push(
         `They orbit with periods of ${pA.toFixed(2)} and ${pB.toFixed(2)} days` +
         ` (differ by ${diffMin.toFixed(0)} minutes, ${diffPct.toFixed(1)}%).`
       );
+    } else if (withPeriods.length > 2) {
+      const periodStrs = withPeriods.map(b => b.info!.orbitalPeriodDays.toFixed(2));
+      parts.push(`They orbit with periods of ${this.joinNames(periodStrs, 'and')} days.`);
     }
 
-    // Moons and rings — only mention when present.
+    // Moons and rings across all involved bodies — only mention when present.
     const features: string[] = [];
-    if (bi?.moonCount) { features.push(`${shortName(d.bodyName)} has ${bi.moonCount} moon${bi.moonCount > 1 ? 's' : ''}`); }
-    if (bi?.hasRings) { features.push(`${shortName(d.bodyName)} has rings`); }
-    if (pi?.moonCount && d.partnerName) { features.push(`${shortName(d.partnerName)} has ${pi.moonCount} moon${pi.moonCount > 1 ? 's' : ''}`); }
-    if (pi?.hasRings && d.partnerName) { features.push(`${shortName(d.partnerName)} has rings`); }
+    for (const b of involved) {
+      if (b.info?.moonCount) { features.push(`${b.short} has ${b.info.moonCount} moon${b.info.moonCount > 1 ? 's' : ''}`); }
+      if (b.info?.hasRings) { features.push(`${b.short} has rings`); }
+    }
     if (features.length > 0) { parts.push(features.join('; ') + '.'); }
 
     // Synodic period and collision frequency.
@@ -223,13 +341,9 @@ export class CollisionDialogComponent {
       parts.push(`${n} collisions are predicted over the next ${spanStr}.`);
     }
 
-    // Multi-body group.
-    if (d.simultaneousPartners.length > 0 && d.partnerName) {
-      const allNames = [shortName(d.bodyName), shortName(d.partnerName), ...d.simultaneousPartners.map(n => shortName(n))];
-      const listed = allNames.length === 2
-        ? allNames.join(' and ')
-        : allNames.slice(0, -1).join(', ') + ', and ' + allNames[allNames.length - 1];
-      parts.push(`${listed} all have crossing orbits with each other and may collide simultaneously during the same conjunction.`);
+    // Multi-body group: name every body that shares crossing orbits.
+    if (d.simultaneousPartners.length > 0) {
+      parts.push(`${this.joinNames(shorts, 'and')} all have crossing orbits with each other and may collide simultaneously during the same conjunction.`);
     }
 
     return parts.join(' ');

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.ts
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.ts
@@ -67,8 +67,9 @@ export class CollisionDialogComponent {
    */
   public get overlapPercent(): number | null {
     const c = this.data.nextCollision;
-    if (!c || !this.data.combinedRadiiKm) { return null; }
-    return Math.max(0, (1 - c.minSeparationKm / this.data.combinedRadiiKm) * 100);
+    const combined = c?.combinedRadiiKm ?? this.data.combinedRadiiKm;
+    if (!c || !combined) { return null; }
+    return Math.max(0, (1 - c.minSeparationKm / combined) * 100);
   }
 
   /** Plain-language severity for the overlap, mirroring the Canonn collision-table wording. */
@@ -91,6 +92,32 @@ export class CollisionDialogComponent {
     return this.data.synodicPeriodDays === null ? null : this.data.synodicPeriodDays / DAYS_PER_YEAR;
   }
 
+  /** Body name with the system-name prefix stripped (e.g. "Foo System 1 a" → "1 a"). */
+  public shortName(name: string | null | undefined): string {
+    if (!name) { return ''; }
+    const prefix = this.data.systemName + ' ';
+    return name.startsWith(prefix) ? name.slice(prefix.length) : name;
+  }
+
+  /**
+   * Distinct sibling names this body actually collides with, drawn from the upcoming-collisions
+   * list (so a multi-body cluster lists every partner). Falls back to the primary partner when
+   * there are no timed windows. Used for the "Bodies" summary line.
+   */
+  public get collisionPartners(): string[] {
+    const names = new Set<string>();
+    for (const w of this.data.upcomingCollisions) {
+      if (w.partnerName) { names.add(w.partnerName); }
+    }
+    if (names.size === 0 && this.data.partnerName) { names.add(this.data.partnerName); }
+    return [...names];
+  }
+
+  /** Short partner name for a contact window (the sibling it is a collision with). */
+  public windowPartner(w: CollisionWindow): string {
+    return this.shortName(w.partnerName ?? this.data.partnerName);
+  }
+
   /**
    * Prose summary of the collision pair: population, body types, atmospheres, moons/rings,
    * period difference, synodic interval, and a rough collision-frequency hint.
@@ -110,10 +137,7 @@ export class CollisionDialogComponent {
     };
 
     /** Body name with the system-name prefix stripped (e.g. "Foo System 1 a" → "1 a"). */
-    const shortName = (name: string): string => {
-      const prefix = d.systemName + ' ';
-      return name.startsWith(prefix) ? name.slice(prefix.length) : name;
-    };
+    const shortName = (name: string): string => this.shortName(name);
 
     /** Atmosphere description, or empty string when there is none. */
     const atmoStr = (info: CollisionBodyInfo | null): string => {
@@ -231,8 +255,10 @@ export class CollisionDialogComponent {
 
   /** Overlap percentage for a given contact window (0% = grazing, 100% = dead-on). */
   public overlapPercentFor(w: CollisionWindow): number | null {
-    if (!this.data.combinedRadiiKm) { return null; }
-    return Math.max(0, (1 - w.minSeparationKm / this.data.combinedRadiiKm) * 100);
+    // Use the window's own pair radii (partners differ in size); fall back to the status-level value.
+    const combined = w.combinedRadiiKm ?? this.data.combinedRadiiKm;
+    if (!combined) { return null; }
+    return Math.max(0, (1 - w.minSeparationKm / combined) * 100);
   }
 
   /** Years until the start of a contact window (for display alongside day counts). */

--- a/src/app/dialogs/collision-dialog/collision-dialog.component.ts
+++ b/src/app/dialogs/collision-dialog/collision-dialog.component.ts
@@ -2,7 +2,12 @@ import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DatePipe, DecimalPipe } from '@angular/common';
 import { DialogShellComponent } from '../dialog-shell/dialog-shell.component';
-import { CollisionWindow } from '../../data/orbital-relations.service';
+import { CollisionWindow, SimultaneousCollision } from '../../data/orbital-relations.service';
+import {
+  SynodicDiagram,
+  SynodicDiagramInput,
+  synodicDistanceDiagram,
+} from '../../data/collision-diagram';
 
 /** Key descriptive facts about one of the two colliding bodies. */
 export interface CollisionBodyInfo {
@@ -39,6 +44,19 @@ export interface CollisionDialogData {
   systemName: string;
   /** Additional sibling names beyond the primary partner that are also in the crossing-orbit group. */
   simultaneousPartners: string[];
+  /**
+   * Timed multi-body pile-ups over the next ~180 days, detected across every crossing partner's
+   * contacts rather than only the (capped) upcoming-collisions rows — so a simultaneous collision
+   * further out than the listed contacts is still surfaced. When omitted, the section falls back
+   * to clustering the visible rows.
+   */
+  simultaneousCollisions?: SimultaneousCollision[];
+  /**
+   * Centre-to-centre distance-over-time samples driving the synodic-period diagram, one
+   * series per directly-colliding partner. Omitted (or null) when the bodies lack the phase
+   * data needed to place them in time, in which case the diagram is hidden.
+   */
+  separationDiagram?: SynodicDiagramInput | null;
 }
 
 /**
@@ -83,6 +101,42 @@ export class CollisionDialogComponent {
 
   public readonly heading = this.data.nextCollision ? 'Predicted Collision' : 'Collision Candidate';
 
+  /** The viewer's resolved IANA time zone (e.g. "Europe/Berlin"), for DST-correct local rendering. */
+  private readonly localZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  /**
+   * Local wall-clock parts for `d` in the viewer's own time zone. Uses Intl with the resolved
+   * IANA zone, so the offset is the one in effect *on that date* — summer vs winter (DST) is
+   * honoured, rather than today's offset being assumed for a contact months away.
+   */
+  private localParts(d: Date): { date: string; time: string; zone: string } {
+    const parts: Record<string, string> = {};
+    for (const p of new Intl.DateTimeFormat('en-CA', {
+      timeZone: this.localZone, hourCycle: 'h23',
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+      timeZoneName: 'shortOffset',
+    }).formatToParts(d)) {
+      parts[p.type] = p.value;
+    }
+    return {
+      date: `${parts['year']}-${parts['month']}-${parts['day']}`,
+      time: `${parts['hour']}:${parts['minute']}:${parts['second']}`,
+      zone: parts['timeZoneName'] ?? '',
+    };
+  }
+
+  /** Local date-time "yyyy-MM-dd HH:mm:ss" for `d` in the viewer's zone (DST-aware). */
+  public localDateTime(d: Date): string {
+    const p = this.localParts(d);
+    return `${p.date} ${p.time}`;
+  }
+
+  /** DST-correct UTC-offset label for `d` in the viewer's zone (e.g. "GMT+2" in summer, "GMT+1" in winter). */
+  public localZoneLabel(d: Date): string {
+    return this.localParts(d).zone;
+  }
+
   /** Contact-window duration in minutes (start → end), or null when there is no timed window. */
   public get durationMinutes(): number | null {
     const c = this.data.nextCollision;
@@ -119,6 +173,19 @@ export class CollisionDialogComponent {
   /** Synodic period expressed in years (for context alongside the day count). */
   public get synodicPeriodYears(): number | null {
     return this.data.synodicPeriodDays === null ? null : this.data.synodicPeriodDays / DAYS_PER_YEAR;
+  }
+
+  /**
+   * Laid-out distance-over-time (synodic) diagram, or null when there is no plottable data.
+   * Cached because the template reads it several times per change-detection pass and the
+   * input is static for the dialog's lifetime.
+   */
+  private diagramCache: SynodicDiagram | null | undefined;
+  public get diagram(): SynodicDiagram | null {
+    if (this.diagramCache === undefined) {
+      this.diagramCache = this.data.separationDiagram ? synodicDistanceDiagram(this.data.separationDiagram) : null;
+    }
+    return this.diagramCache;
   }
 
   /** Body name with the system-name prefix stripped (e.g. "Foo System 1 a" → "1 a"). */
@@ -231,6 +298,24 @@ export class CollisionDialogComponent {
   /** Simultaneous multi-body collisions among the upcoming windows (empty for simple pairs). */
   public get multiCollisions(): MultiCollision[] {
     return this.clusters.multi;
+  }
+
+  /**
+   * Multi-body pile-ups to list in the "Simultaneous collisions" section. Prefers the
+   * service-computed 180-day scan (which sees clusters beyond the capped contact rows); falls
+   * back to clustering the visible rows when that scan wasn't supplied (e.g. in unit tests).
+   */
+  public get sectionMultiCollisions(): MultiCollision[] {
+    const scanned = this.data.simultaneousCollisions;
+    if (scanned && scanned.length > 0) {
+      return scanned.map(s => ({
+        partners: s.partnerNames.map(n => this.shortName(n)).sort(),
+        start: s.start,
+        end: s.end,
+        days: s.days,
+      }));
+    }
+    return this.multiCollisions;
   }
 
   /** True when this contact window coincides with another partner's — part of a multi-body collision. */

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -119,10 +119,12 @@
               <div>{{ edGalaxy.PGName }}</div>
             </div>
             }
+            @if (data.system.region) {
             <div class="system-data-entry">
               <div>Region</div>
               <div>{{ data.system.region.name }}</div>
             </div>
+            }
             <div class="system-data-entry">
               <div>Id64</div>
               <div class="id64-copy" role="button" tabindex="0" (click)="copyId64ToClipboard()"

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1012,7 +1012,8 @@ export interface CanonnBiostats {
     // powerState
     // powers
     // primaryEconomy
-    region: {
+    // Absent for some systems (e.g. uninhabited deep-space systems served by Spansh), so optional.
+    region?: {
       name: string;
       region: number;
     };

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -27,9 +27,21 @@ import { RocheLimitDialogComponent } from '../dialogs/roche-limit-dialog/roche-l
 import { InvisibleRingDialogComponent, InvisibleRingDialogData } from '../dialogs/invisible-ring-dialog/invisible-ring-dialog.component';
 import { ApoPeriDialogComponent, ApoPeriDialogData } from '../dialogs/apo-peri-dialog/apo-peri-dialog.component';
 import { CollisionDialogComponent, CollisionBodyInfo, CollisionDialogData } from '../dialogs/collision-dialog/collision-dialog.component';
+import { SynodicDiagramInput } from '../data/collision-diagram';
 import { JsonDialogComponent, JsonDialogData, formatBodyJson } from '../dialogs/json-dialog/json-dialog.component';
 import { OnFootSafetyDialogComponent, OnFootSafetyDialogData } from '../dialogs/on-foot-safety-dialog/on-foot-safety-dialog.component';
 import { StellarAgeAssessment, assessStellarAge, isPlottableStarClass } from '../data/stellar-reference';
+
+/** Horizon (days) over which simultaneous (multi-body) collisions are scanned for the dialog's section. */
+const SIMULTANEOUS_COLLISION_HORIZON_DAYS = 180;
+/** Width of the collision dialog's distance-over-time diagram, in synodic periods. */
+const COLLISION_DIAGRAM_SYNODIC_PERIODS = 10;
+/**
+ * Number of separation samples drawn across the diagram window (~100 per synodic period over the
+ * {@link COLLISION_DIAGRAM_SYNODIC_PERIODS}-period span). Enough to render the conjunction dips
+ * smoothly; the exact contact minima are threaded into the curve separately for precise markers.
+ */
+const COLLISION_DIAGRAM_SAMPLES = 1000;
 
 /** Rings below this surface density (kg/km²) are considered invisible. */
 const INVISIBLE_RING_MAX_DENSITY = 0.1;
@@ -1041,6 +1053,7 @@ export class SystemBodyComponent implements OnChanges {
     const status = this.collisionStatus;
     if (!status?.isCandidate) { return; }
     const siblings = this.body().parent?.subBodies ?? [];
+    const now = Date.now();
 
     // Descriptive info for every collision candidate: each crossing partner from the upcoming
     // windows, the primary partner, and any simultaneous-cluster member — so the dialog can
@@ -1075,8 +1088,67 @@ export class SystemBodyComponent implements OnChanges {
         systemPopulation: this.systemPopulation(),
         systemName: this.edGalaxyData()?.Name ?? '',
         simultaneousPartners: status.simultaneousPartners,
+        simultaneousCollisions: this.orbitalRelations.simultaneousCollisionsWithin(this.body(), SIMULTANEOUS_COLLISION_HORIZON_DAYS, now),
+        separationDiagram: this.buildCollisionDistanceDiagram(this.body(), siblings, status, now),
       } satisfies CollisionDialogData,
     });
+  }
+
+  /**
+   * Builds the distance-over-time samples for the collision dialog's synodic-period diagram:
+   * one centre-to-centre separation curve from this body to each sibling it directly collides
+   * with, over a window of ten synodic periods. Every collision falling inside that window is
+   * marked (uncapped — not just the 10 table rows), so no in-view dip is left without a marker.
+   * Returns null when no pair has the phase data needed to place the bodies in time.
+   */
+  private buildCollisionDistanceDiagram(
+    body: SystemBody,
+    siblings: SystemBody[],
+    status: CollisionStatus,
+    now: number,
+  ): SynodicDiagramInput | null {
+    const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+    // Timeline: ten synodic periods — long enough to show the conjunction dips recurring and
+    // which of them deepen into collisions. Without a synodic period there is nothing to scale to.
+    const synMs = (status.synodicPeriodDays ?? 0) * MS_PER_DAY;
+    if (!(synMs > 0)) { return null; }
+    const spanMs = synMs * COLLISION_DIAGRAM_SYNODIC_PERIODS;
+    const endMs = now + spanMs;
+
+    // Every contact inside the window — uncapped — grouped by the partner each is with, so dips
+    // beyond the table's 10-row limit are still marked.
+    const windowContacts = this.orbitalRelations.upcomingContactsWithin(body, spanMs / MS_PER_DAY, now);
+
+    // Distinct siblings this body collides with in-window, plus any from the (capped) status list
+    // and the primary partner, so a curve is drawn even when no contact lands inside the window.
+    const partnerNames = new Set<string>();
+    for (const w of windowContacts) { if (w.partnerName) { partnerNames.add(w.partnerName); } }
+    for (const w of status.upcomingCollisions) { if (w.partnerName) { partnerNames.add(w.partnerName); } }
+    if (partnerNames.size === 0 && status.partnerName) { partnerNames.add(status.partnerName); }
+    if (partnerNames.size === 0) { return null; }
+
+    const series: SynodicDiagramInput['series'] = [];
+    for (const name of partnerNames) {
+      const sibling = siblings.find(s => s.bodyData.name === name);
+      if (!sibling) { continue; }
+      const samplesArr = this.orbitalRelations.separationSeries(body.bodyData, sibling.bodyData, now, endMs, COLLISION_DIAGRAM_SAMPLES);
+      if (samplesArr.length === 0) { continue; }
+      // Every contact window already carries this pair's contact threshold (combinedRadiiKm), so
+      // prefer it; fall back to the status-level value, then the bare radius sum, only if absent.
+      const partnerWindows = windowContacts.filter(w => w.partnerName === name);
+      const combinedRadiiKm = partnerWindows[0]?.combinedRadiiKm
+        ?? status.upcomingCollisions.find(w => w.partnerName === name)?.combinedRadiiKm
+        ?? status.combinedRadiiKm
+        ?? ((body.bodyData.radius ?? 0) + (sibling.bodyData.radius ?? 0));
+      const contacts = partnerWindows.map(w => ({
+        tMs: (w.start.getTime() + w.end.getTime()) / 2,
+        sepKm: w.minSeparationKm,
+      }));
+      series.push({ partnerName: name, combinedRadiiKm, samples: samplesArr, contacts });
+    }
+
+    return series.length > 0 ? { startMs: now, endMs, nowMs: now, series } : null;
   }
 
   /**

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -1040,6 +1040,20 @@ export class SystemBodyComponent implements OnChanges {
   public showCollisionDialog(): void {
     const status = this.collisionStatus;
     if (!status?.isCandidate) { return; }
+    const siblings = this.body().parent?.subBodies ?? [];
+
+    // Descriptive info for every collision candidate: each crossing partner from the upcoming
+    // windows, the primary partner, and any simultaneous-cluster member — so the dialog can
+    // enumerate all involved bodies, not just the primary pair.
+    const partnerNames = new Set<string>();
+    for (const w of status.upcomingCollisions) { if (w.partnerName) { partnerNames.add(w.partnerName); } }
+    if (status.partnerName) { partnerNames.add(status.partnerName); }
+    for (const n of status.simultaneousPartners) { partnerNames.add(n); }
+    const partnerInfos = [...partnerNames].map(name => ({
+      name,
+      info: this.buildCollisionBodyInfo(siblings.find(s => s.bodyData.name === name) ?? null),
+    }));
+
     this.dialog.open(CollisionDialogComponent, {
       width: '900px',
       maxWidth: '95vw',
@@ -1055,8 +1069,9 @@ export class SystemBodyComponent implements OnChanges {
         combinedRadiiKm: status.combinedRadiiKm,
         bodyInfo: this.buildCollisionBodyInfo(this.body()),
         partnerInfo: this.buildCollisionBodyInfo(
-          this.body().parent?.subBodies.find(s => s.bodyData.name === status.partnerName) ?? null
+          siblings.find(s => s.bodyData.name === status.partnerName) ?? null
         ),
+        partnerInfos,
         systemPopulation: this.systemPopulation(),
         systemName: this.edGalaxyData()?.Name ?? '',
         simultaneousPartners: status.simultaneousPartners,


### PR DESCRIPTION
Builds on the existing single-pair collision detection (already in `main`) to handle multi-body pile-ups and visualise how separation evolves over time. Five commits, branched from `c576eba`.

## What's new

### Multi-body collisions
- Detects three- and four-body clusters that share crossing orbits (grown transitively: if A crosses B and B crosses C, C joins the group).
- "Upcoming collisions" table merges contacts across every crossing partner, flags coincident contacts as `multi`, and now names **both** involved bodies per row (`this body ↔ partner`) instead of just the partner.
- "Simultaneous collisions" section lists timed pile-ups from a **180-day scan across all crossing partners**, so clusters beyond the 10-row contact cap are still surfaced.

<img width="1374" height="1120" alt="image" src="https://github.com/user-attachments/assets/24732033-97b4-4140-a5c8-02347c7d4b6b" />
<img width="1352" height="1640" alt="image" src="https://github.com/user-attachments/assets/9c7ee96d-99f6-469c-b6e5-be70edc69894" />
<img width="1402" height="1666" alt="image" src="https://github.com/user-attachments/assets/377799bb-1b2b-43de-a59e-abcf5799e851" />

### Distance-over-time (synodic) diagram
- New framework-free geometry helper (`collision-diagram.ts`) renders a log-scale SVG line chart of centre-to-centre separation, one curve per directly-colliding partner.
- Spans ten synodic periods, with a dashed contact-threshold line, a "now" marker, year-stamped axis labels, and an × at **every** in-view collision (uncapped, via `OrbitalRelationsService.upcomingContactsWithin`) — true contact minima are threaded into the curve so each marker sits on the line.
- Log y-axis keeps AU-scale oppositions and the few-thousand-km contact threshold both legible.

### DST-aware local times
- "Your time" rows render via `Intl.DateTimeFormat` with the viewer's resolved IANA zone, so the UTC offset reflects the contact date's daylight-saving state (e.g. GMT+2 in summer, GMT+1 in winter) rather than today's.

### Performance
- Bounds the coarse orbit-proximity grid to fix an O(N²) collision-scan blow-up for distant orbits.
- e2e guard that rendering a collision-heavy system never blocks the main thread past budget.

## Implementation notes
- Orbital maths stays in the framework-free, unit-tested `OrbitalRelationsService`; shared `separationFunction`/`separationSeries`, extracted `collisionPartners`, `contactWindowsWithin`/`groupSimultaneous`, and a horizon bound on the contact march.
- The diagram helper mirrors the existing `orbital-diagrams.ts` pure-geometry pattern.

## Testing
- Unit: **585 passing** (service maths, diagram geometry, dialog rendering, DST local-time, simultaneity scan).
- E2E: multi-body rendering, the distance diagram, and the collision-detection performance budget — across desktop/tablet/mobile Chromium & Firefox.
- `ng build` strict template typecheck: passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
