### PR TITLE
fix(lagrange): detect Trojan hosts orbiting a barycentre

### DIFF
--- a/e2e/fixtures/hyuqoae-gh-v-f2-368.json
+++ b/e2e/fixtures/hyuqoae-gh-v-f2-368.json
@@ -1,0 +1,751 @@
+{
+  "system": {
+    "allegiance": null, 
+    "bodies": [
+      {
+        "argOfPeriapsis": 109.366434, 
+        "ascendingNode": -36.728229, 
+        "bodyId": 1, 
+        "id64": 36028994726393309, 
+        "meanAnomaly": 250.135333, 
+        "name": "Hyuqoae GH-V f2-368 barycentre 1", 
+        "orbitalEccentricity": 0.018647, 
+        "orbitalInclination": -24.77492, 
+        "orbitalPeriod": 221067.501438989, 
+        "semiMajorAxis": 36.688103011163, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2023-03-19T16:20:05Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2023-03-19 16:20:05+00"
+      }, 
+      {
+        "absoluteMagnitude": 9.852539, 
+        "age": 2, 
+        "argOfPeriapsis": 246.855099, 
+        "ascendingNode": 9.389044, 
+        "axialTilt": 0.0, 
+        "belts": [
+          {
+            "innerRadius": 268270000.0, 
+            "mass": 814410000000000.0, 
+            "name": "Hyuqoae GH-V f2-368 A A Belt", 
+            "outerRadius": 5194700000.0, 
+            "type": "Metallic"
+          }
+        ], 
+        "bodyId": 2, 
+        "distanceToArrival": 0.0, 
+        "id64": 72057791745357277, 
+        "luminosity": "VI", 
+        "mainStar": true, 
+        "meanAnomaly": 173.627046, 
+        "name": "Hyuqoae GH-V f2-368 A", 
+        "orbitalEccentricity": 0.030209, 
+        "orbitalInclination": -8.435659, 
+        "orbitalPeriod": 276.581273862604, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.0665819440972222, 
+        "semiMajorAxis": 0.690326955647963, 
+        "solarMasses": 9.976563, 
+        "solarRadius": 0.206726050323508, 
+        "spectralClass": "AeBe8", 
+        "stations": [], 
+        "subType": "Herbig Ae/Be Star", 
+        "surfaceTemperature": 3999.0, 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:05Z", 
+          "meanAnomaly": "2023-03-19T16:20:05Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2023-03-19 16:20:05+00"
+      }, 
+      {
+        "absoluteMagnitude": -1.713486, 
+        "age": 2, 
+        "argOfPeriapsis": 66.855104, 
+        "ascendingNode": 9.389044, 
+        "axialTilt": 0.0, 
+        "bodyId": 3, 
+        "distanceToArrival": 1054.097151, 
+        "id64": 108086588764321245, 
+        "luminosity": "Vz", 
+        "meanAnomaly": 173.627058, 
+        "name": "Hyuqoae GH-V f2-368 B", 
+        "orbitalEccentricity": 0.030209, 
+        "orbitalInclination": -8.435659, 
+        "orbitalPeriod": 276.581273862604, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.959768594201389, 
+        "semiMajorAxis": 1.36047980261348, 
+        "solarMasses": 5.0625, 
+        "solarRadius": 2.77911354708843, 
+        "spectralClass": "B0", 
+        "stations": [], 
+        "subType": "B (Blue-White) Star", 
+        "surfaceTemperature": 15632.0, 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:06Z", 
+          "meanAnomaly": "2023-03-19T16:20:06Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2023-03-19 16:20:06+00"
+      }, 
+      {
+        "absoluteMagnitude": -0.152802, 
+        "age": 2, 
+        "argOfPeriapsis": 289.366428, 
+        "ascendingNode": -36.728229, 
+        "axialTilt": 0.0, 
+        "bodyId": 4, 
+        "distanceToArrival": 96085.427759, 
+        "id64": 144115385783285213, 
+        "luminosity": "Vz", 
+        "meanAnomaly": 250.135333, 
+        "name": "Hyuqoae GH-V f2-368 C", 
+        "orbitalEccentricity": 0.018647, 
+        "orbitalInclination": -24.77492, 
+        "orbitalPeriod": 221067.501438989, 
+        "parents": [
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.953280565787037, 
+        "semiMajorAxis": 153.98837308771, 
+        "solarMasses": 3.640625, 
+        "solarRadius": 2.1477658317757, 
+        "spectralClass": "B0", 
+        "stations": [], 
+        "subType": "B (Blue-White) Star", 
+        "surfaceTemperature": 12415.0, 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:06Z", 
+          "meanAnomaly": "2023-03-19T16:20:06Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2023-03-19 16:20:06+00"
+      }, 
+      {
+        "absoluteMagnitude": 16.070679, 
+        "age": 2, 
+        "argOfPeriapsis": 124.012879, 
+        "ascendingNode": 23.115559, 
+        "axialTilt": -2.536546, 
+        "bodyId": 12, 
+        "distanceToArrival": 2034.030178, 
+        "id64": 432345761934996957, 
+        "luminosity": "VI", 
+        "meanAnomaly": 136.92159, 
+        "name": "Hyuqoae GH-V f2-368 AB 1", 
+        "orbitalEccentricity": 0.01, 
+        "orbitalInclination": 0.027107, 
+        "orbitalPeriod": 570.710851914352, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 1.77805319981482, 
+        "semiMajorAxis": 3.3416031175574, 
+        "solarMasses": 0.082031, 
+        "solarRadius": 0.2225646930266, 
+        "spectralClass": "TTS6", 
+        "stations": [], 
+        "subType": "T Tauri Star", 
+        "surfaceTemperature": 921.0, 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:06Z", 
+          "meanAnomaly": "2023-03-19T16:20:06Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2023-03-19 16:20:06+00"
+      }, 
+      {
+        "absoluteMagnitude": 17.870773, 
+        "age": 2, 
+        "argOfPeriapsis": 134.271718, 
+        "ascendingNode": 167.443119, 
+        "axialTilt": 2.99549, 
+        "bodyId": 13, 
+        "distanceToArrival": 2393.264912, 
+        "id64": 468374558953960925, 
+        "luminosity": "VI", 
+        "meanAnomaly": 80.552574, 
+        "name": "Hyuqoae GH-V f2-368 AB 2", 
+        "orbitalEccentricity": 5.3e-05, 
+        "orbitalInclination": 0.280852, 
+        "orbitalPeriod": 1159.38864096447, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 0.577998723912037, 
+        "semiMajorAxis": 5.35998361098975, 
+        "solarMasses": 0.042969, 
+        "solarRadius": 0.150512667145938, 
+        "spectralClass": "TTS9", 
+        "stations": [], 
+        "subType": "T Tauri Star", 
+        "surfaceTemperature": 740.0, 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:06Z", 
+          "meanAnomaly": "2023-03-19T16:20:06Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2023-03-19 16:20:06+00"
+      }, 
+      {
+        "argOfPeriapsis": 1.770638, 
+        "ascendingNode": 167.374339, 
+        "atmosphereType": null, 
+        "axialTilt": -0.188433, 
+        "bodyId": 14, 
+        "distanceToArrival": 2405.272826, 
+        "earthMasses": 0.025277, 
+        "gravity": 0.252970531253186, 
+        "id64": 504403355972924893, 
+        "isLandable": true, 
+        "materials": {
+          "Carbon": 14.520767, 
+          "Chromium": 8.659201, 
+          "Germanium": 5.074257, 
+          "Iron": 19.254086, 
+          "Manganese": 7.95174, 
+          "Mercury": 0.840794, 
+          "Molybdenum": 1.25728, 
+          "Nickel": 14.562983, 
+          "Phosphorus": 9.296445, 
+          "Sulphur": 17.2682, 
+          "Tellurium": 1.314243
+        }, 
+        "meanAnomaly": 252.514523, 
+        "name": "Hyuqoae GH-V f2-368 AB 2 a", 
+        "orbitalEccentricity": 0.0, 
+        "orbitalInclination": 89.964291, 
+        "orbitalPeriod": 102.521174207882, 
+        "parents": [
+          {
+            "Star": 13
+          }, 
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 2015.16625, 
+        "rotationalPeriod": 0.66796377619213, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.151911998202538, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 13.9335, 
+          "Rock": 85.9483
+        }, 
+        "stations": [], 
+        "subType": "Rocky body", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 576.194519, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:21Z", 
+          "meanAnomaly": "2023-03-19T16:20:21Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2023-03-19 16:20:21+00"
+      }, 
+      {
+        "argOfPeriapsis": 194.271716, 
+        "ascendingNode": 167.443119, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 98.245087, 
+          "Silicates": 0.705356, 
+          "Sulphur dioxide": 0.982451
+        }, 
+        "atmosphereType": "Hot thick Carbon dioxide", 
+        "axialTilt": 0.484315, 
+        "bodyId": 15, 
+        "distanceToArrival": 2729.48248, 
+        "earthMasses": 2.538967, 
+        "gravity": 1.61009228102376, 
+        "id64": 540432152991888861, 
+        "isLandable": false, 
+        "meanAnomaly": 80.552613, 
+        "name": "Hyuqoae GH-V f2-368 AB 3", 
+        "orbitalEccentricity": 5.3e-05, 
+        "orbitalInclination": 0.280852, 
+        "orbitalPeriod": 1159.38864096447, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 8005.523, 
+        "rotationalPeriod": 0.437838859097222, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 5.35998361098975, 
+        "solidComposition": {
+          "Ice": 0.8715, 
+          "Metal": 32.6422, 
+          "Rock": 66.4864
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 1686.70460399704, 
+        "surfaceTemperature": 2235.307617, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:17Z", 
+          "meanAnomaly": "2023-03-19T16:20:17Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2023-03-19 16:20:17+00", 
+        "volcanismType": "Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 74.27172, 
+        "ascendingNode": 167.443119, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 98.916832, 
+          "Silicates": 0.093773, 
+          "Sulphur dioxide": 0.989168
+        }, 
+        "atmosphereType": "Hot thick Carbon dioxide", 
+        "axialTilt": 0.070373, 
+        "bodyId": 16, 
+        "distanceToArrival": 2357.373492, 
+        "earthMasses": 2.297379, 
+        "gravity": 1.55345834607933, 
+        "id64": 576460950010852829, 
+        "isLandable": false, 
+        "meanAnomaly": 80.55267, 
+        "name": "Hyuqoae GH-V f2-368 AB 4", 
+        "orbitalEccentricity": 5.3e-05, 
+        "orbitalInclination": 0.280852, 
+        "orbitalPeriod": 1159.38864096447, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 7752.703, 
+        "rotationalPeriod": 1.61204727231481, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 5.35998361098975, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 32.9292, 
+          "Rock": 67.0708
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 331.547081174439, 
+        "surfaceTemperature": 1827.096313, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:32Z", 
+          "meanAnomaly": "2023-03-19T16:20:32Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2023-03-19 16:20:32+00", 
+        "volcanismType": "Metallic Magma"
+      }, 
+      {
+        "argOfPeriapsis": 223.747821, 
+        "ascendingNode": -149.992587, 
+        "bodyId": 17, 
+        "id64": 612489747029816797, 
+        "meanAnomaly": 299.443771, 
+        "name": "Hyuqoae GH-V f2-368 barycentre 17", 
+        "orbitalEccentricity": 0.000189, 
+        "orbitalInclination": 0.00193, 
+        "orbitalPeriod": 1789.65946866406, 
+        "semiMajorAxis": 7.15908828477669, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2023-03-19T16:20:06Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2023-03-19 16:20:06+00"
+      }, 
+      {
+        "absoluteMagnitude": 20.766098, 
+        "age": 2, 
+        "argOfPeriapsis": 75.140482, 
+        "ascendingNode": 25.554169, 
+        "axialTilt": 0.214325, 
+        "bodyId": 18, 
+        "distanceToArrival": 3356.755621, 
+        "id64": 648518544048780765, 
+        "luminosity": "VI", 
+        "meanAnomaly": 159.032551, 
+        "name": "Hyuqoae GH-V f2-368 AB 5", 
+        "orbitalEccentricity": 0.080373, 
+        "orbitalInclination": 5.489458, 
+        "orbitalPeriod": 10.0232151647454, 
+        "parents": [
+          {
+            "Null": 17
+          }, 
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 1.82449502616898, 
+        "semiMajorAxis": 0.0280772073951255, 
+        "solarMasses": 0.023438, 
+        "solarRadius": 0.103607166067577, 
+        "spectralClass": "TTS3", 
+        "stations": [], 
+        "subType": "T Tauri Star", 
+        "surfaceTemperature": 458.0, 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:06Z", 
+          "meanAnomaly": "2023-03-19T16:20:06Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2023-03-19 16:20:06+00"
+      }, 
+      {
+        "absoluteMagnitude": 16.779297, 
+        "age": 2, 
+        "argOfPeriapsis": 255.140477, 
+        "ascendingNode": 25.554169, 
+        "axialTilt": -2.64055, 
+        "bodyId": 19, 
+        "distanceToArrival": 3366.433315, 
+        "id64": 684547341067744733, 
+        "luminosity": "VI", 
+        "meanAnomaly": 159.032551, 
+        "name": "Hyuqoae GH-V f2-368 AB 6", 
+        "orbitalEccentricity": 0.080373, 
+        "orbitalInclination": 5.489458, 
+        "orbitalPeriod": 10.0232151647454, 
+        "parents": [
+          {
+            "Null": 17
+          }, 
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 1.59658835553241, 
+        "semiMajorAxis": 0.0116845931189277, 
+        "solarMasses": 0.058594, 
+        "solarRadius": 0.18081663263839, 
+        "spectralClass": "TTS7", 
+        "stations": [], 
+        "subType": "T Tauri Star", 
+        "surfaceTemperature": 868.0, 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:06Z", 
+          "meanAnomaly": "2023-03-19T16:20:06Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2023-03-19 16:20:06+00"
+      }, 
+      {
+        "argOfPeriapsis": 23.993109, 
+        "ascendingNode": 113.669965, 
+        "bodyId": 20, 
+        "id64": 720576138086708701, 
+        "meanAnomaly": 115.509544, 
+        "name": "Hyuqoae GH-V f2-368 barycentre 20", 
+        "orbitalEccentricity": 0.000616, 
+        "orbitalInclination": 0.042273, 
+        "orbitalPeriod": 2709.76195180858, 
+        "semiMajorAxis": 9.43984666072106, 
+        "stations": [], 
+        "timestamps": {
+          "meanAnomaly": "2023-03-19T16:20:06Z"
+        }, 
+        "type": "Barycentre", 
+        "updateTime": "2023-03-19 16:20:06+00"
+      }, 
+      {
+        "absoluteMagnitude": 19.498215, 
+        "age": 2, 
+        "argOfPeriapsis": 121.635267, 
+        "ascendingNode": 28.993842, 
+        "axialTilt": 0.912848, 
+        "bodyId": 21, 
+        "distanceToArrival": 5051.884891, 
+        "id64": 756604935105672669, 
+        "luminosity": "VI", 
+        "meanAnomaly": 28.767439, 
+        "name": "Hyuqoae GH-V f2-368 AB 7", 
+        "orbitalEccentricity": 0.06732, 
+        "orbitalInclination": -1.840812, 
+        "orbitalPeriod": 141.980016121157, 
+        "parents": [
+          {
+            "Null": 20
+          }, 
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "rotationalPeriod": 1.4876636555787, 
+        "semiMajorAxis": 0.0065270821167239, 
+        "solarMasses": 0.023438, 
+        "solarRadius": 0.101684566498922, 
+        "spectralClass": "TTS1", 
+        "stations": [], 
+        "subType": "T Tauri Star", 
+        "surfaceTemperature": 619.0, 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:06Z", 
+          "meanAnomaly": "2023-03-19T16:20:06Z"
+        }, 
+        "type": "Star", 
+        "updateTime": "2023-03-19 16:20:06+00"
+      }, 
+      {
+        "argOfPeriapsis": 301.635262, 
+        "ascendingNode": 28.993842, 
+        "atmosphereComposition": {
+          "Helium": 25.350952, 
+          "Hydrogen": 74.64904
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": 0.490868, 
+        "bodyId": 22, 
+        "distanceToArrival": 5096.485875, 
+        "earthMasses": 379.11673, 
+        "gravity": 2.85552717446722, 
+        "id64": 792633732124636637, 
+        "isLandable": false, 
+        "meanAnomaly": 28.768433, 
+        "name": "Hyuqoae GH-V f2-368 AB 8", 
+        "orbitalEccentricity": 0.06732, 
+        "orbitalInclination": -1.840812, 
+        "orbitalPeriod": 141.980016121157, 
+        "parents": [
+          {
+            "Null": 20
+          }, 
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 73456.448, 
+        "rotationalPeriod": 1.01619651865741, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 0.155825513198072, 
+        "stations": [], 
+        "subType": "Class III gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 486.382507, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:40Z", 
+          "meanAnomaly": "2023-03-19T16:20:40Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2023-03-19 16:20:40+00"
+      }, 
+      {
+        "argOfPeriapsis": 86.695622, 
+        "ascendingNode": -52.062803, 
+        "atmosphereComposition": {
+          "Helium": 25.350962, 
+          "Hydrogen": 74.649048
+        }, 
+        "atmosphereType": null, 
+        "axialTilt": -1.895134, 
+        "bodyId": 23, 
+        "distanceToArrival": 6421.776723, 
+        "earthMasses": 41.875248, 
+        "gravity": 2.06278831446926, 
+        "id64": 828662529143600605, 
+        "isLandable": false, 
+        "meanAnomaly": 137.718205, 
+        "name": "Hyuqoae GH-V f2-368 AB 9", 
+        "orbitalEccentricity": 0.002018, 
+        "orbitalInclination": -6.977794, 
+        "orbitalPeriod": 4411.07498826804, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 28723.542, 
+        "rotationalPeriod": 1.25311270824074, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 13.0629243284662, 
+        "stations": [], 
+        "subType": "Class III gas giant", 
+        "surfacePressure": 0.0, 
+        "surfaceTemperature": 365.061676, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:12Z", 
+          "meanAnomaly": "2023-03-19T16:20:12Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2023-03-19 16:20:12+00"
+      }, 
+      {
+        "argOfPeriapsis": 36.94226, 
+        "ascendingNode": 49.324959, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 14.494181, 
+          "Silicates": 0.556578, 
+          "Water": 84.306541
+        }, 
+        "atmosphereType": "Hot thick Water", 
+        "axialTilt": 0.010949, 
+        "bodyId": 24, 
+        "distanceToArrival": 6376.692209, 
+        "earthMasses": 9.113529, 
+        "gravity": 2.93977536453554, 
+        "id64": 864691326162564573, 
+        "isLandable": false, 
+        "meanAnomaly": 240.569106, 
+        "name": "Hyuqoae GH-V f2-368 AB 10", 
+        "orbitalEccentricity": 0.012444, 
+        "orbitalInclination": 0.043243, 
+        "orbitalPeriod": 4560.97570282442, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 11224.651, 
+        "rotationalPeriod": 0.896478270497685, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 13.3572156932559, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 32.9291, 
+          "Rock": 67.0707
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 8103.10426844313, 
+        "surfaceTemperature": 2433.744629, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:28Z", 
+          "meanAnomaly": "2023-03-19T16:20:28Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2023-03-19 16:20:28+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }, 
+      {
+        "argOfPeriapsis": 66.375143, 
+        "ascendingNode": -57.995686, 
+        "atmosphereComposition": {
+          "Carbon dioxide": 14.739788, 
+          "Silicates": 0.496542, 
+          "Water": 84.110657
+        }, 
+        "atmosphereType": "Hot thick Water", 
+        "axialTilt": 0.193281, 
+        "bodyId": 25, 
+        "distanceToArrival": 7019.014831, 
+        "earthMasses": 9.015028, 
+        "gravity": 2.92385479759356, 
+        "id64": 900720123181528541, 
+        "isLandable": false, 
+        "meanAnomaly": 38.353189, 
+        "name": "Hyuqoae GH-V f2-368 AB 11", 
+        "orbitalEccentricity": 0.005658, 
+        "orbitalInclination": 0.018924, 
+        "orbitalPeriod": 4658.61328498081, 
+        "parents": [
+          {
+            "Null": 1
+          }, 
+          {
+            "Null": 0
+          }
+        ], 
+        "radius": 11194.179, 
+        "rotationalPeriod": 0.991199151226852, 
+        "rotationalPeriodTidallyLocked": false, 
+        "semiMajorAxis": 13.5471691563165, 
+        "solidComposition": {
+          "Ice": 0.0, 
+          "Metal": 32.9292, 
+          "Rock": 67.0708
+        }, 
+        "stations": [], 
+        "subType": "High metal content world", 
+        "surfacePressure": 7882.00061189243, 
+        "surfaceTemperature": 2410.926025, 
+        "terraformingState": "Not terraformable", 
+        "timestamps": {
+          "distanceToArrival": "2023-03-19T16:20:46Z", 
+          "meanAnomaly": "2023-03-19T16:20:46Z"
+        }, 
+        "type": "Planet", 
+        "updateTime": "2023-03-19 16:20:46+00", 
+        "volcanismType": "Major Silicate Vapour Geysers"
+      }
+    ], 
+    "coords": {
+      "x": -7427.78125, 
+      "y": -118.71875, 
+      "z": 35762.4375
+    }, 
+    "date": "2023-03-19 16:20:00+00", 
+    "government": "None", 
+    "id64": 197707429341, 
+    "name": "Hyuqoae GH-V f2-368", 
+    "population": 0, 
+    "primaryEconomy": "None", 
+    "secondaryEconomy": "None", 
+    "security": "Anarchy", 
+    "stations": []
+  }
+}

--- a/e2e/trojan-lagrange.spec.ts
+++ b/e2e/trojan-lagrange.spec.ts
@@ -6,10 +6,12 @@ import { loadFixtureSystem, type FixtureOptions } from './support/system-fixture
  *
  * The unit suite (`orbital-relations.service.spec.ts`) pins the detection maths; these
  * tests close the loop by proving the full pipeline — biostats parse → body-tree build →
- * co-orbital detection → header badge — lights up the right badge on the right body for
- * five real systems. They are genuine same-radius ±60° Trojans (not 180° binaries), each
- * encoding the entire offset in `argOfPeriapsis` with ascendingNode/meanAnomaly held equal
- * across siblings — see the fixtures under `e2e/fixtures/` and the service-spec rationale.
+ * co-orbital detection → header badge — lights up the right badge on the right body across
+ * several real systems. Most are genuine same-radius ±60° Trojans, each encoding the entire
+ * offset in `argOfPeriapsis` with ascendingNode/meanAnomaly held equal across siblings;
+ * Hyuqoae GH-V f2-368 adds a Trojan host that orbits a barycentre, and Cloomoo IL-Y e1
+ * covers a same-radius 180° binary whose L3 is suppressed under its barycentre — see the
+ * fixtures under `e2e/fixtures/` and the service-spec rationale.
  *
  * A body's own header carries the badge as `<span class="badge badge-blue">` with text
  * "L4"/"L5" (a Trojan) or "Host" (the co-orbital primary, companions at both L4 and L5).
@@ -79,6 +81,24 @@ const SYSTEMS: TrojanSystem[] = [
       { bodyId: 35, name: 'Eorld Byio AA-A h539 barycentre', badge: 'Host', tooltip: HOST_TOOLTIP },
       { bodyId: 38, name: 'Eorld Byio AA-A h539 A 18', badge: 'L4', tooltip: 'Trojan at Lagrange L4 — click for the diagram' },
       { bodyId: 39, name: 'Eorld Byio AA-A h539 A 19', badge: 'L5', tooltip: 'Trojan at Lagrange L5 — click for the diagram' },
+    ],
+  },
+  {
+    // AB 2 / AB 3 / AB 4 are a same-radius ±60° Trojan trio — AB 2 (a T Tauri star) is the
+    // host, AB 3 leads at +60° (L4), AB 4 trails at −60° (L5) — but they orbit *barycentre 1*,
+    // not a star. They are still badged: a Trojan host is a real massive secondary even around
+    // a barycentre (commit 97d9a50 wrongly suppressed these). The same-radius 180° L3
+    // suppression under a barycentre is covered by Cloomoo C/D below; here the three 180°
+    // stellar pairs (A/B, AB 5/6, AB 7/8) sit at *different* radii, so they aren't co-orbital
+    // L-point candidates at all — the suppression test confirms the trojan fix doesn't bleed
+    // a badge onto them.
+    fixture: 'hyuqoae-gh-v-f2-368.json',
+    systemName: 'Hyuqoae GH-V f2-368',
+    id64: 197707429341,
+    badges: [
+      { bodyId: 13, name: 'Hyuqoae GH-V f2-368 AB 2', badge: 'Host', tooltip: HOST_TOOLTIP },
+      { bodyId: 15, name: 'Hyuqoae GH-V f2-368 AB 3', badge: 'L4', tooltip: 'Trojan at Lagrange L4 — click for the diagram' },
+      { bodyId: 16, name: 'Hyuqoae GH-V f2-368 AB 4', badge: 'L5', tooltip: 'Trojan at Lagrange L5 — click for the diagram' },
     ],
   },
   {
@@ -230,4 +250,65 @@ test.describe('Lagrange points dialog', () => {
     // With nothing to click, the diagram is never created.
     await expect(page.locator('app-lagrange-dialog')).toHaveCount(0);
   });
+
+  test('badges a barycentre Trojan host but not the same system\'s 180° binaries', async ({ page }) => {
+    await loadFixtureSystem(page, byName('Hyuqoae GH-V f2-368'));
+
+    // AB 2 (body 13) hosts AB 3 / AB 4 at ±60° around barycentre 1 → it is badged Host, and
+    // clicking opens the diagram centred on the barycentre as the primary.
+    await page.locator('#body-13 > .body-title .badge.badge-blue', { hasText: 'Host' }).click();
+    const svg = page.locator('app-lagrange-dialog svg');
+    await expect(page.locator('app-lagrange-dialog').getByRole('heading', { name: 'Lagrange points' })).toBeVisible();
+    await expect(svg).toContainText('AB 2');
+    await expect(svg).toContainText('AB 3');
+    await expect(svg).toContainText('AB 4');
+    // The barycentre is the primary at the centre (system prefix stripped).
+    await expect(svg).toContainText('barycentre 1');
+    // Host + L4 + L5 are real bodies; L1/L2/L3 stay placeholders.
+    await expect(svg.locator('circle.body')).toHaveCount(3);
+    await expect(svg.locator('circle.placeholder')).toHaveCount(3);
+
+    // The system's three 180° stellar pairs (A/B, AB 5/6, AB 7/8) sit at different radii, so
+    // they are not co-orbital L-point candidates — they must carry no Trojan/Lagrange badge,
+    // confirming the trojan fix above doesn't bleed onto a barycentre's other children.
+    // (The same-radius 180° L3-suppression guard itself is exercised by the Cloomoo test.)
+    for (const bodyId of [2, 3, 18, 19, 21, 22]) {
+      const header = page.locator(`#body-${bodyId} > .body-title`);
+      await expect(header, `#body-${bodyId} header should render`).toBeVisible();
+      await expect(
+        header.locator('.badge.badge-blue').filter({ hasText: /^(L[1-5]|Host)$/ }),
+        `#body-${bodyId} should carry no Trojan/Lagrange badge`,
+      ).toHaveCount(0);
+    }
+  });
+
+  // Open the same AB 2/3/4 family from each member and confirm the diagram is identical —
+  // host AB 2 always fills the secondary slot, AB 3/AB 4 stay on L4/L5 — with the focus
+  // highlight tracking whichever body was clicked.
+  for (const { bodyId, badge, name } of [
+    { bodyId: 13, badge: 'Host', name: 'AB 2' },
+    { bodyId: 15, badge: 'L4', name: 'AB 3' },
+    { bodyId: 16, badge: 'L5', name: 'AB 4' },
+  ] as const) {
+    test(`opens the AB 2/3/4 barycentre Trojan diagram from ${name} (${badge})`, async ({ page }) => {
+      await loadFixtureSystem(page, byName('Hyuqoae GH-V f2-368'));
+
+      await page.locator(`#body-${bodyId} > .body-title .badge.badge-blue`, { hasText: badge }).click();
+
+      const svg = page.locator('app-lagrange-dialog svg');
+      await expect(page.locator('app-lagrange-dialog').getByRole('heading', { name: 'Lagrange points' })).toBeVisible();
+      // Host AB 2 (secondary) + AB 3 (L4) + AB 4 (L5) are all drawn, around barycentre 1.
+      await expect(svg).toContainText('AB 2');
+      await expect(svg).toContainText('AB 3');
+      await expect(svg).toContainText('AB 4');
+      await expect(svg).toContainText('barycentre 1');
+      // The host fills the secondary slot, so it is never a "secondary" placeholder caption.
+      await expect(svg).not.toContainText('secondary');
+      // Three real bodies (host + L4 + L5); L1/L2/L3 remain placeholders.
+      await expect(svg.locator('circle.body')).toHaveCount(3);
+      await expect(svg.locator('circle.placeholder')).toHaveCount(3);
+      // Exactly the clicked body is highlighted.
+      await expect(svg.locator('circle.body.focus')).toHaveCount(1);
+    });
+  }
 });

--- a/src/app/data/orbital-relations.service.spec.ts
+++ b/src/app/data/orbital-relations.service.spec.ts
@@ -54,21 +54,64 @@ describe('OrbitalRelationsService', () => {
       expect(service.detectTrojanStatus(opposite).lagrangePoint).toBe('L3');
     });
 
-    it('suppresses any status when the shared parent is a barycentre', () => {
-      // A barycentre is the centre of mass of a binary, not a real central body, so its
-      // children orbiting it (here a 180° pair that would otherwise read as L3) have no
-      // Lagrange host and therefore no Trojan/Lagrange status.
+    it('suppresses the L3 of a 180° pair when the shared parent is a barycentre', () => {
+      // A barycentre is the centre of mass of a binary, not a real central body, so a 180°
+      // pair orbiting it is just the two components opposite each other — there is no third
+      // central body hosting an L3, so the opposition is left unbadged (Cloomoo IL-Y e1 C/D).
       const [a, b] = makeFamily([
         { orbitalPeriod: 10, semiMajorAxis: 5, argOfPeriapsis: 0 },
         { orbitalPeriod: 10, semiMajorAxis: 5, argOfPeriapsis: 180 },
       ]);
       // With the default (Star) parent the pair is detected as L3…
       expect(service.detectTrojanStatus(a).lagrangePoint).toBe('L3');
-      // …but under a barycentre parent the status — and the whole diagram — is suppressed.
+      // …but under a barycentre parent the L3 — and the whole diagram — is suppressed.
       a.parent!.bodyData.type = BODY_TYPE.Barycentre;
       expect(service.detectTrojanStatus(a).lagrangePoint).toBeNull();
       expect(service.detectTrojanStatus(b).lagrangePoint).toBeNull();
       expect(service.lagrangeConfiguration(a)).toBeNull();
+    });
+
+    it('still detects a ±60° Trojan host under a barycentre (Hyuqoae GH-V f2-368 AB 2/3/4)', () => {
+      // Unlike a 180° binary, a ±60° co-orbital trio has a genuine massive secondary (the
+      // host) its companions hang off, so the configuration is real even when the trio orbits
+      // a barycentre. AB 2 (a T Tauri star) sits between AB 3 (+60°) and AB 4 (−60°), all at
+      // the same radius around barycentre 1 — verbatim argOfPeriapsis from the Spansh dump.
+      const [ab2, ab3, ab4] = makeFamily([
+        { orbitalPeriod: 1159.38864, semiMajorAxis: 5.35998361098975, argOfPeriapsis: 134.271718 },
+        { orbitalPeriod: 1159.38864, semiMajorAxis: 5.35998361098975, argOfPeriapsis: 194.271716 },
+        { orbitalPeriod: 1159.38864, semiMajorAxis: 5.35998361098975, argOfPeriapsis: 74.27172 },
+      ]);
+      ab2.parent!.bodyData.type = BODY_TYPE.Barycentre;
+
+      const host = service.detectTrojanStatus(ab2);
+      expect(host.isHost).toBe(true);
+      expect(host.lagrangePoint).toBeNull();
+      expect(service.detectTrojanStatus(ab3).lagrangePoint).toBe('L4');
+      expect(service.detectTrojanStatus(ab4).lagrangePoint).toBe('L5');
+
+      // The diagram builds too, centred on the barycentre as the primary.
+      const config = service.lagrangeConfiguration(ab3)!;
+      expect(config.primaryName).toBe('Parent');
+      expect(config.secondary).toEqual({ name: 'Child 1', bodyId: 1, isFocus: false });
+      expect(config.points.L4).toEqual([{ name: 'Child 2', bodyId: 2, isFocus: true }]);
+      expect(config.points.L5).toEqual([{ name: 'Child 3', bodyId: 3, isFocus: false }]);
+      expect(config.points.L3).toEqual([]);
+    });
+
+    it('suppresses L1/L2 when the shared parent is a barycentre', () => {
+      // L1/L2 (like L3) are defined relative to a real central body, so an aligned
+      // same-period pair that reads as L1/L2 around a star is left unbadged around a
+      // barycentre — only a ±60° Trojan host survives there.
+      const [inner, outer] = makeFamily([
+        { orbitalPeriod: 10, semiMajorAxis: 4, argOfPeriapsis: 30, ascendingNode: 50 },
+        { orbitalPeriod: 10, semiMajorAxis: 6, argOfPeriapsis: 30, ascendingNode: 50 },
+      ]);
+      // With the default (Star) parent the pair reads as L1 / L2…
+      expect(service.detectTrojanStatus(inner).lagrangePoint).toBe('L1');
+      // …but under a barycentre parent both are suppressed.
+      inner.parent!.bodyData.type = BODY_TYPE.Barycentre;
+      expect(service.detectTrojanStatus(inner).lagrangePoint).toBeNull();
+      expect(service.detectTrojanStatus(outer).lagrangePoint).toBeNull();
     });
 
     it('distinguishes L1 (inner) from L2 (outer) for aligned same-period bodies', () => {

--- a/src/app/data/orbital-relations.service.ts
+++ b/src/app/data/orbital-relations.service.ts
@@ -197,13 +197,15 @@ export class OrbitalRelationsService {
       return result;
     }
 
-    // A Lagrange configuration needs a real massive central body to define the points
-    // relative to. When the shared parent is a barycentre, the "co-orbital" siblings are
-    // really the components of a binary orbiting their own centre of mass — there is no
-    // third central body hosting Lagrange points — so there is no Trojan/Lagrange status.
-    if (body.parent.bodyData.type === BODY_TYPE.Barycentre) {
-      return result;
-    }
+    // L1, L2 and L3 are defined relative to a real massive central body. When the shared
+    // parent is a barycentre there is no such third body — its children are the components
+    // of a binary (or families) orbiting a centre of mass — so those points are suppressed
+    // below (the L3 branch and the L1/L2 block both bail on `parentIsBarycentre`). A ±60°
+    // Trojan host, by contrast, *is* the massive co-orbital secondary its companions hang
+    // off, so it remains valid even around a barycentre; we therefore no longer suppress the
+    // whole family here (commit 97d9a50 did, which also hid genuine barycentre-orbiting
+    // Trojan hosts like Hyuqoae GH-V f2-368 AB 2/3/4).
+    const parentIsBarycentre = body.parent.bodyData.type === BODY_TYPE.Barycentre;
 
     // L3, L4, L5 candidates share the same orbital distance (semi-major axis).
     //
@@ -245,10 +247,21 @@ export class OrbitalRelationsService {
         const relativePos = this.signedAngleDiff(bd.argOfPeriapsis!, sibling.bodyData.argOfPeriapsis!);
         result.lagrangePoint = relativePos > 0 ? 'L4' : 'L5';
         return result;
-      } else if (Math.abs(normalizedDiff - 180) < ANGLE_TOLERANCE_DEG) {
+      } else if (!parentIsBarycentre && Math.abs(normalizedDiff - 180) < ANGLE_TOLERANCE_DEG) {
+        // 180° opposition → L3, but only around a real central body. A 180° pair orbiting a
+        // barycentre is a binary, not an L3, so it falls through here and is left unbadged.
         result.lagrangePoint = 'L3';
         return result;
       }
+    }
+
+    // L1 and L2 (like L3) are defined relative to a real massive central body, so under a
+    // barycentre none of them apply — only the ±60° Trojan host detected above (which is
+    // itself the massive co-orbital secondary) survives. A binary's components are 180°
+    // opposed, never aligned, so the L1/L2 test below can't misfire on one anyway, but we
+    // stop here to keep the barycentre rule symmetric with the suppressed L3.
+    if (parentIsBarycentre) {
+      return result;
     }
 
     // L1, L2 share the orbital period but sit at a different distance, aligned in
@@ -290,12 +303,11 @@ export class OrbitalRelationsService {
       return null;
     }
 
-    // The centre of a Lagrange diagram is the body the family orbits; a barycentre is the
-    // centre of mass of a binary, not a real central body, so it can't host Lagrange points.
-    // Mirrors the guard in detectTrojanStatus, which already suppresses the badges here.
-    if (parent.bodyData.type === BODY_TYPE.Barycentre) {
-      return null;
-    }
+    // A barycentre can be the centre of a genuine Trojan configuration (its mass hosts a
+    // ±60° co-orbital secondary at L4/L5), so — unlike commit 97d9a50, which bailed out for
+    // every barycentre — we build the diagram and let detectTrojanStatus decide per member.
+    // A plain 180° binary orbiting a barycentre yields no classified members (its L3 is
+    // suppressed there), so the family below has no occupants and we still return null.
 
     // The co-orbital family: every sibling sharing this body's orbital period (so L1/L2
     // partners at a different radius are included too), plus `body` itself — it already


### PR DESCRIPTION
## Problem

Commit 97d9a50 added a **blanket** barycentre guard: any co-orbital family whose shared parent is a barycentre got no Trojan/Lagrange badge and no diagram. That over-suppressed — it correctly hid 180° binaries (Cloomoo IL-Y e1 C/D) but also killed *genuine* ±60° Trojan hosts that happen to orbit a barycentre, like **Hyuqoae GH-V f2-368 AB 2/3/4** (AB 2 is a T Tauri star with HMC worlds at ±60°). No fixture had that shape, so nothing caught it.

## Fix

Narrow the rule in [`orbital-relations.service.ts`](src/app/data/orbital-relations.service.ts): under a barycentre, suppress only the points that need a real massive central body to be defined — **L3** (180° opposition) and **L1/L2** — while letting the ±60° **Host / L4 / L5** detection run.

- `detectTrojanStatus`: replaced the early `return` with a `parentIsBarycentre` flag; gated the L3 branch and the L1/L2 block on it.
- `lagrangeConfiguration`: removed the blanket `return null`. A Trojan family now builds its diagram (centred on the barycentre as primary); a plain 180° binary classifies to nothing, so it still returns null.

The L1/L2 suppression keeps the barycentre rule symmetric with L3. (A binary's components are 180°-opposed and never alias L1/L2, so this can't change real-data output — it just makes the intent explicit, addressing a review finding that L1/L2 was left ungated.)

## Resulting behavior — Hyuqoae GH-V f2-368

- **AB 2 = Host, AB 3 = L4 (+60°), AB 4 = L5 (−60°)** — the trojan trio, now badged; clicking opens a diagram centred on barycentre 1.
- **A/B, AB 5/6, AB 7/8** — 180° stellar pairs at different radii → no badge.
- Cloomoo C/D (same-radius 180° binary under a barycentre) — unchanged, still suppressed.

## Tests

- New `e2e/fixtures/hyuqoae-gh-v-f2-368.json` with Host/L4/L5 badge + tooltip assertions, a barycentre-centred dialog test opened from each of AB 2/3/4, and a suppression check that the system's three 180° pairs stay unbadged.
- Unit specs gain the barycentre Trojan-host case and an L1/L2-suppression case; the existing barycentre test is narrowed to the L3 it actually exercises.
- **618** unit tests pass, `ng build` clean, **126** e2e tests pass across browsers.

## Review

Reviewed at high effort (3 finder angles + verification). Addressed: the ungated L1/L2 branch (now gated) and misleading e2e comments (the Hyuqoae 180° pairs are unbadged due to mismatched radii, not the L3 guard — corrected to say so; the same-radius L3-suppression guard is exercised by the Cloomoo test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)