### PR TITLE
feat(export): calculated values in body JSON + full-system export

### DIFF
--- a/e2e/export-calculated-values.spec.ts
+++ b/e2e/export-calculated-values.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * End-to-end coverage for the export enhancements: the per-body JSON now carries a `calculated`
+ * block, and the system header offers a full-system JSON download (Spansh shape + enriched bodies).
+ * Runs against the built-in `test` fixture (`assets/test-system.json`) so the data is deterministic.
+ *
+ *   #body-1 → Test Neutron Star (13.48 M☉ → super-massive, Schwarzschild radius + danger alert)
+ *   #body-2 → Venus (High metal content world, orbits the primary → orbit extents + temperature)
+ */
+
+async function loadTestSystem(page: Page) {
+  await page.goto('/');
+  await page.getByRole('combobox').fill('test');
+  await page.getByRole('button', { name: 'Search' }).click();
+  await expect(page.getByText('Test System', { exact: true })).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe('Export with calculated values', () => {
+  test.beforeEach(async ({ page }) => {
+    await loadTestSystem(page);
+  });
+
+  test('downloads the whole system as enriched Spansh JSON', async ({ page }) => {
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Export system JSON with calculated values' }).click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe('Test-System.json');
+
+    const path = await download.path();
+    const fs = await import('node:fs/promises');
+    const parsed = JSON.parse(await fs.readFile(path, 'utf8'));
+
+    // Spansh shape is preserved, with generation metadata alongside it.
+    expect(parsed.system.name).toBe('Test System');
+    expect(parsed._generated.generator).toBe('canonn-signals');
+    expect(Array.isArray(parsed.system.bodies)).toBe(true);
+
+    // Every body carries a calculated block.
+    for (const body of parsed.system.bodies) {
+      expect(body.calculated).toBeTruthy();
+      expect(typeof body.calculated.computedAt).toBe('string');
+    }
+
+    // The super-massive neutron star reports its collapse geometry and a stability danger.
+    const neutronStar = parsed.system.bodies.find((b: { bodyId: number }) => b.bodyId === 1);
+    expect(neutronStar.calculated.schwarzschildRadiusKm).toBeGreaterThan(0);
+    expect(neutronStar.calculated.massStability.severity).toBe('danger');
+
+    // A planet in orbit reports its orbit extents (apoapsis ≥ periapsis) and a temperature range.
+    const planet = parsed.system.bodies.find((b: { bodyId: number }) => b.bodyId === 2);
+    expect(planet.calculated.orbit.apoapsisKm).toBeGreaterThanOrEqual(planet.calculated.orbit.periapsisKm);
+    expect(planet.calculated.temperature).not.toBeNull();
+  });
+
+  test('shows the calculated block in a body JSON dialog', async ({ page }) => {
+    await page.locator('#body-2').getByRole('button', { name: 'View body JSON (right-click to copy)' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText('Body JSON Data')).toBeVisible();
+    const json = await dialog.locator('pre').innerText();
+    const parsed = JSON.parse(json);
+    // Raw Spansh fields remain, plus the new calculated block.
+    expect(parsed.subType).toBe('High metal content world');
+    expect(parsed.calculated).toBeTruthy();
+    expect(parsed.calculated.orbit).not.toBeNull();
+  });
+});

--- a/src/app/data/body-enrichment.service.spec.ts
+++ b/src/app/data/body-enrichment.service.spec.ts
@@ -1,0 +1,196 @@
+import { TestBed } from '@angular/core/testing';
+import { BodyEnrichmentService } from './body-enrichment.service';
+import { CanonnBiostatsBody, SystemBody } from '../home/home.component';
+import { BODY_TYPE } from './body-types';
+
+const KM_PER_AU = 149597870.7;
+
+/** A fixed epoch so every time-dependent value is reproducible. */
+const NOW = Date.UTC(2026, 0, 1, 0, 0, 0);
+
+function makeBody(bodyData: Partial<CanonnBiostatsBody>, parent: SystemBody | null = null): SystemBody {
+  const node: SystemBody = {
+    bodyData: { bodyId: 1, id64: 0n, name: 'Test', type: BODY_TYPE.Planet, subType: '', ...bodyData },
+    subBodies: [],
+    parent,
+  };
+  if (parent) { parent.subBodies.push(node); }
+  return node;
+}
+
+describe('BodyEnrichmentService', () => {
+  let service: BodyEnrichmentService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BodyEnrichmentService);
+  });
+
+  it('is created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('orbit extents', () => {
+    it('derives apoapsis/periapsis and eccentricity class from the Keplerian elements', () => {
+      const body = makeBody({ semiMajorAxis: 1, orbitalEccentricity: 0.5 });
+      const { orbit } = service.computeCalculatedValues(body, NOW);
+      expect(orbit).not.toBeNull();
+      expect(orbit!.semiMajorAxisKm).toBeCloseTo(KM_PER_AU, 3);
+      expect(orbit!.apoapsisKm).toBeCloseTo(KM_PER_AU * 1.5, 3);
+      expect(orbit!.periapsisKm).toBeCloseTo(KM_PER_AU * 0.5, 3);
+      expect(orbit!.eccentricityClass).toBe('Eccentric');
+    });
+
+    it('classifies a circular orbit and returns null when no semi-major axis is present', () => {
+      expect(service.computeCalculatedValues(makeBody({ semiMajorAxis: 2, orbitalEccentricity: 0 }), NOW).orbit!.eccentricityClass)
+        .toBe('Circular');
+      expect(service.computeCalculatedValues(makeBody({}), NOW).orbit).toBeNull();
+    });
+  });
+
+  describe('time-dependent values', () => {
+    it('echoes the supplied epoch as computedAt and computes the next apsis relative to it', () => {
+      const body = makeBody({
+        semiMajorAxis: 1,
+        orbitalEccentricity: 0.3,
+        orbitalPeriod: 100,
+        meanAnomaly: 0,
+        timestamps: { distanceToArrival: '', meanAnomaly: new Date(NOW).toISOString() },
+      });
+      const calc = service.computeCalculatedValues(body, NOW);
+      expect(calc.computedAt).toBe(new Date(NOW).toISOString());
+      // meanAnomaly 0 at NOW → apoapsis (180°) is half a period (50 days) away.
+      expect(calc.nextApoapsis).not.toBeNull();
+      expect(calc.nextApoapsis!.days).toBeCloseTo(50, 6);
+    });
+
+    it('returns null apsides when the orbital timing data is missing', () => {
+      const calc = service.computeCalculatedValues(makeBody({ semiMajorAxis: 1, orbitalEccentricity: 0.3 }), NOW);
+      expect(calc.nextApoapsis).toBeNull();
+      expect(calc.nextPeriapsis).toBeNull();
+    });
+  });
+
+  describe('gated stellar values', () => {
+    it('classifies a neutron star and reports compact-object radius, tangential velocity and Schwarzschild radius', () => {
+      const ns = makeBody({
+        type: BODY_TYPE.Star,
+        subType: 'Neutron Star',
+        solarMasses: 1.5,
+        solarRadius: 0.00002,
+        rotationalPeriod: 1e-7, // ~8.6 ms spin period → sub-0.01s "Millisecond Pulsar" band
+        absoluteMagnitude: 12,
+      });
+      const calc = service.computeCalculatedValues(ns, NOW);
+      expect(calc.neutronStarClass).toBe('Millisecond Pulsar');
+      expect(calc.schwarzschildRadiusKm).toBeGreaterThan(0);
+      expect(calc.compactObjectRadiusKm).toBeGreaterThan(0);
+      expect(calc.tangentialVelocityKms).toBeGreaterThan(0);
+    });
+
+    it('leaves compact-object fields null for an ordinary planet', () => {
+      const calc = service.computeCalculatedValues(makeBody({ subType: 'High metal content world' }), NOW);
+      expect(calc.neutronStarClass).toBeNull();
+      expect(calc.schwarzschildRadiusKm).toBeNull();
+      expect(calc.compactObjectRadiusKm).toBeNull();
+      expect(calc.tangentialVelocityKms).toBeNull();
+    });
+
+    it('flags a super-Chandrasekhar white dwarf via massStability', () => {
+      const wd = makeBody({ type: BODY_TYPE.Star, subType: 'White Dwarf (DA)', solarMasses: 1.6 });
+      expect(service.computeCalculatedValues(wd, NOW).massStability?.severity).toBe('danger');
+    });
+  });
+
+  describe('spin resonance', () => {
+    it('reports a simple resonance and maps "none" to null', () => {
+      expect(service.computeCalculatedValues(makeBody({ rotationalPeriod: 10, orbitalPeriod: 10 }), NOW).spinResonance)
+        .toBe('1:1');
+      expect(service.computeCalculatedValues(makeBody({ rotationalPeriod: 1, orbitalPeriod: 7.13 }), NOW).spinResonance)
+        .toBeNull();
+    });
+  });
+
+  describe('temperature', () => {
+    it('estimates an on-foot temperature range with its lookup source', () => {
+      const calc = service.computeCalculatedValues(makeBody({ subType: 'High metal content world', surfaceTemperature: 300 }), NOW);
+      expect(calc.temperature).not.toBeNull();
+      expect(calc.temperature!.minK).toBeLessThan(calc.temperature!.maxK);
+      expect(typeof calc.temperature!.source).toBe('string');
+    });
+
+    it('returns null temperature when no surface temperature is recorded', () => {
+      expect(service.computeCalculatedValues(makeBody({ subType: 'Icy body' }), NOW).temperature).toBeNull();
+    });
+  });
+
+  describe('ring geometry', () => {
+    it('derives width, area, density, Roche limits and dynamics for a ring', () => {
+      const parent = makeBody({ type: BODY_TYPE.Planet, radius: 60000, earthMasses: 95 });
+      const ring = makeBody({
+        type: BODY_TYPE.Ring,
+        subType: 'Icy',
+        innerRadius: 70000,
+        outerRadius: 140000,
+        mass: 1e18,
+      }, parent);
+      const { ring: r } = service.computeCalculatedValues(ring, NOW);
+      expect(r).not.toBeNull();
+      expect(r!.widthKm).toBeCloseTo(70000, 3);
+      expect(r!.areaKm2).toBeCloseTo(Math.PI * (140000 ** 2 - 70000 ** 2), 0);
+      expect(r!.dynamics).not.toBeNull();
+      expect(r!.rigidRocheLimitKm).toBeGreaterThan(0);
+      expect(r!.invisible).toBe(false);
+    });
+
+    it('leaves ring null for a non-ring body', () => {
+      expect(service.computeCalculatedValues(makeBody({ subType: 'Icy body' }), NOW).ring).toBeNull();
+    });
+  });
+
+  describe('shepherding', () => {
+    it('reports shepherding analysis for a moon orbiting within its parent\'s rings', () => {
+      // Parent planet (60 000 km radius) with a ring system out to 200 000 km, and a moon
+      // orbiting at ~150 000 km — inside the rings, so it is a shepherding candidate.
+      const parent = makeBody({
+        type: BODY_TYPE.Planet, radius: 60000, earthMasses: 95,
+        rings: [{ name: 'A Ring', innerRadius: 70_000_000, outerRadius: 200_000_000, mass: 1e18, type: 'Icy' }],
+      });
+      const moon = makeBody({
+        type: BODY_TYPE.Planet, subType: 'Icy body', semiMajorAxis: 0.001, earthMasses: 0.01, radius: 1500,
+      }, parent);
+      const { shepherding } = service.computeCalculatedValues(moon, NOW);
+      expect(shepherding).not.toBeNull();
+      expect(shepherding!.isCandidate).toBe(true);
+      expect(shepherding!.withinParentRings).toBe(true);
+      expect(typeof shepherding!.isShepherd).toBe('boolean');
+    });
+
+    it('leaves shepherding null for a body with no ringed parent', () => {
+      expect(service.computeCalculatedValues(makeBody({ semiMajorAxis: 1 }), NOW).shepherding).toBeNull();
+    });
+  });
+
+  describe('enrichBody', () => {
+    it('attaches calculated without mutating the raw body and preserves raw fields', () => {
+      const body = makeBody({ bodyId: 7, name: 'Sol 3', subType: 'Earth-like world', semiMajorAxis: 1, orbitalEccentricity: 0.02 });
+      const enriched = service.enrichBody(body, NOW);
+      expect(enriched.name).toBe('Sol 3');
+      expect(enriched.bodyId).toBe(7);
+      expect(enriched.calculated).toBeTruthy();
+      expect(enriched.calculated.orbit!.eccentricityClass).toBe('Nearly Circular');
+      // The original body data must be untouched (no `calculated` key leaked onto it).
+      expect('calculated' in body.bodyData).toBe(false);
+    });
+  });
+
+  describe('determinism', () => {
+    it('produces identical output for identical inputs and epoch', () => {
+      const build = () => makeBody({
+        type: BODY_TYPE.Star, subType: 'Neutron Star', solarMasses: 1.5,
+        solarRadius: 0.00002, rotationalPeriod: 0.5, absoluteMagnitude: 12,
+      });
+      expect(service.computeCalculatedValues(build(), NOW)).toEqual(service.computeCalculatedValues(build(), NOW));
+    });
+  });
+});

--- a/src/app/data/body-enrichment.service.ts
+++ b/src/app/data/body-enrichment.service.ts
@@ -1,0 +1,285 @@
+import { inject, Injectable } from '@angular/core';
+import { CanonnBiostatsBody, SystemBody } from '../home/home.component';
+import { BODY_TYPE } from './body-types';
+import {
+  BodyPhysicsService,
+  BodyRocheLimits,
+  MassStabilityAlert,
+  PlanetaryDensity,
+  RingDynamics,
+  ShepherdingHillLimit,
+} from './body-physics.service';
+import { StellarPhysicsService } from './stellar-physics.service';
+import {
+  CollisionStatus,
+  CollisionWindow,
+  OrbitalRelationsService,
+  TrojanStatus,
+} from './orbital-relations.service';
+import { estimateTempRange, lookupTempDelta } from './temperature-estimation';
+
+/** Orbit extents and eccentricity classification derived from the Keplerian elements. */
+export interface OrbitExtents {
+  semiMajorAxisKm: number;
+  apoapsisKm: number;
+  periapsisKm: number;
+  eccentricity: number;
+  /** Descriptive class: Circular / Nearly Circular / Eccentric / Highly Eccentric. */
+  eccentricityClass: string;
+}
+
+/** A future periapsis/apoapsis passage, with the date rendered as an ISO-8601 string. */
+export interface OrbitalEventJson {
+  /** ISO-8601 instant of the passage. */
+  date: string;
+  /** Days from {@link CalculatedValues.computedAt} until the passage. */
+  days: number;
+}
+
+/** Ring/belt geometry derived from the inner/outer radii and mass. */
+export interface RingGeometry {
+  widthKm: number;
+  areaKm2: number;
+  densityKgPerKm2: number;
+  /** True when the ring is too diffuse and wide to render in-game (density < 0.1 kg/km², width > 1e6 km). */
+  invisible: boolean;
+  /** Rigid-body (1.26×) and fluid (2.456×) Roche limits for this ring's material, in km. */
+  rigidRocheLimitKm: number | null;
+  fluidRocheLimitKm: number | null;
+  /** Rigid-body orbital period and edge velocities (Elite treats rings as rigid). */
+  dynamics: RingDynamics | null;
+}
+
+/** Estimated on-foot surface-temperature range (Kelvin) with the lookup rule that produced it. */
+export interface EstimatedTempRangeJson {
+  minK: number;
+  maxK: number;
+  /** Human-readable description of the delta-lookup rule (e.g. "SubType + Atmosphere (...)"). */
+  source: string;
+}
+
+/** Ring-shepherding analysis for a moon that may confine its parent's rings. */
+export interface ShepherdingJson {
+  hillLimit: ShepherdingHillLimit | null;
+  isShepherd: boolean;
+  isCandidate: boolean;
+  withinParentRings: boolean;
+}
+
+/** A collision contact window, with dates rendered as ISO-8601 strings. */
+export interface CollisionWindowJson {
+  start: string;
+  end: string;
+  days: number;
+  minSeparationKm: number;
+  partnerName: string | null;
+  combinedRadiiKm: number | null;
+}
+
+/** Summary of crossing-orbit collision analysis for a body. */
+export interface CollisionJson {
+  isCandidate: boolean;
+  partnerName: string | null;
+  synodicPeriodDays: number | null;
+  combinedRadiiKm: number | null;
+  nextCollision: CollisionWindowJson | null;
+  upcomingCollisions: CollisionWindowJson[];
+  simultaneousPartners: string[];
+}
+
+/**
+ * The derived/calculated values the UI computes from raw Spansh body data, gathered into a
+ * single plain-JSON structure for export. Every field is null when it does not apply to the
+ * body (e.g. `neutronStarClass` is null for a planet), so the shape is stable and
+ * self-describing. Time-dependent values (`nextApoapsis`, `nextPeriapsis`, `collision`) are
+ * computed relative to {@link computedAt}, so an export is fully reproducible given that instant.
+ */
+export interface CalculatedValues {
+  /** ISO-8601 instant the time-dependent values were computed at (makes the export reproducible). */
+  computedAt: string;
+  orbit: OrbitExtents | null;
+  nextApoapsis: OrbitalEventJson | null;
+  nextPeriapsis: OrbitalEventJson | null;
+  density: PlanetaryDensity | null;
+  ring: RingGeometry | null;
+  bodyRocheLimits: BodyRocheLimits | null;
+  rocheExcessKm: number | null;
+  shepherding: ShepherdingJson | null;
+  /** Spin-orbit resonance ratio (e.g. "1:1", "3:2"), or null when there is no simple resonance. */
+  spinResonance: string | null;
+  /** Equatorial surface velocity (km/s) — only reported for neutron stars / black holes. */
+  tangentialVelocityKms: number | null;
+  /** Physical radius (km) of a compact object (neutron star / black hole), or null. */
+  compactObjectRadiusKm: number | null;
+  schwarzschildRadiusKm: number | null;
+  neutronStarClass: string | null;
+  massStability: MassStabilityAlert | null;
+  temperature: EstimatedTempRangeJson | null;
+  /** Trojan/Lagrange status, or null when the body is not part of a co-orbital configuration. */
+  trojan: TrojanStatus | null;
+  /** Rosette label (e.g. "Rosette (3)"), or null. */
+  rosette: string | null;
+  collision: CollisionJson | null;
+}
+
+/** A raw Spansh body with the derived values attached under a single `calculated` key. */
+export type EnrichedBody = CanonnBiostatsBody & { calculated: CalculatedValues };
+
+/**
+ * Computes the derived ("calculated") values for a body by delegating to the existing physics
+ * services, so the export can never disagree with what the UI renders. This is the single source
+ * of truth for enrichment used by both the per-body JSON export and the full-system export.
+ *
+ * The service is pure with respect to its inputs: the only non-determinism is the `now` epoch,
+ * which every time-dependent value is computed against and which is echoed back in
+ * {@link CalculatedValues.computedAt}.
+ */
+@Injectable({ providedIn: 'root' })
+export class BodyEnrichmentService {
+  private readonly physics = inject(BodyPhysicsService);
+  private readonly stellarPhysics = inject(StellarPhysicsService);
+  private readonly orbital = inject(OrbitalRelationsService);
+
+  private isBlackHoleOrNeutronStar(bd: CanonnBiostatsBody): boolean {
+    return bd.type === BODY_TYPE.Star
+      && (bd.subType?.includes('Black Hole') || bd.subType === 'Neutron Star') === true;
+  }
+
+  private orbitExtents(bd: CanonnBiostatsBody): OrbitExtents | null {
+    const extents = this.physics.orbitExtentsKm(bd);
+    if (!extents) { return null; }
+    return { ...extents, eccentricityClass: this.physics.eccentricityClass(extents.eccentricity) };
+  }
+
+  private orbitalEventJson(bd: CanonnBiostatsBody, type: 'apo' | 'peri', now: number): OrbitalEventJson | null {
+    const event = this.orbital.nextOrbitalEvent(bd, type, now);
+    return event ? { date: event.date.toISOString(), days: event.days } : null;
+  }
+
+  private ringGeometry(body: SystemBody): RingGeometry | null {
+    const bd = body.bodyData;
+    if (bd.type !== BODY_TYPE.Ring && bd.type !== BODY_TYPE.Belt) { return null; }
+    const outer = bd.outerRadius ?? 0;
+    const inner = bd.innerRadius ?? 0;
+    const widthKm = outer - inner;
+    const areaKm2 = Math.PI * (outer * outer - inner * inner);
+    const densityKgPerKm2 = areaKm2 > 0 ? (bd.mass ?? 0) / areaKm2 : 0;
+    const invisible = bd.type === BODY_TYPE.Ring && this.physics.isLowDensityWideRing(widthKm, densityKgPerKm2);
+    return {
+      widthKm,
+      areaKm2,
+      densityKgPerKm2,
+      invisible,
+      rigidRocheLimitKm: this.physics.calculateRigidRocheLimit(body),
+      fluidRocheLimitKm: this.physics.calculateFluidRocheLimit(body),
+      dynamics: this.physics.ringDynamics(body),
+    };
+  }
+
+  private shepherding(body: SystemBody): ShepherdingJson | null {
+    const bd = body.bodyData;
+    if (bd.type === BODY_TYPE.Ring || bd.type === BODY_TYPE.Belt || !body.parent) { return null; }
+    const isCandidate = this.physics.isShepherdingCandidate(body);
+    const withinParentRings = this.physics.isBodyWithinParentRings(body);
+    if (!isCandidate && !withinParentRings) { return null; }
+    return {
+      hillLimit: this.physics.calculateShepherdingHillLimit(body),
+      isShepherd: this.physics.isActualShepherd(body),
+      isCandidate,
+      withinParentRings,
+    };
+  }
+
+  private temperature(bd: CanonnBiostatsBody): EstimatedTempRangeJson | null {
+    if (!bd.surfaceTemperature) { return null; }
+    const range = estimateTempRange(bd.surfaceTemperature, bd.subType, bd.atmosphereType, bd.surfacePressure);
+    const { source } = lookupTempDelta(bd.subType, bd.atmosphereType, bd.surfacePressure);
+    return { minK: range.min, maxK: range.max, source };
+  }
+
+  private tangentialVelocity(bd: CanonnBiostatsBody): number | null {
+    if (!this.isBlackHoleOrNeutronStar(bd) || !bd.rotationalPeriod) { return null; }
+    const radiusKm = this.stellarPhysics.radiusKm(bd.radius, bd.solarRadius);
+    return radiusKm === null ? null : this.stellarPhysics.tangentialVelocityKms(bd.rotationalPeriod, radiusKm);
+  }
+
+  private compactObjectRadiusKm(bd: CanonnBiostatsBody): number | null {
+    return this.isBlackHoleOrNeutronStar(bd) ? this.stellarPhysics.radiusKm(bd.radius, bd.solarRadius) : null;
+  }
+
+  private schwarzschildRadiusKm(bd: CanonnBiostatsBody): number | null {
+    return this.isBlackHoleOrNeutronStar(bd) ? this.physics.schwarzschildRadiusKm(bd.solarMasses) : null;
+  }
+
+  private neutronStarClass(bd: CanonnBiostatsBody): string | null {
+    if (bd.type !== BODY_TYPE.Star || bd.subType !== 'Neutron Star') { return null; }
+    return this.stellarPhysics.classifyNeutronStar(bd.solarMasses, bd.rotationalPeriod, bd.absoluteMagnitude);
+  }
+
+  private collisionWindowJson(window: CollisionWindow): CollisionWindowJson {
+    return {
+      start: window.start.toISOString(),
+      end: window.end.toISOString(),
+      days: window.days,
+      minSeparationKm: window.minSeparationKm,
+      partnerName: window.partnerName ?? null,
+      combinedRadiiKm: window.combinedRadiiKm ?? null,
+    };
+  }
+
+  private collision(body: SystemBody, now: number): CollisionJson | null {
+    const status: CollisionStatus = this.orbital.detectCollisionStatus(body, now);
+    if (!status.isCandidate) { return null; }
+    return {
+      isCandidate: status.isCandidate,
+      partnerName: status.partnerName,
+      synodicPeriodDays: status.synodicPeriodDays,
+      combinedRadiiKm: status.combinedRadiiKm,
+      nextCollision: status.nextCollision ? this.collisionWindowJson(status.nextCollision) : null,
+      upcomingCollisions: status.upcomingCollisions.map(w => this.collisionWindowJson(w)),
+      simultaneousPartners: status.simultaneousPartners,
+    };
+  }
+
+  private trojan(body: SystemBody): TrojanStatus | null {
+    const status = this.orbital.detectTrojanStatus(body);
+    return (status.lagrangePoint || status.isHost) ? status : null;
+  }
+
+  /**
+   * Builds the full {@link CalculatedValues} block for a body. `now` (epoch ms) fixes the instant
+   * the time-dependent values (next apo/peri, collisions) are computed against; it defaults to the
+   * current time but callers should pass an explicit epoch for a reproducible export.
+   */
+  public computeCalculatedValues(body: SystemBody, now: number = Date.now()): CalculatedValues {
+    const bd = body.bodyData;
+    const spin = this.stellarPhysics.spinResonance(bd.rotationalPeriod, bd.orbitalPeriod);
+
+    return {
+      computedAt: new Date(now).toISOString(),
+      orbit: this.orbitExtents(bd),
+      nextApoapsis: this.orbitalEventJson(bd, 'apo', now),
+      nextPeriapsis: this.orbitalEventJson(bd, 'peri', now),
+      density: this.physics.getPlanetaryDensity(bd),
+      ring: this.ringGeometry(body),
+      bodyRocheLimits: this.physics.calculateBodyRocheLimits(body),
+      rocheExcessKm: this.physics.rocheExcess(body),
+      shepherding: this.shepherding(body),
+      spinResonance: spin === 'none' ? null : spin,
+      tangentialVelocityKms: this.tangentialVelocity(bd),
+      compactObjectRadiusKm: this.compactObjectRadiusKm(bd),
+      schwarzschildRadiusKm: this.schwarzschildRadiusKm(bd),
+      neutronStarClass: this.neutronStarClass(bd),
+      massStability: this.physics.massStabilityAlert(bd.subType, bd.solarMasses),
+      temperature: this.temperature(bd),
+      trojan: this.trojan(body),
+      rosette: this.orbital.detectRosetteStatus(body),
+      collision: this.collision(body, now),
+    };
+  }
+
+  /** Returns a shallow copy of the raw body with the calculated values attached under `calculated`. */
+  public enrichBody(body: SystemBody, now: number = Date.now()): EnrichedBody {
+    return { ...body.bodyData, calculated: this.computeCalculatedValues(body, now) };
+  }
+}

--- a/src/app/data/body-physics.service.spec.ts
+++ b/src/app/data/body-physics.service.spec.ts
@@ -296,4 +296,38 @@ describe('BodyPhysicsService', () => {
       expect(service.massStabilityAlert(undefined, 5)).toBeNull();
     });
   });
+
+  describe('orbitExtentsKm', () => {
+    it('derives semi-major axis, apoapsis and periapsis in km', () => {
+      const extents = service.orbitExtentsKm({ semiMajorAxis: 1, orbitalEccentricity: 0.5 } as CanonnBiostatsBody);
+      expect(extents).not.toBeNull();
+      expect(extents!.semiMajorAxisKm).toBeCloseTo(KM_PER_AU, 3);
+      expect(extents!.apoapsisKm).toBeCloseTo(KM_PER_AU * 1.5, 3);
+      expect(extents!.periapsisKm).toBeCloseTo(KM_PER_AU * 0.5, 3);
+      expect(extents!.eccentricity).toBe(0.5);
+    });
+
+    it('defaults eccentricity to 0 and returns null without a semi-major axis', () => {
+      expect(service.orbitExtentsKm({ semiMajorAxis: 2 } as CanonnBiostatsBody)!.apoapsisKm)
+        .toBeCloseTo(2 * KM_PER_AU, 3);
+      expect(service.orbitExtentsKm({} as CanonnBiostatsBody)).toBeNull();
+    });
+  });
+
+  describe('eccentricityClass', () => {
+    it('classifies eccentricity into the four bands', () => {
+      expect(service.eccentricityClass(0)).toBe('Circular');
+      expect(service.eccentricityClass(0.39)).toBe('Nearly Circular');
+      expect(service.eccentricityClass(0.5)).toBe('Eccentric');
+      expect(service.eccentricityClass(0.9)).toBe('Highly Eccentric');
+    });
+  });
+
+  describe('isLowDensityWideRing', () => {
+    it('flags only rings that are both very diffuse and very wide', () => {
+      expect(service.isLowDensityWideRing(2_000_000, 0.05)).toBe(true);
+      expect(service.isLowDensityWideRing(2_000_000, 0.5)).toBe(false); // too dense
+      expect(service.isLowDensityWideRing(500_000, 0.05)).toBe(false); // too narrow
+    });
+  });
 });

--- a/src/app/data/body-physics.service.ts
+++ b/src/app/data/body-physics.service.ts
@@ -10,6 +10,11 @@ const EARTH_MASSES_PER_SOLAR_MASS = 332950;
 export const GRAVITATIONAL_CONSTANT = 6.6743e-11;
 export const SPEED_OF_LIGHT = 299792458;
 
+/** Rings below this surface density (kg/km²) are considered invisible in-game. */
+export const INVISIBLE_RING_MAX_DENSITY = 0.1;
+/** Rings wider than this (km) are considered invisible when density is also low. */
+export const INVISIBLE_RING_MIN_WIDTH = 1_000_000;
+
 /**
  * Degenerate-matter stability limits (solar masses). The Chandrasekhar limit caps a
  * white dwarf supported by electron degeneracy pressure; the Tolman–Oppenheimer–Volkoff
@@ -39,6 +44,14 @@ export interface PlanetaryDensity {
   tooltip: string;
   /** Raw bulk density in kg/m³ — the base for the unit-conversion dialog. */
   densityKgM3: number;
+}
+
+/** Orbit extents (km) derived from a body's semi-major axis and eccentricity. */
+export interface OrbitExtentsKm {
+  semiMajorAxisKm: number;
+  apoapsisKm: number;
+  periapsisKm: number;
+  eccentricity: number;
 }
 
 export interface ShepherdingHillLimit {
@@ -92,6 +105,40 @@ export interface RingDynamics {
 export class BodyPhysicsService {
   private sphereVolumeM3(radiusM: number): number {
     return (4 / 3) * Math.PI * radiusM ** 3;
+  }
+
+  /**
+   * Orbit extents (km) from a body's semi-major axis (AU) and eccentricity: apoapsis =
+   * a(1+e), periapsis = a(1−e). Returns null when there is no semi-major axis. Single
+   * source of truth shared by the orbit row in the UI and the JSON export.
+   */
+  orbitExtentsKm(bd: CanonnBiostatsBody): OrbitExtentsKm | null {
+    if (!bd.semiMajorAxis) { return null; }
+    const semiMajorAxisKm = bd.semiMajorAxis * KM_PER_AU;
+    const eccentricity = bd.orbitalEccentricity ?? 0;
+    return {
+      semiMajorAxisKm,
+      apoapsisKm: semiMajorAxisKm * (1 + eccentricity),
+      periapsisKm: semiMajorAxisKm * (1 - eccentricity),
+      eccentricity,
+    };
+  }
+
+  /** Descriptive eccentricity class: Circular / Nearly Circular / Eccentric / Highly Eccentric. */
+  eccentricityClass(eccentricity: number): string {
+    if (eccentricity === 0) { return 'Circular'; }
+    if (eccentricity < 0.4) { return 'Nearly Circular'; }
+    if (eccentricity < 0.8) { return 'Eccentric'; }
+    return 'Highly Eccentric';
+  }
+
+  /**
+   * Invisible-ring heuristic: a ring is invisible in-game when it is both very low surface
+   * density (kg/km²) and very wide (km). Shared by the ring badge, the invisible-ring dialog
+   * and the JSON export so all three agree.
+   */
+  isLowDensityWideRing(widthKm: number, densityKgPerKm2: number): boolean {
+    return densityKgPerKm2 < INVISIBLE_RING_MAX_DENSITY && widthKm > INVISIBLE_RING_MIN_WIDTH;
   }
 
   /** Parent radius in km, or null when the parent exposes no radius. */

--- a/src/app/data/system-export.spec.ts
+++ b/src/app/data/system-export.spec.ts
@@ -1,0 +1,150 @@
+import { TestBed } from '@angular/core/testing';
+import { buildSystemExport, downloadJson, serializeSystemExport, systemExportFilename } from './system-export';
+import { BodyEnrichmentService } from './body-enrichment.service';
+import { CanonnBiostats, CanonnBiostatsBody, SystemBody } from '../home/home.component';
+import { BODY_TYPE } from './body-types';
+
+const NOW = Date.UTC(2026, 0, 1, 0, 0, 0);
+
+function starRaw(): CanonnBiostatsBody {
+  return {
+    bodyId: 0, id64: 10n, name: 'Test A', type: BODY_TYPE.Star, subType: 'K (Yellow-Orange) Star',
+    solarMasses: 0.9, solarRadius: 0.8, mainStar: true,
+  };
+}
+
+function planetRaw(): CanonnBiostatsBody {
+  return {
+    bodyId: 1, id64: 11n, name: 'Test 1', type: BODY_TYPE.Planet, subType: 'High metal content world',
+    semiMajorAxis: 2, orbitalEccentricity: 0.1, earthMasses: 95, radius: 60000, surfaceTemperature: 200,
+    parents: [{ Star: 0 }],
+    rings: [{ name: 'Test 1 A Ring', innerRadius: 70_000_000, outerRadius: 140_000_000, mass: 1e18, type: 'Icy' }],
+  };
+}
+
+/** A minimal loaded system with a star and a ringed planet, plus the matching SystemBody tree. */
+function makeSystem(): { data: CanonnBiostats; roots: SystemBody[] } {
+  const star = starRaw();
+  const planet = planetRaw();
+  const starNode: SystemBody = { bodyData: star, subBodies: [], parent: null };
+  const planetNode: SystemBody = { bodyData: planet, subBodies: [], parent: starNode };
+  starNode.subBodies.push(planetNode);
+
+  const data: CanonnBiostats = {
+    system: {
+      allegiance: '', bodies: [star, planet], bodyCount: 2,
+      coords: { x: 1, y: 2, z: 3 }, date: '2026-01-01', government: null,
+      id64: 1234n, name: 'Test System', population: 0,
+    },
+  };
+  return { data, roots: [starNode] };
+}
+
+describe('system-export', () => {
+  let enrich: BodyEnrichmentService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    enrich = TestBed.inject(BodyEnrichmentService);
+  });
+
+  describe('buildSystemExport', () => {
+    it('preserves the Spansh system metadata and body count', () => {
+      const { data, roots } = makeSystem();
+      const result = buildSystemExport(data, roots, enrich, NOW);
+      expect(result.system.name).toBe('Test System');
+      expect(result.system.id64).toBe(1234n);
+      expect(result.system.coords).toEqual({ x: 1, y: 2, z: 3 });
+      expect(result.system.bodies.length).toBe(2);
+    });
+
+    it('attaches a calculated block to every body while keeping raw fields', () => {
+      const { data, roots } = makeSystem();
+      const result = buildSystemExport(data, roots, enrich, NOW);
+      const planet = result.system.bodies.find(b => b.bodyId === 1)!;
+      expect(planet.subType).toBe('High metal content world');
+      expect(planet.semiMajorAxis).toBe(2);
+      expect(planet.calculated).toBeTruthy();
+      expect(planet.calculated.orbit).not.toBeNull();
+      expect(planet.calculated.density).not.toBeNull();
+    });
+
+    it('enriches each ring using its parent body for context', () => {
+      const { data, roots } = makeSystem();
+      const result = buildSystemExport(data, roots, enrich, NOW);
+      const planet = result.system.bodies.find(b => b.bodyId === 1)!;
+      expect(planet.rings).toBeDefined();
+      const ring = planet.rings![0];
+      // Raw ring fields survive (radii still in metres) and gain calculated ring dynamics.
+      expect(ring.innerRadius).toBe(70_000_000);
+      expect(ring.calculated.ring).not.toBeNull();
+      expect(ring.calculated.ring!.dynamics).not.toBeNull();
+    });
+
+    it('still exports a body that is absent from the tree (context-free fallback)', () => {
+      const { data, roots } = makeSystem();
+      const orphan: CanonnBiostatsBody = { bodyId: 99, id64: 99n, name: 'Orphan', type: BODY_TYPE.Planet, subType: 'Icy body' };
+      data.system.bodies.push(orphan);
+      const result = buildSystemExport(data, roots, enrich, NOW);
+      const exported = result.system.bodies.find(b => b.bodyId === 99);
+      expect(exported).toBeDefined();
+      expect(exported!.calculated).toBeTruthy();
+    });
+
+    it('records reproducible generation metadata outside the system object', () => {
+      const { data, roots } = makeSystem();
+      const result = buildSystemExport(data, roots, enrich, NOW);
+      expect(result._generated.generatedAt).toBe(new Date(NOW).toISOString());
+      expect(result._generated.generator).toBe('canonn-signals');
+      expect(typeof result._generated.note).toBe('string');
+    });
+
+    it('is deterministic for the same inputs and epoch', () => {
+      const a = buildSystemExport(makeSystem().data, makeSystem().roots, enrich, NOW);
+      const b = buildSystemExport(makeSystem().data, makeSystem().roots, enrich, NOW);
+      expect(a).toEqual(b);
+    });
+  });
+
+  describe('serializeSystemExport', () => {
+    it('renders BigInt ids as decimal strings', () => {
+      const { data, roots } = makeSystem();
+      const json = serializeSystemExport(buildSystemExport(data, roots, enrich, NOW));
+      expect(json).toContain('"id64": "1234"');
+      expect(json).toContain('"generator": "canonn-signals"');
+      // Round-trips as valid JSON.
+      expect(() => JSON.parse(json)).not.toThrow();
+    });
+  });
+
+  describe('systemExportFilename', () => {
+    it('slugifies a system name and appends .json', () => {
+      expect(systemExportFilename('Col 285 Sector AB-1')).toBe('Col-285-Sector-AB-1.json');
+      expect(systemExportFilename('  Sol  ')).toBe('Sol.json');
+      expect(systemExportFilename('***')).toBe('system.json');
+    });
+  });
+
+  describe('downloadJson', () => {
+    it('creates an anchor, clicks it and revokes the object URL', () => {
+      const anchor = document.createElement('a');
+      const clickSpy = vi.spyOn(anchor, 'click').mockImplementation(() => { /* no navigation in tests */ });
+      vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+      // jsdom does not implement the URL object-URL methods, so ensure they exist before spying.
+      const urlObj = URL as unknown as { createObjectURL?: unknown; revokeObjectURL?: unknown };
+      urlObj.createObjectURL ??= () => '';
+      urlObj.revokeObjectURL ??= () => { /* noop */ };
+      const createUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
+      const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => { /* noop */ });
+
+      downloadJson('test.json', '{"a":1}');
+
+      expect(createUrlSpy).toHaveBeenCalled();
+      expect(anchor.download).toBe('test.json');
+      expect(clickSpy).toHaveBeenCalled();
+      expect(revokeSpy).toHaveBeenCalledWith('blob:mock');
+
+      vi.restoreAllMocks();
+    });
+  });
+});

--- a/src/app/data/system-export.ts
+++ b/src/app/data/system-export.ts
@@ -1,0 +1,157 @@
+import { CanonnBiostats, CanonnBiostatsBody, SystemBody } from '../home/home.component';
+import { BODY_TYPE } from './body-types';
+import { BodyEnrichmentService, CalculatedValues } from './body-enrichment.service';
+import { formatBodyJson } from '../dialogs/json-dialog/format-body-json';
+
+/** A raw Spansh ring/belt object with the derived values attached under `calculated`. */
+type RingOrBeltWithCalculated<T> = T & { calculated: CalculatedValues };
+
+/**
+ * A raw Spansh body enriched for export: every field of the original body is preserved, plus a
+ * `calculated` block, and each ring/belt gains its own `calculated` block. Downstream Spansh
+ * consumers can ignore the added `calculated` keys entirely.
+ */
+export type ExportBody = Omit<CanonnBiostatsBody, 'rings' | 'belts'> & {
+  calculated: CalculatedValues;
+  rings?: RingOrBeltWithCalculated<NonNullable<CanonnBiostatsBody['rings']>[number]>[];
+  belts?: RingOrBeltWithCalculated<NonNullable<CanonnBiostatsBody['belts']>[number]>[];
+};
+
+/**
+ * Full-system export: the exact Spansh dump shape (`{ system: { …, bodies: [] } }`) with each
+ * body enriched, plus a sibling `_generated` metadata block. The `_generated` key sits outside
+ * `system`, so a consumer that reads Spansh dumps (which only look at `.system`) is unaffected.
+ */
+export interface SystemExport {
+  system: Omit<CanonnBiostats['system'], 'bodies'> & { bodies: ExportBody[] };
+  _generated: {
+    /** ISO-8601 instant the export was produced (the epoch its time-dependent values use). */
+    generatedAt: string;
+    /** Identifies the tool that produced the file. */
+    generator: string;
+    /** Human-readable note describing the added `calculated` fields. */
+    note: string;
+  };
+}
+
+/** Builds a bodyId → tree-node map from the root bodies, so each raw body can find its context. */
+function indexByBodyId(roots: SystemBody[]): Map<number, SystemBody> {
+  const map = new Map<number, SystemBody>();
+  const walk = (node: SystemBody): void => {
+    // Synthesized ring/belt nodes carry bodyId -1; only real bodies have unique ids worth indexing.
+    if (node.bodyData.bodyId >= 0) { map.set(node.bodyData.bodyId, node); }
+    for (const child of node.subBodies) { walk(child); }
+  };
+  roots.forEach(walk);
+  return map;
+}
+
+/**
+ * Wraps a raw ring/belt (radii in metres) as a SystemBody with radii in km and its real parent,
+ * mirroring the tree synthesis in HomeComponent so ring dynamics / Roche limits match the UI.
+ */
+function ringBeltWrapper(
+  raw: { name: string; innerRadius: number; outerRadius: number; mass: number; type: string; id64?: bigint },
+  type: typeof BODY_TYPE.Ring | typeof BODY_TYPE.Belt,
+  parent: SystemBody | null,
+): SystemBody {
+  return {
+    bodyData: {
+      bodyId: -1,
+      name: raw.name,
+      id64: raw.id64 ?? 0n,
+      subType: raw.type,
+      type,
+      innerRadius: raw.innerRadius / 1000,
+      outerRadius: raw.outerRadius / 1000,
+      mass: raw.mass,
+    },
+    subBodies: [],
+    parent,
+  };
+}
+
+/**
+ * Reconstructs the full-system Spansh dump with every body (and every ring/belt) enriched with
+ * calculated values. Pure: `now` (epoch ms) fixes the instant that time-dependent values are
+ * computed against, so the output is reproducible.
+ *
+ * @param data   The loaded system (raw Spansh shape).
+ * @param roots  The root bodies of the built SystemBody tree (provides parent/sibling context).
+ * @param enrich The enrichment service (single source of truth for the calculated values).
+ * @param now    Epoch ms fixing the reproducible instant for time-dependent values.
+ */
+export function buildSystemExport(
+  data: CanonnBiostats,
+  roots: SystemBody[],
+  enrich: BodyEnrichmentService,
+  now: number,
+): SystemExport {
+  const nodesById = indexByBodyId(roots);
+
+  const bodies: ExportBody[] = data.system.bodies.map(raw => {
+    // Prefer the built tree node (carries parent/sibling context); fall back to a context-free
+    // wrapper if the tree somehow lacks it, so no body is dropped from the export.
+    const node = nodesById.get(raw.bodyId) ?? { bodyData: raw, subBodies: [], parent: null };
+
+    // Pull rings/belts out of the spread so the raw (un-enriched) arrays don't clash with the
+    // enriched element type; they are re-added below with their own `calculated` blocks.
+    const { rings, belts, ...rest } = raw;
+    const exportBody: ExportBody = {
+      ...rest,
+      calculated: enrich.computeCalculatedValues(node, now),
+    };
+
+    if (rings) {
+      exportBody.rings = rings.map(ring => ({
+        ...ring,
+        calculated: enrich.computeCalculatedValues(ringBeltWrapper(ring, BODY_TYPE.Ring, node), now),
+      }));
+    }
+    if (belts) {
+      exportBody.belts = belts.map(belt => ({
+        ...belt,
+        calculated: enrich.computeCalculatedValues(ringBeltWrapper(belt, BODY_TYPE.Belt, node), now),
+      }));
+    }
+
+    return exportBody;
+  });
+
+  return {
+    system: { ...data.system, bodies },
+    _generated: {
+      generatedAt: new Date(now).toISOString(),
+      generator: 'canonn-signals',
+      note: 'Each body (and ring/belt) carries a `calculated` block of values derived from the raw '
+        + 'Spansh data. Raw Spansh fields are unchanged; consumers may ignore `calculated` and `_generated`.',
+    },
+  };
+}
+
+/** Serializes a system export to pretty JSON (BigInt ids rendered as decimal strings). */
+export function serializeSystemExport(exportData: SystemExport): string {
+  return formatBodyJson(exportData);
+}
+
+/** Safe-ish filename for a system export, e.g. "Col 285 Sector AB-1" → "Col-285-Sector-AB-1.json". */
+export function systemExportFilename(systemName: string): string {
+  const slug = systemName.trim().replace(/[^\w.-]+/g, '-').replace(/^-+|-+$/g, '') || 'system';
+  return `${slug}.json`;
+}
+
+/**
+ * Triggers a browser download of `text` as `filename`. Isolated here (rather than inline in the
+ * component) so the pure builder above stays DOM-free and unit-testable.
+ */
+export function downloadJson(filename: string, text: string): void {
+  const blob = new Blob([text], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}

--- a/src/app/dialogs/json-dialog/json-dialog.component.spec.ts
+++ b/src/app/dialogs/json-dialog/json-dialog.component.spec.ts
@@ -27,7 +27,7 @@ describe('JsonDialogComponent', () => {
   afterEach(() => TestBed.resetTestingModule());
 
   it('formats the body JSON and renders the bodyId in the EDGalaxy link', () => {
-    const fixture = setup({ body: makeBody({ subType: 'Rocky body', bodyId: 3 }), edGalaxyData: null });
+    const fixture = setup({ body: makeBody({ subType: 'Rocky body', bodyId: 3 }), edGalaxyData: null, now: 0 });
     const c = fixture.componentInstance;
     expect(c.formattedBodyJson).toContain('"subType": "Rocky body"');
     expect(c.edGalaxyHref).toContain('bodyId=3');
@@ -35,14 +35,14 @@ describe('JsonDialogComponent', () => {
 
   it('falls back to the parent bodyId for a ring with no own id', () => {
     const parent = makeBody({ bodyId: 7 });
-    const fixture = setup({ body: makeBody({ bodyId: -1, type: 'Ring' }, parent), edGalaxyData: null });
+    const fixture = setup({ body: makeBody({ bodyId: -1, type: 'Ring' }, parent), edGalaxyData: null, now: 0 });
     expect(fixture.componentInstance.edGalaxyHref).toContain('bodyId=7');
   });
 
   it('flashes the copied state when copying succeeds', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });
-    const fixture = setup({ body: makeBody({}), edGalaxyData: null });
+    const fixture = setup({ body: makeBody({}), edGalaxyData: null, now: 0 });
     fixture.componentInstance.copyBodyJson();
     await Promise.resolve();
     expect(writeText).toHaveBeenCalled();

--- a/src/app/dialogs/json-dialog/json-dialog.component.ts
+++ b/src/app/dialogs/json-dialog/json-dialog.component.ts
@@ -4,11 +4,14 @@ import { MatButton } from '@angular/material/button';
 import { DialogShellComponent } from '../dialog-shell/dialog-shell.component';
 import { SystemBody, EdGalaxyData } from '../../home/home.component';
 import { formatBodyJson } from './format-body-json';
+import { BodyEnrichmentService } from '../../data/body-enrichment.service';
 
 /** Data passed to the body-JSON dialog when it is opened. */
 export interface JsonDialogData {
   body: SystemBody;
   edGalaxyData: EdGalaxyData | null;
+  /** Epoch (ms) the calculated values are computed against — the host's clock override or now. */
+  now: number;
 }
 
 /**
@@ -25,11 +28,15 @@ export interface JsonDialogData {
 })
 export class JsonDialogComponent {
   private readonly data = inject<JsonDialogData>(MAT_DIALOG_DATA);
+  private readonly enrichment = inject(BodyEnrichmentService);
 
   public readonly bodyJsonCopied = signal(false);
 
-  /** Pretty-printed body JSON, cached so the template binding doesn't re-stringify per CD pass. */
-  public readonly formattedBodyJson = formatBodyJson(this.data.body.bodyData);
+  /**
+   * Pretty-printed body JSON — the raw Spansh body plus a `calculated` block of derived values —
+   * cached so the template binding doesn't re-stringify (or re-enrich) on every CD pass.
+   */
+  public readonly formattedBodyJson = formatBodyJson(this.enrichment.enrichBody(this.data.body, this.data.now));
 
   /** Deep link into the EDGalaxyData journal lookup for this body. */
   public readonly edGalaxyHref = this.buildEdGalaxyHref();

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -37,7 +37,7 @@
   <div class="system-container-data">
     <div class="system-info-box">
       <div class="system-title">
-        <span style="display: flex; align-items: center; gap: 4px;">
+        <span style="display: flex; align-items: center; flex-wrap: wrap; gap: 4px;">
           <span>{{ data.system.name }}@if (edastro?.name) {
             <span> ({{ edastro.name }})</span>
             }</span>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -96,6 +96,13 @@
               style="max-height: 1.1em; width: 1.1em; display: block; pointer-events: auto; cursor: pointer;" />
           </a>
           }
+          <button type="button" class="title-link title-link-button system-export-button"
+            (click)="exportSystem(data)"
+            title="Download the full system JSON, enriched with calculated values"
+            aria-label="Export system JSON with calculated values">
+            <fa-icon [icon]="faDownload" aria-hidden="true"></fa-icon>
+            <span class="system-export-button__label">Export</span>
+          </button>
         </span>
         @if (data.system.population !== null && data.system.population !== undefined) {
         <span class="population">Population: {{ data.system.population | number }}</span>

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -23,6 +23,44 @@
     cursor: pointer;
 }
 
+/* An action rendered inline with the site links; strips the native button chrome so the
+   icon matches the surrounding <a> links. */
+.title-link-button {
+    padding: 0;
+    border: none;
+    background: none;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+}
+
+/* The "Export" action is a local download, not an external-site link, so it sits at the end of
+   the row set apart from the logos: a labelled outlined pill rather than a bare icon. */
+.system-export-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    margin-left: 0.75em;
+    padding: 0.15em 0.6em;
+    border: 1px solid color-mix(in srgb, currentColor 40%, transparent);
+    border-radius: 999px;
+    font-size: 0.8em;
+    line-height: 1;
+    opacity: 0.85;
+    transition: opacity 0.15s ease, border-color 0.15s ease;
+}
+
+.system-export-button:hover,
+.system-export-button:focus-visible {
+    opacity: 1;
+    border-color: currentColor;
+}
+
+.system-export-button__label {
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
 .title-link-icon--rounded {
     border-radius: 4px;
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, inject, viewChild, signal, computed } from '@angular/core';
 import { AppService, EdastroData } from '../app.service';
 import { ActivatedRoute, Params, Router } from '@angular/router';
-import { faChartColumn, faFileCode, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { faChartColumn, faDownload, faFileCode, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import { MatDialog } from '@angular/material/dialog';
 import { openLazyDialog } from '../dialogs/lazy-dialog';
 import type { HistogramDialogData } from '../dialogs/histogram-dialog/histogram-dialog.component';
@@ -23,6 +23,8 @@ import { decodeHtmlEntities } from '../data/html-entities';
 import { CREDITS_HTML } from '../data/credits.generated';
 import { findNearestNebulae, NearestNebula } from '../data/nebulae';
 import { isPermitLockedSystem } from '../data/permit-locked-systems';
+import { BodyEnrichmentService } from '../data/body-enrichment.service';
+import { buildSystemExport, downloadJson, serializeSystemExport, systemExportFilename } from '../data/system-export';
 
 @Component({
   selector: 'app-home',
@@ -35,6 +37,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   readonly appService = inject(AppService);
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly enrichment = inject(BodyEnrichmentService);
 
   private lastSimbadSystemName: string | null = null;
   private lastSimbadId64: bigint | null = null;
@@ -404,10 +407,24 @@ export class HomeComponent implements OnInit, OnDestroy {
     if (!data?.system?.id64) return;
     this.copyToClipboard(`${data.system.id64}`);
   }
+
+  /**
+   * Downloads the whole system as a Spansh-shaped JSON dump with each body (and ring/belt)
+   * enriched with a `calculated` block. Uses a single `now` epoch so every body's
+   * time-dependent values share one reproducible instant.
+   */
+  public exportSystem(data: CanonnBiostats): void {
+    // Honour the app clock override (used by the `?t=` param and frozen-clock e2e fixtures) so
+    // the export's time-dependent values match what the UI shows.
+    const now = this.appService.nowOverride() ?? Date.now();
+    const exportData = buildSystemExport(data, this.bodies(), this.enrichment, now);
+    downloadJson(systemExportFilename(data.system.name), serializeSystemExport(exportData));
+  }
   public encodeURIComponent(value: string): string {
     return encodeURIComponent(value);
   }
   public readonly faFileCode = faFileCode;
+  public readonly faDownload = faDownload;
   public readonly faMagnifyingGlass = faMagnifyingGlass;
   public readonly faChartColumn = faChartColumn;
   private readonly dialog = inject(MatDialog);

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -32,6 +32,7 @@ import type { CollisionBodyInfo, CollisionDialogData } from '../dialogs/collisio
 import type { SynodicDiagramInput } from '../data/collision-diagram';
 import type { JsonDialogData } from '../dialogs/json-dialog/json-dialog.component';
 import { formatBodyJson } from '../dialogs/json-dialog/format-body-json';
+import { BodyEnrichmentService } from '../data/body-enrichment.service';
 import type { LagrangeDialogData } from '../dialogs/lagrange-dialog/lagrange-dialog.component';
 import type { OnFootSafetyDialogData } from '../dialogs/on-foot-safety-dialog/on-foot-safety-dialog.component';
 import { StellarAgeAssessment, assessStellarAge, isPlottableStarClass } from '../data/stellar-reference';
@@ -77,11 +78,6 @@ const COLLISION_DIAGRAM_SYNODIC_PERIODS = 10;
  */
 const COLLISION_DIAGRAM_SAMPLES = 1000;
 
-/** Rings below this surface density (Mt/km²) are considered invisible. */
-const INVISIBLE_RING_MAX_DENSITY = 0.1;
-/** Rings wider than this (km) are considered invisible when density is also low. */
-const INVISIBLE_RING_MIN_WIDTH = 1_000_000;
-
 /**
  * Maximum gap between adjacent rings (km) for the Racing Rings badge.
  * Set so that both ring edges are likely to be simultaneously visible when
@@ -124,6 +120,7 @@ export class SystemBodyComponent implements OnChanges {
   private readonly orbitalRelations = inject(OrbitalRelationsService);
   private readonly orbitalWorker = inject(OrbitalWorkerService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly enrichment = inject(BodyEnrichmentService);
 
   // Expose Math.abs for template use
   abs(value: number): number {
@@ -426,11 +423,10 @@ export class SystemBodyComponent implements OnChanges {
     const body = this.body();
     const bd = body.bodyData;
 
-    // Orbit extents (km).
-    const semiMajorAxisKm = (bd.semiMajorAxis ?? 0) * 149597870.7;
-    const eccentricity = bd.orbitalEccentricity ?? 0;
-    this.getApoapsis.set(semiMajorAxisKm * (1 + eccentricity));
-    this.getPeriapsis.set(semiMajorAxisKm * (1 - eccentricity));
+    // Orbit extents (km) — shared with the JSON export via BodyPhysicsService.
+    const extents = this.physics.orbitExtentsKm(bd);
+    this.getApoapsis.set(extents?.apoapsisKm ?? 0);
+    this.getPeriapsis.set(extents?.periapsisKm ?? 0);
 
     // Mean/true anomaly: propagated to the most recent mean-anomaly observation
     // timestamp anywhere in the system (not "now"), so every body in a system reads
@@ -572,10 +568,7 @@ export class SystemBodyComponent implements OnChanges {
 
 
   public getEccentricityAnalysis(eccentricity: number): string {
-    if (eccentricity === 0) return 'Circular';
-    if (eccentricity < 0.4) return 'Nearly Circular';
-    if (eccentricity < 0.8) return 'Eccentric';
-    return 'Highly Eccentric';
+    return this.physics.eccentricityClass(eccentricity);
   }
 
 
@@ -1032,6 +1025,11 @@ export class SystemBodyComponent implements OnChanges {
     this.hoveredIndex = index;
   }
 
+  /** Epoch the export's time-dependent values use — the app clock override (frozen-clock tests / `?t=`) or now. */
+  private exportNow(): number {
+    return this.appService.nowOverride() ?? Date.now();
+  }
+
   public async showBodyJsonDialog(): Promise<void> {
     openLazyDialog(this.dialog, {
       loader: () => import('../dialogs/json-dialog/json-dialog.component').then(m => m.JsonDialogComponent),
@@ -1039,13 +1037,13 @@ export class SystemBodyComponent implements OnChanges {
       width: '900px',
       maxWidth: '95vw',
       restoreFocus: false,
-      data: { body: this.body(), edGalaxyData: this.edGalaxyData() } satisfies JsonDialogData,
+      data: { body: this.body(), edGalaxyData: this.edGalaxyData(), now: this.exportNow() } satisfies JsonDialogData,
     });
   }
 
-  /** Copies the body JSON to the clipboard (right-click shortcut on the JSON button). */
+  /** Copies the body JSON — raw Spansh plus the `calculated` block — to the clipboard (right-click shortcut). */
   public copyBodyJson(): void {
-    navigator.clipboard?.writeText(formatBodyJson(this.body().bodyData))
+    navigator.clipboard?.writeText(formatBodyJson(this.enrichment.enrichBody(this.body(), this.exportNow())))
       .catch(() => { /* clipboard unavailable */ });
   }
 
@@ -1573,7 +1571,7 @@ export class SystemBodyComponent implements OnChanges {
 
   /** Shared invisibility heuristic used for ring stats, badges, and dialog explanations. */
   private isLowDensityWideRing(widthKm: number, densityKgPerKm2: number): boolean {
-    return densityKgPerKm2 < INVISIBLE_RING_MAX_DENSITY && widthKm > INVISIBLE_RING_MIN_WIDTH;
+    return this.physics.isLowDensityWideRing(widthKm, densityKgPerKm2);
   }
 
   /** `parent`'s ring-type sub-bodies, sorted by inner radius ascending. Includes invisible rings — callers filter those out themselves when they don't want them. */


### PR DESCRIPTION
## Summary

Implements the two requested export enhancements:

1. **Calculated values in body JSON** — every exported body now carries a `calculated` block of values derived from the raw Spansh data.
2. **Full-system export** — a new download action in the system header exports the whole system as a Spansh-shaped dump with every body enriched.

### Body-level export (`calculated` block)
- New `BodyEnrichmentService` is the **single source of truth** for enrichment. It builds `calculated` by delegating to the existing physics services (no formula divergence): density, rigid/fluid Roche limits, body Roche limits + excess, shepherding/Hill analysis, ring geometry + dynamics, spin resonance, tangential velocity, compact-object + Schwarzschild radius, neutron-star class, mass-stability alert, on-foot temperature range, Trojan/Lagrange + rosette status, and crossing-orbit collision analysis, plus orbit extents.
- Fields are **null when not applicable**, so the shape is stable and self-describing; consumers can safely ignore `calculated`.
- Raw Spansh fields are **unchanged** — the per-body JSON dialog and right-click copy now serialise `{ ...rawBody, calculated }`.

### Full-system export
- Download button (labelled **Export** pill) in the system header writes `<System>.json`.
- Output is the exact Spansh shape `{ system: { …, bodies: [] } }` with each body — and each ring/belt — enriched, plus a sibling `_generated` metadata block (`generatedAt`, `generator`, `note`) that sits **outside** `system` so Spansh consumers are unaffected.

### Determinism / reproducibility
- Time-dependent values (`computedAt`, next apo/peri, collisions) are computed against a single `now` epoch that honours the app clock override (`?t=` param / frozen-clock e2e fixtures), so an export matches what the UI shows and is reproducible from the same instant.

### Refactor (from review)
- Lifted the shared apoapsis/periapsis, eccentricity-class and invisible-ring helpers into `BodyPhysicsService`; the UI and the export now consume one copy each.

<img width="1278" height="330" alt="image" src="https://github.com/user-attachments/assets/a3f59e66-1dfb-49f5-abcf-f04866f14d62" />
<img width="1410" height="1904" alt="image" src="https://github.com/user-attachments/assets/fbb16816-22f8-4268-8300-1d6b40dc8c9b" />

## Acceptance criteria
- [x] Exported body JSON includes both raw Spansh fields and calculated fields
- [x] New export option for full system data
- [x] System export includes all bodies + metadata in a single structured output
- [x] Calculated values are consistent, deterministic (given `computedAt`), and documented
- [x] No breaking changes to existing body export behaviour (raw fields untouched)
- [x] Downstream consumers can ignore the new `calculated` / `_generated` keys
- [x] Tests validate both body-level and system-level exports

## Testing
- Unit: `body-enrichment.service.spec.ts`, `system-export.spec.ts`, new `BodyPhysicsService` helper specs; updated `json-dialog` spec.
- E2E: `export-calculated-values.spec.ts` — downloads the enriched system dump and asserts a body dialog carries `calculated`.
- Full suite **648/648** passing; `ng build` clean; changed-file coverage ≥ 80% (app/data ~96.7%).
- Two-round code review (correctness + cleanup); all findings addressed, re-review clean.

## Notes
- The full-system export computes collision analysis synchronously on click; cost is bounded to bodies with crossing-orbit siblings (the same ones the UI already scans) and completes quickly for real systems.

Closes #85
