### PR TITLE
Extend unit conversions: angle, temperature, areal density + source-precision badges

### DIFF
--- a/e2e/unit-conversions.spec.ts
+++ b/e2e/unit-conversions.spec.ts
@@ -124,9 +124,10 @@ test.describe('Unit-conversion dialog — angle & duration (Alpha Centauri fixtu
     ]);
   });
 
-  test('surface pressure is badged "from journal" on the atm row (data source delivers atmospheres)', async ({ page }) => {
-    // Eden (body 10) has a surface pressure. The data source delivers it in atmospheres
-    // (the journal's Pascals ÷ 101325), so the atm row — not Pa — is the authoritative source.
+  test('surface pressure badges the Pa row "Journal / unprecise" (journal is Pa, data is atm)', async ({ page }) => {
+    // Eden (body 10) has a surface pressure. The game journal records it in Pascals, but the
+    // data source delivers atmospheres (journal Pa ÷ 101325), so the Pa row is a back-conversion
+    // and is badged "Journal / unprecise" — the same treatment as radius (journal m, data km).
     await ensureBodyExpanded(page, 10);
     await bodyRowValue(page, 10, 'Surface pressure').locator('.convert-icon').click();
 
@@ -134,7 +135,7 @@ test.describe('Unit-conversion dialog — angle & duration (Alpha Centauri fixtu
     await expect(dialog).toBeVisible();
     await expect(dialog).toContainText('Surface pressure');
     await expect(dialog.locator('.conversion-table tbody th')).toHaveText([
-      'atm from journal', 'psi', 'kPa', 'Pa',
+      'atm', 'psi', 'kPa', 'Pa Journal / unprecise',
     ]);
   });
 });

--- a/e2e/unit-conversions.spec.ts
+++ b/e2e/unit-conversions.spec.ts
@@ -22,11 +22,11 @@ test.describe('Unit-conversion dialog (fixture)', () => {
     await expect(dialog).toBeVisible();
     await expect(dialog).toContainText('Radius');
 
-    // Units are listed largest-unit-first (declared order, not sorted at runtime). The unit
-    // the value natively arrives in from the game journal is badged "from journal" — the
-    // journal records body radius in metres, so the m row carries the badge.
+    // Units are listed largest-unit-first (declared order, not sorted at runtime). The
+    // journal records body radius in metres, but the data source delivers it in km, so the
+    // metres row is a back-conversion and is badged "Journal / unprecise" (not "from journal").
     await expect(dialog.locator('.conversion-table tbody th')).toHaveText([
-      'Light Years', 'AU', 'Solar Radii', 'Light seconds', 'km', 'm from journal',
+      'Light Years', 'AU', 'Solar Radii', 'Light seconds', 'km', 'm Journal / unprecise',
     ]);
 
     // Clicking a value copies it and flips the cell to "Copied!" (clipboard is
@@ -57,5 +57,84 @@ test.describe('Unit-conversion dialog (fixture)', () => {
       'Solar Masses from journal', 'Earth Masses', 'Megatonnes',
     ]);
     await expect(dialog.locator('.comparisons')).toContainText('African bush elephants');
+  });
+});
+
+/**
+ * Angle (degrees ⇄ radians) and duration ("Next apoapsis/periapsis") conversions, loaded
+ * from Alpha Centauri whose primary star (body 2) carries an axial tilt and both apsis
+ * day-counts. The clock is pinned by the loader so the day-counts are deterministic.
+ */
+test.describe('Unit-conversion dialog — angle & duration (Alpha Centauri fixture)', () => {
+  const AC = { fixture: 'alpha-centauri.json', systemName: 'Alpha Centauri', id64: 1178708478315 };
+
+  test.beforeEach(async ({ page }) => {
+    await loadFixtureSystem(page, AC);
+  });
+
+  test('an axial tilt (degrees) is convertible to radians, radians badged from journal', async ({ page }) => {
+    await ensureBodyExpanded(page, 2);
+    await bodyRowValue(page, 2, 'Axial tilt').locator('.convert-icon').click();
+
+    const dialog = page.locator('app-unit-conversion-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Axial tilt');
+    // The journal records axial tilt in radians (the app shows degrees), so the Radians
+    // row carries the "from journal" badge and is listed first (radians > degrees).
+    await expect(dialog.locator('.conversion-table tbody th')).toHaveText([
+      'Radians from journal', 'Degrees',
+    ]);
+  });
+
+  test('the "Next apoapsis" day-count is convertible to other durations', async ({ page }) => {
+    await ensureBodyExpanded(page, 2);
+    await bodyRowValue(page, 2, 'Next apoapsis').locator('.convert-icon').click();
+
+    const dialog = page.locator('app-unit-conversion-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Next apoapsis');
+    await expect(dialog.locator('.conversion-table tbody th')).toHaveText([
+      'Centuries', 'Decades', 'Years', 'Weeks', 'Days', 'Hours', 'Minutes', 'Seconds',
+    ]);
+  });
+
+  test('an orbital period badges the Seconds row "Journal / unprecise" (journal is seconds, data is days)', async ({ page }) => {
+    await ensureBodyExpanded(page, 2);
+    await bodyRowValue(page, 2, 'Orbital period').locator('.convert-icon').click();
+
+    const dialog = page.locator('app-unit-conversion-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Orbital period');
+    // The game journal records the period in seconds, but the data source delivers days, so
+    // the Seconds row is a back-conversion and is badged "Journal / unprecise".
+    await expect(dialog.locator('.conversion-table tbody th')).toHaveText([
+      'Centuries', 'Decades', 'Years', 'Weeks', 'Days', 'Hours', 'Minutes', 'Seconds Journal / unprecise',
+    ]);
+  });
+
+  test('a surface temperature is convertible to °C / °F / °R, K badged from journal', async ({ page }) => {
+    await ensureBodyExpanded(page, 2);
+    await bodyRowValue(page, 2, 'Surface Temperature').locator('.convert-icon').click();
+
+    const dialog = page.locator('app-unit-conversion-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Surface temperature');
+    await expect(dialog.locator('.conversion-table tbody th')).toHaveText([
+      'K from journal', '°C', '°F', '°R',
+    ]);
+  });
+
+  test('surface pressure is badged "from journal" on the atm row (data source delivers atmospheres)', async ({ page }) => {
+    // Eden (body 10) has a surface pressure. The data source delivers it in atmospheres
+    // (the journal's Pascals ÷ 101325), so the atm row — not Pa — is the authoritative source.
+    await ensureBodyExpanded(page, 10);
+    await bodyRowValue(page, 10, 'Surface pressure').locator('.convert-icon').click();
+
+    const dialog = page.locator('app-unit-conversion-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Surface pressure');
+    await expect(dialog.locator('.conversion-table tbody th')).toHaveText([
+      'atm from journal', 'psi', 'kPa', 'Pa',
+    ]);
   });
 });

--- a/src/app/data/unit-conversions.spec.ts
+++ b/src/app/data/unit-conversions.spec.ts
@@ -206,11 +206,16 @@ describe('dynamic inline formatters', () => {
     expect(formatDynamicArea(2 * KM_PER_LIGHT_SECOND * KM_PER_LIGHT_SECOND)).toBe('2.00 ls²');
   });
 
-  it('formats ring density in Mt/km², scaling up to Gt/km² for very dense rings', () => {
+  it('formats ring density: Mt/km² mid-range, up to Gt/km², down to kg/m² for sparse belts', () => {
     expect(formatDynamicArealDensity(12.5)).toBe('12.50 Mt/km²');
     expect(formatDynamicArealDensity(2500)).toBe('2.50 Gt/km²');
+    // A sparse belt (~0.05 Mt/km²) drops to kg/m² (× 1e6) rather than reading "0.05 Mt/km²".
+    expect(formatDynamicArealDensity(0.05)).toBe('50,000.00 kg/m²');
     expect(dynamicArealDensityUnitLabel(12.5)).toBe('Mt/km²');
     expect(dynamicArealDensityUnitLabel(2500)).toBe('Gt/km²');
+    expect(dynamicArealDensityUnitLabel(0.05)).toBe('kg/m²');
+    // 0.1 Mt/km² is the boundary — it stays in Mt/km².
+    expect(dynamicArealDensityUnitLabel(0.1)).toBe('Mt/km²');
     expect(formatDynamicArealDensity(NaN)).toBe('—');
     expect(dynamicArealDensityUnitLabel(NaN)).toBe('');
   });

--- a/src/app/data/unit-conversions.spec.ts
+++ b/src/app/data/unit-conversions.spec.ts
@@ -1,11 +1,13 @@
 import {
   buildConversions,
   buildMassComparisons,
+  dynamicArealDensityUnitLabel,
   dynamicAreaUnitLabel,
   dynamicDistanceUnitLabel,
   dynamicLengthUnitLabel,
   dynamicMassUnitLabel,
   formatDynamicArea,
+  formatDynamicArealDensity,
   formatDynamicDistanceLs,
   formatDynamicLength,
   formatDynamicMass,
@@ -39,13 +41,18 @@ describe('buildConversions', () => {
     expect(copyNum(rows, 'm')).toBeCloseTo(KM_PER_AU * 1000, 0);
   });
 
-  it('converts duration from days', () => {
+  it('converts duration from days, centuries-first', () => {
     const rows = buildConversions('duration', 1);
+    expect(rows.map(r => r.unit)).toEqual(
+      ['Centuries', 'Decades', 'Years', 'Weeks', 'Days', 'Hours', 'Minutes', 'Seconds'],
+    );
     expect(copyNum(rows, 'Seconds')).toBeCloseTo(86400, 6);
     expect(copyNum(rows, 'Minutes')).toBeCloseTo(1440, 6);
     expect(copyNum(rows, 'Hours')).toBeCloseTo(24, 6);
     expect(copyNum(rows, 'Days')).toBeCloseTo(1, 6);
     expect(copyNum(rows, 'Years')).toBeCloseTo(1 / 365.25, 9);
+    expect(copyNum(rows, 'Decades')).toBeCloseTo(1 / (10 * 365.25), 9);
+    expect(copyNum(rows, 'Centuries')).toBeCloseTo(1 / (100 * 365.25), 9);
   });
 
   it('converts mass from kilograms', () => {
@@ -79,6 +86,64 @@ describe('buildConversions', () => {
     expect(copyNum(rows, 'kPa')).toBeCloseTo(101.325, 3);
     expect(copyNum(rows, 'Pa')).toBeCloseTo(101325, 0);
     expect(copyNum(rows, 'psi')).toBeCloseTo(14.6959488, 5);
+  });
+
+  it('converts temperature from Kelvin using affine offsets', () => {
+    const rows = buildConversions('temperature', 300);
+    expect(rows.map(r => r.unit)).toEqual(['K', '°C', '°F', '°R']);
+    expect(copyNum(rows, 'K')).toBeCloseTo(300, 6);
+    expect(copyNum(rows, '°C')).toBeCloseTo(26.85, 6);
+    expect(copyNum(rows, '°F')).toBeCloseTo(80.33, 4);
+    expect(copyNum(rows, '°R')).toBeCloseTo(540, 4);
+    // Absolute zero sanity check across the scales.
+    const zero = buildConversions('temperature', 0);
+    expect(copyNum(zero, '°C')).toBeCloseTo(-273.15, 6);
+    expect(copyNum(zero, '°F')).toBeCloseTo(-459.67, 4);
+  });
+
+  it('converts angle from degrees to radians, radians-first', () => {
+    const rows = buildConversions('angle', 180);
+    expect(rows.map(r => r.unit)).toEqual(['Radians', 'Degrees']);
+    expect(copyNum(rows, 'Radians')).toBeCloseTo(Math.PI, 9);
+    expect(copyNum(rows, 'Degrees')).toBeCloseTo(180, 9);
+  });
+
+  it('converts ring areal density from Mt/km², Gt-first, with kg/m²', () => {
+    const rows = buildConversions('arealDensity', 2000);
+    expect(rows.map(r => r.unit)).toEqual(['Gt/km²', 'Mt/km²', 'kg/m²']);
+    expect(copyNum(rows, 'Gt/km²')).toBeCloseTo(2, 9);
+    expect(copyNum(rows, 'Mt/km²')).toBeCloseTo(2000, 6);
+    // 1 Mt/km² (teragram megatonne) spreads 1e12 kg over 1e6 m² = 1e6 kg/m².
+    expect(copyNum(rows, 'kg/m²')).toBeCloseTo(2000 * 1e6, -3);
+  });
+
+  it('shows the journal/source unit unrounded while derived units stay rounded', () => {
+    // Mass recorded in Solar Masses: the Solar Masses row keeps full precision, the
+    // derived Earth Masses row is rounded to the readable ≤4-fraction-digit display.
+    const rows = buildConversions('mass', 0.123456789 * KG_PER_SOLAR_MASS, 'Solar Masses');
+    expect(display(rows, 'Solar Masses')).toBe('0.123456789');
+    expect(display(rows, 'Earth Masses')).not.toMatch(/\d\.\d{5,}/);
+  });
+
+  it('groups the journal/source value with thousand separators at full precision', () => {
+    // Distance recorded in light seconds: the source row keeps every significant digit
+    // (unlike the 4-fraction-digit derived rows) but is still grouped for readability.
+    const rows = buildConversions('length', 2108.215154 * KM_PER_LIGHT_SECOND, 'Light seconds');
+    expect(display(rows, 'Light seconds')).toBe('2,108.215154');
+  });
+
+  it('rounds the source row when it is a back-conversion (sourcePrecise=false)', () => {
+    // Radius arrives in km though the journal records metres, so the metres row is a
+    // back-conversion — it must stay rounded like any derived unit, not pretend to the
+    // journal's full precision. The rounded display uses grouped thousands (with commas);
+    // the full-precision copy value does not.
+    const km = 6.7841234567; // → 6,784.1234567 m
+    const rows = buildConversions('length', km, 'm', false);
+    const preciseRows = buildConversions('length', km, 'm');
+    expect(display(rows, 'm')).toContain(',');
+    expect(display(rows, 'm')).toBe(display(buildConversions('length', km), 'm')); // same as an ordinary row
+    expect(display(rows, 'm')).toBe('6,784.1235'); // rounded to 4 fraction digits
+    expect(display(preciseRows, 'm')).toBe('6,784.1234567'); // default (precise) shows full precision
   });
 
   it('renders zero across every unit and keeps non-finite values safe', () => {
@@ -139,6 +204,15 @@ describe('dynamic inline formatters', () => {
   it('formats area across the km² / ls² ladder', () => {
     expect(formatDynamicArea(1000)).toBe('1,000.00 km²');
     expect(formatDynamicArea(2 * KM_PER_LIGHT_SECOND * KM_PER_LIGHT_SECOND)).toBe('2.00 ls²');
+  });
+
+  it('formats ring density in Mt/km², scaling up to Gt/km² for very dense rings', () => {
+    expect(formatDynamicArealDensity(12.5)).toBe('12.50 Mt/km²');
+    expect(formatDynamicArealDensity(2500)).toBe('2.50 Gt/km²');
+    expect(dynamicArealDensityUnitLabel(12.5)).toBe('Mt/km²');
+    expect(dynamicArealDensityUnitLabel(2500)).toBe('Gt/km²');
+    expect(formatDynamicArealDensity(NaN)).toBe('—');
+    expect(dynamicArealDensityUnitLabel(NaN)).toBe('');
   });
 });
 

--- a/src/app/data/unit-conversions.ts
+++ b/src/app/data/unit-conversions.ts
@@ -31,18 +31,34 @@ export const KG_PER_MEGATONNE = 1e12;
 // --- Velocity (base: km/s) ---
 export const SPEED_OF_LIGHT_KM_S = 299792.458;
 
+// --- Angle (base: degrees) ---
+export const RADIANS_PER_DEGREE = Math.PI / 180;
+
 // --- Pressure (base: atm) ---
 export const KPA_PER_ATM = 101.325;
 export const PA_PER_ATM = 101325;
 export const PSI_PER_ATM = 14.6959488;
 
+// --- Temperature (base: Kelvin) --- affine, not purely multiplicative: °C = K − 273.15,
+// °F = K·9/5 − 459.67, °R (Rankine) = K·9/5. Handled via the optional `offset` below.
+export const CELSIUS_ZERO_IN_K = 273.15;
+export const FAHRENHEIT_OFFSET = -459.67;
+
 // 1 Mt/cm³ = 1e12 kg ÷ 1e-6 m³ = 1e18 kg/m³ (uses the teragram megatonne above).
 const KG_M3_PER_MT_CM3 = 1e18;
 // km² in one square light-second.
 const KM2_PER_LS2 = KM_PER_LIGHT_SECOND * KM_PER_LIGHT_SECOND;
+// Areal (surface) density conversion for ring/belt mass: 1 Mt/km² spreads KG_PER_MEGATONNE kg
+// over 1e6 m² (uses the same megatonne as the mass table, so a ring's mass, area and density
+// cross-reference exactly). = 1e12 / 1e6 = 1e6 kg/m².
+const KG_M2_PER_MT_KM2 = KG_PER_MEGATONNE / (M_PER_KM * M_PER_KM);
+// A gigatonne is 1000 of the app's megatonnes — the scale-up unit for very dense rings.
+const MT_PER_GT = 1000;
 
 /** The kinds of quantity a value can be converted between, each with a fixed base unit. */
-export type QuantityKind = 'length' | 'duration' | 'mass' | 'velocity' | 'density' | 'area' | 'pressure';
+export type QuantityKind =
+  | 'length' | 'duration' | 'mass' | 'velocity' | 'density' | 'area' | 'pressure'
+  | 'angle' | 'arealDensity' | 'temperature';
 
 /** One scale-unit row shown in the conversion dialog. */
 export interface ConversionRow {
@@ -60,7 +76,7 @@ export interface ConversionRow {
  * turns the kind's base value into that unit. The order is declared here, not sorted at
  * runtime. Density and area factors are derived from the named constants above.
  */
-const CONVERSIONS: Record<QuantityKind, { unit: string; factor: number }[]> = {
+const CONVERSIONS: Record<QuantityKind, { unit: string; factor: number; offset?: number }[]> = {
   length: [
     { unit: 'Light Years', factor: 1 / KM_PER_LIGHT_YEAR },
     { unit: 'AU', factor: 1 / KM_PER_AU },
@@ -70,6 +86,8 @@ const CONVERSIONS: Record<QuantityKind, { unit: string; factor: number }[]> = {
     { unit: 'm', factor: M_PER_KM },
   ],
   duration: [
+    { unit: 'Centuries', factor: 1 / (100 * DAYS_PER_YEAR) },
+    { unit: 'Decades', factor: 1 / (10 * DAYS_PER_YEAR) },
     { unit: 'Years', factor: 1 / DAYS_PER_YEAR },
     { unit: 'Weeks', factor: WEEKS_PER_DAY },
     { unit: 'Days', factor: 1 },
@@ -101,6 +119,21 @@ const CONVERSIONS: Record<QuantityKind, { unit: string; factor: number }[]> = {
     { unit: 'kPa', factor: KPA_PER_ATM },
     { unit: 'Pa', factor: PA_PER_ATM },
   ],
+  angle: [
+    { unit: 'Radians', factor: RADIANS_PER_DEGREE },
+    { unit: 'Degrees', factor: 1 },
+  ],
+  arealDensity: [
+    { unit: 'Gt/km²', factor: 1 / MT_PER_GT },
+    { unit: 'Mt/km²', factor: 1 },
+    { unit: 'kg/m²', factor: KG_M2_PER_MT_KM2 },
+  ],
+  temperature: [
+    { unit: 'K', factor: 1 },
+    { unit: '°C', factor: 1, offset: -CELSIUS_ZERO_IN_K },
+    { unit: '°F', factor: 9 / 5, offset: FAHRENHEIT_OFFSET },
+    { unit: '°R', factor: 9 / 5 },
+  ],
 };
 
 /** Readable number: grouped with ≤4 fraction digits for ordinary magnitudes, exponential for extremes. */
@@ -120,11 +153,36 @@ function formatCopyNumber(value: number): string {
   return Number(value.toPrecision(12)).toString();
 }
 
-/** Builds the full set of scale-unit rows for a base value of the given kind. */
-export function buildConversions(kind: QuantityKind, baseValue: number): ConversionRow[] {
-  return CONVERSIONS[kind].map(({ unit, factor }) => {
-    const value = baseValue * factor;
-    return { unit, display: formatDisplayNumber(value), copyText: formatCopyNumber(value) };
+/**
+ * The authoritative "from journal" value: full precision (~12 sig figs, not rounded to 4
+ * fraction digits like derived rows) but grouped with thousand separators for readability —
+ * the plain, separator-free form is kept for the clipboard copy value.
+ */
+function formatSourceNumber(value: number): string {
+  if (!Number.isFinite(value)) { return '—'; }
+  if (value === 0) { return '0'; }
+  return Number(value.toPrecision(12)).toLocaleString('en-US', { maximumFractionDigits: 20 });
+}
+
+/**
+ * Builds the full set of scale-unit rows for a base value of the given kind. When
+ * `sourceUnit` names the unit the value natively arrives in, and `sourcePrecise` is true
+ * (the data source delivers the value in exactly that unit), that row is shown at full
+ * precision (unrounded) — it is the authoritative figure the game recorded, so we don't
+ * round it away. When `sourcePrecise` is false the value reaches us in a *different* unit
+ * and this row is a back-conversion, so it stays rounded like the other derived units.
+ */
+export function buildConversions(
+  kind: QuantityKind,
+  baseValue: number,
+  sourceUnit?: string | null,
+  sourcePrecise = true,
+): ConversionRow[] {
+  return CONVERSIONS[kind].map(({ unit, factor, offset = 0 }) => {
+    const value = baseValue * factor + offset;
+    const copyText = formatCopyNumber(value);
+    const isSource = unit === sourceUnit && sourcePrecise && Number.isFinite(value);
+    return { unit, display: isSource ? formatSourceNumber(value) : formatDisplayNumber(value), copyText };
   });
 }
 
@@ -268,4 +326,29 @@ export function formatDynamicArea(km2: number): string {
 /** Dialog-row label for the inline area unit chosen at this magnitude. */
 export function dynamicAreaUnitLabel(km2: number): string {
   return Number.isFinite(km2) ? pickInlineAreaUnit(km2).label : '';
+}
+
+/** Inline areal-density unit: abbreviation, matching dialog-row label, and Mt/km² multiplier. */
+interface InlineArealDensityUnit { unit: string; label: string; perMtKm2: number; }
+
+/**
+ * Picks the inline ring/belt areal-density unit (Mt/km², stepping up to Gt/km² for very
+ * dense rings) by magnitude. Single source for both the inline display
+ * ({@link formatDynamicArealDensity}) and the dialog accent label ({@link dynamicArealDensityUnitLabel}).
+ */
+function pickInlineArealDensityUnit(mtKm2: number): InlineArealDensityUnit {
+  if (Math.abs(mtKm2) >= MT_PER_GT) { return { unit: 'Gt/km²', label: 'Gt/km²', perMtKm2: 1 / MT_PER_GT }; }
+  return { unit: 'Mt/km²', label: 'Mt/km²', perMtKm2: 1 };
+}
+
+/** Inline areal-density display (Mt/km² base), scaling up to Gt/km² for very dense rings. */
+export function formatDynamicArealDensity(mtKm2: number): string {
+  if (!Number.isFinite(mtKm2)) { return '—'; }
+  const u = pickInlineArealDensityUnit(mtKm2);
+  return `${fixed2(mtKm2 * u.perMtKm2)} ${u.unit}`;
+}
+
+/** Dialog-row label for the inline areal-density unit chosen at this magnitude. */
+export function dynamicArealDensityUnitLabel(mtKm2: number): string {
+  return Number.isFinite(mtKm2) ? pickInlineArealDensityUnit(mtKm2).label : '';
 }

--- a/src/app/data/unit-conversions.ts
+++ b/src/app/data/unit-conversions.ts
@@ -332,16 +332,20 @@ export function dynamicAreaUnitLabel(km2: number): string {
 interface InlineArealDensityUnit { unit: string; label: string; perMtKm2: number; }
 
 /**
- * Picks the inline ring/belt areal-density unit (Mt/km², stepping up to Gt/km² for very
- * dense rings) by magnitude. Single source for both the inline display
- * ({@link formatDynamicArealDensity}) and the dialog accent label ({@link dynamicArealDensityUnitLabel}).
+ * Picks the inline ring/belt areal-density unit by magnitude: Mt/km² for ordinary rings,
+ * stepping up to Gt/km² for very dense rings, and dropping to kg/m² (a real surface density)
+ * for sparse belts — which otherwise read as a tiny "0.0x Mt/km²" fraction. Single source for
+ * both the inline display ({@link formatDynamicArealDensity}) and the dialog accent label
+ * ({@link dynamicArealDensityUnitLabel}); every unit here has a matching dialog row.
  */
 function pickInlineArealDensityUnit(mtKm2: number): InlineArealDensityUnit {
-  if (Math.abs(mtKm2) >= MT_PER_GT) { return { unit: 'Gt/km²', label: 'Gt/km²', perMtKm2: 1 / MT_PER_GT }; }
+  const abs = Math.abs(mtKm2);
+  if (abs >= MT_PER_GT) { return { unit: 'Gt/km²', label: 'Gt/km²', perMtKm2: 1 / MT_PER_GT }; }
+  if (abs !== 0 && abs < 0.1) { return { unit: 'kg/m²', label: 'kg/m²', perMtKm2: KG_M2_PER_MT_KM2 }; }
   return { unit: 'Mt/km²', label: 'Mt/km²', perMtKm2: 1 };
 }
 
-/** Inline areal-density display (Mt/km² base), scaling up to Gt/km² for very dense rings. */
+/** Inline areal-density display (Mt/km² base), scaling up to Gt/km² and down to kg/m². */
 export function formatDynamicArealDensity(mtKm2: number): string {
   if (!Number.isFinite(mtKm2)) { return '—'; }
   const u = pickInlineArealDensityUnit(mtKm2);

--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.spec.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.spec.ts
@@ -25,12 +25,14 @@ describe('ConvertIconComponent', () => {
     label: string,
     uiUnit?: string,
     sourceUnit?: string,
+    sourcePrecise?: boolean,
   ): ConvertIconComponent {
     fixture.componentRef.setInput('kind', kind);
     fixture.componentRef.setInput('value', value);
     fixture.componentRef.setInput('label', label);
     if (uiUnit !== undefined) { fixture.componentRef.setInput('uiUnit', uiUnit); }
     if (sourceUnit !== undefined) { fixture.componentRef.setInput('sourceUnit', sourceUnit); }
+    if (sourcePrecise !== undefined) { fixture.componentRef.setInput('sourcePrecise', sourcePrecise); }
     fixture.detectChanges();
     return fixture.componentInstance;
   }
@@ -50,7 +52,7 @@ describe('ConvertIconComponent', () => {
     expect(opened).toHaveLength(1);
     expect(opened[0].component).toBe(UnitConversionDialogComponent);
     expect(opened[0].config.data).toEqual({
-      title: 'Radius', kind: 'length', baseValue: 6371, uiUnit: null, sourceUnit: null,
+      title: 'Radius', kind: 'length', baseValue: 6371, uiUnit: null, sourceUnit: null, sourcePrecise: true,
     });
   });
 
@@ -59,7 +61,17 @@ describe('ConvertIconComponent', () => {
     await click(component);
 
     expect(opened[0].config.data).toEqual({
-      title: 'Mass', kind: 'mass', baseValue: 2.88e30, uiUnit: 'Solar Masses', sourceUnit: 'Earth Masses',
+      title: 'Mass', kind: 'mass', baseValue: 2.88e30, uiUnit: 'Solar Masses',
+      sourceUnit: 'Earth Masses', sourcePrecise: true,
+    });
+  });
+
+  it('forwards sourcePrecise=false for a back-converted (imprecise) source unit', async () => {
+    const component = render('length', 6371, 'Radius', 'km', 'm', false);
+    await click(component);
+
+    expect(opened[0].config.data).toEqual({
+      title: 'Radius', kind: 'length', baseValue: 6371, uiUnit: 'km', sourceUnit: 'm', sourcePrecise: false,
     });
   });
 

--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
@@ -37,6 +37,13 @@ export class ConvertIconComponent {
   readonly uiUnit = input<string | null | undefined>();
   /** Conversion-row label for the unit the value is recorded in by the game journal; badged in the dialog. */
   readonly sourceUnit = input<string | null | undefined>();
+  /**
+   * Whether the data source delivers the value in exactly {@link sourceUnit}. Default true
+   * ("from journal"). Set false when the app holds the value in a different unit (e.g. radius
+   * arrives in km though the journal records metres) — the source row is then a back-conversion,
+   * badged "Journal / unprecise" and left rounded.
+   */
+  readonly sourcePrecise = input<boolean | null | undefined>();
 
   protected async open(event: Event): Promise<void> {
     event.stopPropagation();
@@ -53,6 +60,7 @@ export class ConvertIconComponent {
         baseValue,
         uiUnit: this.uiUnit() ?? null,
         sourceUnit: this.sourceUnit() ?? null,
+        sourcePrecise: this.sourcePrecise() ?? true,
       },
     });
   }

--- a/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.html
+++ b/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.html
@@ -14,7 +14,12 @@
             <th scope="row">
               {{ row.unit }}
               @if (row.unit === sourceUnit) {
-                <span class="unit-tag source" matTooltip="The unit this value is recorded in by the game journal">from journal</span>
+                @if (sourcePrecise) {
+                  <span class="unit-tag source" matTooltip="The unit this value is recorded in by the game journal">from journal</span>
+                } @else {
+                  <span class="unit-tag source unprecise"
+                        matTooltip="The game journal records this in {{ sourceUnit }}, but the data source provides it in a different unit — so this figure is a back-conversion and may be less precise than the game's own.">Journal / unprecise</span>
+                }
               }
             </th>
             <td class="value clickable"

--- a/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.ts
+++ b/src/app/dialogs/unit-conversion-dialog/unit-conversion-dialog.component.ts
@@ -23,6 +23,12 @@ export interface UnitConversionDialogData {
   uiUnit?: string | null;
   /** Conversion-row label for the unit the value natively arrives in (badged), or null. */
   sourceUnit?: string | null;
+  /**
+   * Whether the data source delivers the value in exactly `sourceUnit`. When false, the
+   * value reaches us in a different unit and the source row is a back-conversion — badged
+   * "Journal / unprecise" and left rounded rather than shown at full precision. Defaults true.
+   */
+  sourcePrecise?: boolean;
 }
 
 /**
@@ -42,11 +48,14 @@ export class UnitConversionDialogComponent {
   private readonly data = inject<UnitConversionDialogData>(MAT_DIALOG_DATA);
 
   protected readonly title = this.data.title;
-  protected readonly rows: ConversionRow[] = buildConversions(this.data.kind, this.data.baseValue);
-  /** Conversion-row label shown inline in the UI (accented row), if any. */
-  protected readonly uiUnit = this.data.uiUnit ?? null;
   /** Conversion-row label the value natively arrives in (source badge), if any. */
   protected readonly sourceUnit = this.data.sourceUnit ?? null;
+  /** Whether the source row holds the exact figure (true) or a back-conversion (false). */
+  protected readonly sourcePrecise = this.data.sourcePrecise ?? true;
+  protected readonly rows: ConversionRow[] =
+    buildConversions(this.data.kind, this.data.baseValue, this.sourceUnit, this.sourcePrecise);
+  /** Conversion-row label shown inline in the UI (accented row), if any. */
+  protected readonly uiUnit = this.data.uiUnit ?? null;
   protected readonly comparisons: MassComparison[] =
     this.data.kind === 'mass' ? buildMassComparisons(this.data.baseValue) : [];
 

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -676,7 +676,7 @@
             </div>
             <div>
               <span [matTooltip]="cachedSurfacePressureTooltip() || ''"
-                    matTooltipClass="multiline-tooltip">{{ body().bodyData.surfacePressure | number:'0.2-2' }} atmospheres</span><app-convert-icon [kind]="'pressure'" [value]="body().bodyData.surfacePressure" label="Surface pressure" uiUnit="atm" sourceUnit="atm" />
+                    matTooltipClass="multiline-tooltip">{{ body().bodyData.surfacePressure | number:'0.2-2' }} atmospheres</span><app-convert-icon [kind]="'pressure'" [value]="body().bodyData.surfacePressure" label="Surface pressure" uiUnit="atm" sourceUnit="Pa" [sourcePrecise]="false" />
             </div>
           </div>
           }

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -198,7 +198,7 @@
                 Orbital period
               </div>
               <div>
-                <span [matTooltip]="body().bodyData.orbitalPeriod + ' days'">{{ getOrbitalPeriodDisplay() }}</span><app-convert-icon [kind]="'duration'" [value]="body().bodyData.orbitalPeriod" label="Orbital period" [uiUnit]="durationUnitLabel(body().bodyData.orbitalPeriod)" sourceUnit="Seconds" />
+                <span [matTooltip]="body().bodyData.orbitalPeriod + ' days'">{{ getOrbitalPeriodDisplay() }}</span><app-convert-icon [kind]="'duration'" [value]="body().bodyData.orbitalPeriod" label="Orbital period" [uiUnit]="durationUnitLabel(body().bodyData.orbitalPeriod)" sourceUnit="Seconds" [sourcePrecise]="false" />
               </div>
             </div>
             }
@@ -208,7 +208,7 @@
                 Semi-major axis
               </div>
               <div>
-                <span [matTooltip]="body().bodyData.semiMajorAxis + ' au'">{{ formatOrbitDistance(getSemiMajorAxisKm()) }}</span><app-convert-icon [kind]="'length'" [value]="getSemiMajorAxisKm()" label="Semi-major axis" [uiUnit]="orbitDistanceUnitLabel()" sourceUnit="m" />
+                <span [matTooltip]="body().bodyData.semiMajorAxis + ' au'">{{ formatOrbitDistance(getSemiMajorAxisKm()) }}</span><app-convert-icon [kind]="'length'" [value]="getSemiMajorAxisKm()" label="Semi-major axis" [uiUnit]="orbitDistanceUnitLabel()" sourceUnit="m" [sourcePrecise]="false" />
               </div>
             </div>
             }
@@ -239,8 +239,8 @@
               <div>
                 Next apoapsis<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
               </div>
-              <div [matTooltip]="(getNextApoapsis()!.date | date:'yyyy-MM-dd HH:mm') || ''">
-                {{ getNextApoapsis()!.days | number:'0.1-1' }} days
+              <div>
+                <span [matTooltip]="(getNextApoapsis()!.date | date:'yyyy-MM-dd HH:mm') || ''">{{ getNextApoapsis()!.days | number:'0.1-1' }} days</span><app-convert-icon [kind]="'duration'" [value]="getNextApoapsis()!.days" label="Next apoapsis" uiUnit="Days" />
               </div>
             </div>
             }
@@ -260,8 +260,8 @@
               <div>
                 Next periapsis<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
               </div>
-              <div [matTooltip]="(getNextPeriapsis()!.date | date:'yyyy-MM-dd HH:mm') || ''">
-                {{ getNextPeriapsis()!.days | number:'0.1-1' }} days
+              <div>
+                <span [matTooltip]="(getNextPeriapsis()!.date | date:'yyyy-MM-dd HH:mm') || ''">{{ getNextPeriapsis()!.days | number:'0.1-1' }} days</span><app-convert-icon [kind]="'duration'" [value]="getNextPeriapsis()!.days" label="Next periapsis" uiUnit="Days" />
               </div>
             </div>
             }
@@ -271,8 +271,8 @@
                 Argument of periapsis<fa-icon class="info-icon" title="Click for more information"
                   [icon]="faInfo"></fa-icon>
               </div>
-              <div [matTooltip]="body().bodyData.argOfPeriapsis + '° - click for diagram'">
-                {{ body().bodyData.argOfPeriapsis | number:'0.2-2' }}°
+              <div>
+                <span [matTooltip]="body().bodyData.argOfPeriapsis + '° - click for diagram'">{{ body().bodyData.argOfPeriapsis | number:'0.2-2' }}°</span><app-convert-icon [kind]="'angle'" [value]="body().bodyData.argOfPeriapsis" label="Argument of periapsis" uiUnit="Degrees" sourceUnit="Degrees" />
               </div>
             </div>
             }
@@ -282,8 +282,8 @@
                 Orbital inclination<fa-icon class="info-icon" title="Click for more information"
                   [icon]="faInfo"></fa-icon>
               </div>
-              <div [matTooltip]="body().bodyData.orbitalInclination + '° - click for diagram'">
-                {{ body().bodyData.orbitalInclination | number:'0.2-2' }}°
+              <div>
+                <span [matTooltip]="body().bodyData.orbitalInclination + '° - click for diagram'">{{ body().bodyData.orbitalInclination | number:'0.2-2' }}°</span><app-convert-icon [kind]="'angle'" [value]="body().bodyData.orbitalInclination" label="Orbital inclination" uiUnit="Degrees" sourceUnit="Degrees" />
               </div>
             </div>
             }
@@ -292,8 +292,8 @@
               <div>
                 Ascending node
               </div>
-              <div [matTooltip]="body().bodyData.ascendingNode + '°'">
-                {{ body().bodyData.ascendingNode | number:'0.2-2' }}°
+              <div>
+                <span [matTooltip]="body().bodyData.ascendingNode + '°'">{{ body().bodyData.ascendingNode | number:'0.2-2' }}°</span><app-convert-icon [kind]="'angle'" [value]="body().bodyData.ascendingNode" label="Ascending node" uiUnit="Degrees" sourceUnit="Degrees" />
               </div>
             </div>
             }
@@ -393,7 +393,7 @@
               Radius
             </div>
             <div>
-              <span [matTooltip]="body().bodyData.radius + ' km'">{{ body().bodyData.radius | number:'0.2-2' }} km</span><app-convert-icon [kind]="'length'" [value]="body().bodyData.radius" label="Radius" uiUnit="km" sourceUnit="m" />
+              <span [matTooltip]="body().bodyData.radius + ' km'">{{ body().bodyData.radius | number:'0.2-2' }} km</span><app-convert-icon [kind]="'length'" [value]="body().bodyData.radius" label="Radius" uiUnit="km" sourceUnit="m" [sourcePrecise]="false" />
             </div>
           </div>
           }
@@ -412,7 +412,7 @@
               Radius
             </div>
             <div>
-              <span [matTooltip]="body().bodyData.solarRadius!.toString() + ' R☉'">{{ body().bodyData.solarRadius | number:'0.2-2' }} R☉</span><app-convert-icon [kind]="'length'" [value]="getSolarRadiusKm()" label="Radius" uiUnit="Solar Radii" sourceUnit="m" />
+              <span [matTooltip]="body().bodyData.solarRadius!.toString() + ' R☉'">{{ body().bodyData.solarRadius | number:'0.2-2' }} R☉</span><app-convert-icon [kind]="'length'" [value]="getSolarRadiusKm()" label="Radius" uiUnit="Solar Radii" sourceUnit="m" [sourcePrecise]="false" />
             </div>
           </div>
           }
@@ -467,8 +467,8 @@
             <div>
               Axial tilt<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
             </div>
-            <div [matTooltip]="radToDeg(body().bodyData.axialTilt) + '° - click for diagram'">
-              {{ radToDeg(body().bodyData.axialTilt) | number:'0.2-2' }}°
+            <div>
+              <span [matTooltip]="radToDeg(body().bodyData.axialTilt) + '° - click for diagram'">{{ radToDeg(body().bodyData.axialTilt) | number:'0.2-2' }}°</span><app-convert-icon [kind]="'angle'" [value]="radToDeg(body().bodyData.axialTilt)" label="Axial tilt" uiUnit="Degrees" sourceUnit="Radians" />
             </div>
           </div>
           }
@@ -545,8 +545,8 @@
             <div>
               Density
             </div>
-            <div [matTooltip]="getRingDensity() + ' Mt/km²'">
-              {{ getRingDensity() | number:'0.2-2' }} Mt/km²
+            <div>
+              <span [matTooltip]="getRingDensity() + ' Mt/km²'">{{ formatRingDensity(getRingDensity()) }}</span><app-convert-icon [kind]="'arealDensity'" [value]="getRingDensity()" label="Density" [uiUnit]="ringDensityUnitLabel(getRingDensity())" />
             </div>
           </div>
           }
@@ -650,19 +650,23 @@
               {{ body().bodyData.type === 'Star' ? 'Surface Temperature' : 'Average Surface Temperature'
               }}
             </div>
-            <div [matTooltip]="body().bodyData.surfaceTemperature + ' K'">
-              {{ body().bodyData.surfaceTemperature | number:'0.2-2' }} K
+            <div>
+              <span [matTooltip]="body().bodyData.surfaceTemperature + ' K'">{{ body().bodyData.surfaceTemperature | number:'0.2-2' }} K</span><app-convert-icon [kind]="'temperature'" [value]="body().bodyData.surfaceTemperature" label="Surface temperature" uiUnit="K" sourceUnit="K" />
             </div>
           </div>
           }
           @if (body().bodyData.isLandable && getEstimatedTempRange(); as estTemp) {
           <div class="body-data-entry">
             <div>Min Surface Temperature Estimate</div>
-            <div [matTooltip]="estTemp.min + ' K'">{{ estTemp.min | number:'0.2-2' }} K</div>
+            <div>
+              <span [matTooltip]="estTemp.min + ' K'">{{ estTemp.min | number:'0.2-2' }} K</span><app-convert-icon [kind]="'temperature'" [value]="estTemp.min" label="Min surface temperature estimate" uiUnit="K" />
+            </div>
           </div>
           <div class="body-data-entry">
             <div>Max Surface Temperature Estimate</div>
-            <div [matTooltip]="estTemp.max + ' K'">{{ estTemp.max | number:'0.2-2' }} K</div>
+            <div>
+              <span [matTooltip]="estTemp.max + ' K'">{{ estTemp.max | number:'0.2-2' }} K</span><app-convert-icon [kind]="'temperature'" [value]="estTemp.max" label="Max surface temperature estimate" uiUnit="K" />
+            </div>
           </div>
           }
           @if (body().bodyData.surfacePressure != null && body().bodyData.surfacePressure !== 0) {
@@ -672,7 +676,7 @@
             </div>
             <div>
               <span [matTooltip]="cachedSurfacePressureTooltip() || ''"
-                    matTooltipClass="multiline-tooltip">{{ body().bodyData.surfacePressure | number:'0.2-2' }} atmospheres</span><app-convert-icon [kind]="'pressure'" [value]="body().bodyData.surfacePressure" label="Surface pressure" uiUnit="atm" sourceUnit="Pa" />
+                    matTooltipClass="multiline-tooltip">{{ body().bodyData.surfacePressure | number:'0.2-2' }} atmospheres</span><app-convert-icon [kind]="'pressure'" [value]="body().bodyData.surfacePressure" label="Surface pressure" uiUnit="atm" sourceUnit="atm" />
             </div>
           </div>
           }
@@ -699,7 +703,7 @@
               Rotational period
             </div>
             <div>
-              <span [matTooltip]="body().bodyData.rotationalPeriod + ' days'">{{ getRotationalPeriodDisplay() }}</span><app-convert-icon [kind]="'duration'" [value]="body().bodyData.rotationalPeriod" label="Rotational period" [uiUnit]="durationUnitLabel(body().bodyData.rotationalPeriod)" sourceUnit="Seconds" />
+              <span [matTooltip]="body().bodyData.rotationalPeriod + ' days'">{{ getRotationalPeriodDisplay() }}</span><app-convert-icon [kind]="'duration'" [value]="body().bodyData.rotationalPeriod" label="Rotational period" [uiUnit]="durationUnitLabel(body().bodyData.rotationalPeriod)" sourceUnit="Seconds" [sourcePrecise]="false" />
             </div>
           </div>
           }
@@ -719,8 +723,8 @@
             <div>
               Mean anomaly<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
             </div>
-            <div [matTooltip]="'Calculated for ' + (getSystemAnomalyEpoch() | date:'yyyy-MM-dd HH:mm') + ' UTC - click for details'">
-              {{ getMeanAnomaly() | number:'0.2-2' }}°
+            <div>
+              <span [matTooltip]="'Calculated for ' + (getSystemAnomalyEpoch() | date:'yyyy-MM-dd HH:mm') + ' UTC - click for details'">{{ getMeanAnomaly() | number:'0.2-2' }}°</span><app-convert-icon [kind]="'angle'" [value]="getMeanAnomaly()" label="Mean anomaly" uiUnit="Degrees" sourceUnit="Degrees" />
             </div>
           </div>
           }
@@ -729,8 +733,8 @@
             <div>
               True anomaly<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
             </div>
-            <div [matTooltip]="'Calculated for ' + (getSystemAnomalyEpoch() | date:'yyyy-MM-dd HH:mm') + ' UTC - click for details'">
-              {{ getTrueAnomaly() | number:'0.2-2' }}°
+            <div>
+              <span [matTooltip]="'Calculated for ' + (getSystemAnomalyEpoch() | date:'yyyy-MM-dd HH:mm') + ' UTC - click for details'">{{ getTrueAnomaly() | number:'0.2-2' }}°</span><app-convert-icon [kind]="'angle'" [value]="getTrueAnomaly()" label="True anomaly" uiUnit="Degrees" />
             </div>
           </div>
           }

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -33,11 +33,13 @@ import type { OnFootSafetyDialogData } from '../dialogs/on-foot-safety-dialog/on
 import { StellarAgeAssessment, assessStellarAge, isPlottableStarClass } from '../data/stellar-reference';
 import { ConvertIconComponent } from '../dialogs/unit-conversion-dialog/convert-icon.component';
 import {
+  dynamicArealDensityUnitLabel,
   dynamicAreaUnitLabel,
   dynamicDistanceUnitLabel,
   dynamicLengthUnitLabel,
   dynamicMassUnitLabel,
   formatDynamicArea,
+  formatDynamicArealDensity,
   formatDynamicDistanceLs,
   formatDynamicLength,
   formatDynamicMass,
@@ -696,6 +698,8 @@ export class SystemBodyComponent implements OnChanges {
   public formatDistanceLs(ls: number): string { return formatDynamicDistanceLs(ls); }
   public formatMass(kg: number): string { return formatDynamicMass(kg); }
   public formatArea(km2: number): string { return formatDynamicArea(km2); }
+  /** Ring/belt areal density (Mt/km² base), scaled up to Gt/km² for very dense rings. */
+  public formatRingDensity(mtKm2: number): string { return formatDynamicArealDensity(mtKm2); }
 
   // --- Conversion-dialog "shown in UI" unit labels (which dialog row to accent). ---
   public lengthUnitLabel(km: number | null | undefined): string {
@@ -709,6 +713,9 @@ export class SystemBodyComponent implements OnChanges {
   }
   public areaUnitLabel(km2: number | null | undefined): string {
     return km2 == null ? '' : dynamicAreaUnitLabel(km2);
+  }
+  public ringDensityUnitLabel(mtKm2: number | null | undefined): string {
+    return mtKm2 == null ? '' : dynamicArealDensityUnitLabel(mtKm2);
   }
   /** Dialog-row label for the inline duration unit chosen by {@link formatPeriodDays}. */
   public durationUnitLabel(days: number | null | undefined): string {
@@ -1534,8 +1541,8 @@ export class SystemBodyComponent implements OnChanges {
 
   /**
    * The unit a period reads in at this magnitude: numeric value, inline abbreviation, and
-   * the matching conversion-dialog row label ('' for ms/s/decades/centuries, which have no
-   * dialog row). Single source for both {@link formatPeriodDays} and {@link durationUnitLabel}.
+   * the matching conversion-dialog row label ('' for ms/s, which have no dialog row).
+   * Single source for both {@link formatPeriodDays} and {@link durationUnitLabel}.
    */
   private periodParts(days: number): { value: number; unit: string; label: string } {
     const absDays = Math.abs(days);
@@ -1552,8 +1559,8 @@ export class SystemBodyComponent implements OnChanges {
     if (absDays < 7) return { value: absDays, unit: 'days', label: 'Days' };
     if (weeks < 52) return { value: weeks, unit: 'weeks', label: 'Weeks' };
     if (years < 10) return { value: years, unit: 'years', label: 'Years' };
-    if (years / 10 < 10) return { value: years / 10, unit: 'decades', label: '' };
-    return { value: years / 100, unit: 'centuries', label: '' };
+    if (years / 10 < 10) return { value: years / 10, unit: 'decades', label: 'Decades' };
+    return { value: years / 100, unit: 'centuries', label: 'Centuries' };
   }
 
   private formatPeriodDays(days: number): string {


### PR DESCRIPTION
## Summary

Extends the click-to-convert unit dialog with several new quantity kinds and refines how the "source" (journal) value is presented.

### New conversions
- **Angle** (degrees ⇄ radians) on Axial tilt, Orbital inclination, Argument of periapsis, Ascending node, and Mean/True anomaly.
- **Temperature** (`K` / `°C` / `°F` / `°R`) on Surface temperature and the landable Min/Max estimate rows. Body always shows K inline; alternatives live in the dialog. Implemented via an optional per-unit `offset` so the affine °C/°F transforms work alongside the existing multiplicative model.
- **Ring/Belt areal density** (`Gt/km²` / `Mt/km²` / `kg/m²`), with the inline display scaling up to `Gt/km²` for very dense rings.
- **Duration** gains `Decades` and `Centuries` rows (matching the existing inline period ladder), and **Next apoapsis / Next periapsis** are now convertible.

### Source-unit accuracy
- New **`sourcePrecise`** flag. When the data source delivers a value in a *different* unit than the game journal's native unit, the journal-unit row is badged **"Journal / unprecise"** and left rounded, instead of being shown at fabricated full precision. Applied to:
  - Radius / Solar radius / Semi-major axis — km/R☉/AU vs journal metres.
  - Orbital / Rotational period — days vs journal seconds.
  - **Surface pressure** — the data source delivers atmospheres while the journal records Pascals, so the `Pa` row is badged "Journal / unprecise". (Inline display stays "atmospheres", which is what we actually hold.) Verified against HR 6421 5 d: `8209.756836 Pa ÷ 101325 = 0.0810240003552924 atm`.
- The precise **"from journal"** value is now grouped with **thousand separators** at full precision (the clipboard copy value stays plain/separator-free).
- The "Journal / unprecise" badge shares the same styling/color as "from journal".

## Testing
- `ng build` (strict templates) ✓
- Unit tests: 714 passed ✓
- e2e (desktop-chromium): 96 passed ✓, including new specs for angle, temperature, areal density, duration (decades/centuries), and the corrected orbital-period and surface-pressure "Journal / unprecise" badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
