### PR TITLE
Fix pgnames codec: tryParse slice, BigInt address packing, field widths

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,8 @@
 # TODO — Flagged issues (not yet addressed)
 
 These were surfaced during the astronomy/physics review and the test-coverage work on
-the `upgrade` branch. None have been fixed, and none are regressions — the logic was
-extracted verbatim from `SystemBodyComponent` into the data services, so each bug
-pre-dates this branch.
+the `upgrade` branch. None are regressions — the logic was extracted verbatim from
+`SystemBodyComponent` into the data services, so each bug pre-dates this branch.
 
 ## Physics / source
 
@@ -18,35 +17,3 @@ pre-dates this branch.
   exposes `periapsis`/`apoapsis` ([:228-229](src/app/data/body-physics.service.ts#L228-L229))
   for exactly this comparison. Fix: use periapsis. (The `1.26` coefficient = 2^(1/3) is the
   correct rigid-body value.)
-
-## pgnames (vendored procedural-generation code)
-
-- **`tryParse` rejects all `…AB-C d<n1>-<n2>` names** —
-  [PGSystem.ts:251](src/app/data/pgnames/PGSystem.ts#L251).
-  The mid3 digit slice uses `substring(i + 1, vend - i + 1)` — a *length* passed where an
-  *end index* is expected. The digits live at `[i+1 .. vend]`, so the correct call is
-  `substring(i + 1, vend + 1)`. Since `i > 8` always, `vend - i + 1` is smaller than `i + 1`,
-  so `substring` swaps the bounds and returns a slice of the region-name text; `parseInt` → `NaN`
-  and the parse fails. Only names without the `-<n2>` suffix currently parse. Behaviour pinned
-  by [pgnames.spec.ts:49-55](src/app/data/pgnames/pgnames.spec.ts#L49-L55)
-  (`'Blae Eock kc-c d0-0'` → rejected).
-
-- **`toModSystemAddress` is lossy (32-bit bitwise overflow)** —
-  [PGSystem.ts:309](src/app/data/pgnames/PGSystem.ts#L309).
-  The result is assembled with JS `|`/`<<`
-  ([:330-336](src/app/data/pgnames/PGSystem.ts#L330-L336)), which coerce to 32-bit signed
-  integers and take the shift count mod 32. Shifts packed above bit 31 — `szclass << 37`,
-  `x2 << 40`, `y2 << 47`, `z2 << 53` — wrap (e.g. `<< 53` becomes `<< 21`) before the value is
-  widened by `BigInt(...)`, so the high fields are truncated and the round-trip is lossy.
-  Behaviour pinned by [pgnames.spec.ts:25-33](src/app/data/pgnames/pgnames.spec.ts#L25-L33).
-
-- **`fromSystemAddress` → `toSystemAddress` is not bit-identical** —
-  [PGSystem.ts:287](src/app/data/pgnames/PGSystem.ts#L287).
-  Two causes. The dominant one is the same 32-bit bitwise packing as `toModSystemAddress`:
-  `toSystemAddress` shifts up to 44 ([:301-304](src/app/data/pgnames/PGSystem.ts#L301-L304))
-  wrap mod 32, so the encode is broken for every sector. Secondarily, for an uncatalogued
-  sector `getRegion` synthesises the origin from `getSectorPos` quantised to the 40960-unit
-  boxel grid ([PGRegion.ts:514-522](src/app/data/pgnames/PGRegion.ts#L514-L522)), discarding the
-  original sub-sector offset. Loosely pinned by
-  [pgnames.spec.ts:18-23](src/app/data/pgnames/pgnames.spec.ts#L18-L23), which only asserts a
-  positive bigint result.

--- a/src/app/data/pgnames/PGSystem.ts
+++ b/src/app/data/pgnames/PGSystem.ts
@@ -248,7 +248,7 @@ export class PGSystem implements IPGSystem {
             while (i > 8 && _s[i] >= '0' && _s[i] <= '9') i--;
             if (i === vend) return [false, sys];
 
-            const mid3Str = _s.substring(i + 1, vend - i + 1);
+            const mid3Str = _s.substring(i + 1, vend + 1);
             const mid3 = parseInt(mid3Str);
             if (isNaN(mid3)) return [false, sys];
             sys.mid3 = mid3;
@@ -284,58 +284,108 @@ export class PGSystem implements IPGSystem {
         return [true, sys];
     }
 
-    toSystemAddress(): bigint {
+    /**
+     * Absolute boxel coordinates (from the galaxy origin) of this system's boxel:
+     * the region-relative letter-code offset plus the region origin in boxels.
+     * Throws when the region cannot be resolved or the letter code lies outside
+     * the region, so encoders fail loudly instead of emitting a wrong sector.
+     */
+    private absoluteBoxel(): { x: number; y: number; z: number } {
         const reg = this.region;
+        const boxelSize = 320 << this.sizeClass; // internal units per boxel edge
+
+        if (reg.x0 < 0 || reg.y0 < 0 || reg.z0 < 0) {
+            throw new Error(`Unknown sector: ${this.regionName}`);
+        }
 
         const mid =
             ((this.mid3 * 26 + this.mid2) * 26 + this.mid1b) * 26 + this.mid1a;
-        const x = (mid & 0x7f) + Math.floor(reg.x0 / (320 << this.sizeClass));
-        const y =
-            ((mid >> 7) & 0x7f) + Math.floor(reg.y0 / (320 << this.sizeClass));
-        const z =
-            ((mid >> 14) & 0x7f) + Math.floor(reg.z0 / (320 << this.sizeClass));
-        const seq = this.sequence;
+        if (mid > 0x1fffff) {
+            // Only an oversized n1 can push mid past 21 bits (mid3 contributes mid3 * 26^3).
+            throw new RangeError(`System index n1=${this.mid3} out of range in ${this.regionName}`);
+        }
+        const bx = mid & 0x7f;
+        const by = (mid >> 7) & 0x7f;
+        const bz = (mid >> 14) & 0x7f;
+        // Letter codes count from the region origin snapped DOWN to the boxel
+        // grid, so a region whose origin is not boxel-aligned reaches one boxel
+        // further than sizeX/boxelSize — the bound must include the origin's
+        // offset within its boxel.
+        if (
+            bx * boxelSize >= (reg.x0 % boxelSize) + reg.sizeX ||
+            by * boxelSize >= (reg.y0 % boxelSize) + reg.sizeY ||
+            bz * boxelSize >= (reg.z0 % boxelSize) + reg.sizeZ
+        ) {
+            throw new RangeError(
+                `Letter code out of range for size class ${PGSystem.toLetter(this.sizeClass)} in ${this.regionName}`
+            );
+        }
 
-        const result =
-            this.sizeClass |
-            (z << 3) |
-            (y << (17 - this.sizeClass)) |
-            (x << (30 - this.sizeClass * 2)) |
-            (seq << (44 - this.sizeClass * 3));
+        const x = bx + Math.floor(reg.x0 / boxelSize);
+        const y = by + Math.floor(reg.y0 / boxelSize);
+        const z = bz + Math.floor(reg.z0 / boxelSize);
+        // A system address has 7 sector bits for x/z but only 6 for y; a
+        // parseable name can still resolve to a sector outside that space, and
+        // packing it would silently corrupt neighbouring fields.
+        const sc = this.sizeClass;
+        if (x >= 1 << (14 - sc) || y >= 1 << (13 - sc) || z >= 1 << (14 - sc)) {
+            throw new RangeError(`Sector position of ${this.regionName} does not fit a system address`);
+        }
 
-        return BigInt(result);
+        return { x, y, z };
+    }
+
+    toSystemAddress(): bigint {
+        const sc = this.sizeClass;
+        const { x, y, z } = this.absoluteBoxel();
+
+        // The sequence (N2) field spans bits [44-3*sc, 55); the 9 bits above it
+        // are the body ID, which a system address leaves at zero.
+        const seqWidth = 11 + sc * 3;
+        if (this.sequence < 0 || this.sequence >= 2 ** seqWidth) {
+            throw new RangeError(`Sequence ${this.sequence} does not fit in ${seqWidth} bits`);
+        }
+
+        // Pack with BigInt: JS number bitwise operators truncate operands and
+        // results to 32 bits (ToInt32), so any field reaching bit 31 or above
+        // would be corrupted.
+        return (
+            BigInt(sc) |
+            (BigInt(z) << 3n) |
+            (BigInt(y) << BigInt(17 - sc)) |
+            (BigInt(x) << BigInt(30 - sc * 2)) |
+            (BigInt(this.sequence) << BigInt(44 - sc * 3))
+        );
     }
 
     toModSystemAddress(): bigint {
-        const reg = this.region;
+        const sc = this.sizeClass;
+        const bps = 7 - sc; // log2 of boxels per sector edge at this size class
+        const boxelMask = 0x7f >> sc;
+        const { x, y, z } = this.absoluteBoxel();
 
-        const mid =
-            ((this.mid3 * 26 + this.mid2) * 26 + this.mid1b) * 26 + this.mid1a;
-        const x = (mid & 0x7f) + Math.floor(reg.x0 / (320 << this.sizeClass));
-        const x1 = x & 0x7f;
-        const x2 = (x >> 7) & 0x7f;
-        const y =
-            ((mid >> 7) & 0x7f) + Math.floor(reg.y0 / (320 << this.sizeClass));
-        const y1 = y & 0x7f;
-        const y2 = (y >> 7) & 0x3f;
-        const z =
-            ((mid >> 14) & 0x7f) + Math.floor(reg.z0 / (320 << this.sizeClass));
-        const z1 = z & 0x7f;
-        const z2 = (z >> 7) & 0x7f;
-        const seq = this.sequence;
-        const szclass = this.sizeClass;
+        if (this.sequence < 0 || this.sequence > 0x7fff) {
+            throw new RangeError(`Sequence ${this.sequence} does not fit in the 15-bit mod-address field`);
+        }
 
-        const result =
-            seq |
-            (x1 << 16) |
-            (y1 << 23) |
-            (z1 << 30) |
-            (szclass << 37) |
-            (x2 << 40) |
-            (y2 << 47) |
-            (z2 << 53);
+        // Split each axis into sector coordinate and within-sector boxel. Sectors
+        // span 2^(7 - sizeClass) boxels at this size class, not a fixed 7 bits.
+        // The sector-relative letter code is what fromModSystemAddress reads from
+        // bits 16-36.
+        const midOut =
+            (x & boxelMask) | ((y & boxelMask) << 7) | ((z & boxelMask) << 14);
 
-        return BigInt(result);
+        // Pack with BigInt: JS number bitwise operators truncate operands and
+        // results to 32 bits (ToInt32), so any field reaching bit 31 or above
+        // would be corrupted.
+        return (
+            BigInt(this.sequence) |
+            (BigInt(midOut) << 16n) |
+            (BigInt(sc) << 37n) |
+            (BigInt((x >> bps) & 0x7f) << 40n) |
+            (BigInt((y >> bps) & 0x3f) << 47n) |
+            (BigInt((z >> bps) & 0x7f) << 53n)
+        );
     }
 
     static fromSystemAddress(systemaddress: bigint): PGSystem {
@@ -350,7 +400,11 @@ export class PGSystem implements IPGSystem {
         const x0 = Number((addr >> BigInt(30 - sizeclass * 2)) & BigInt(0x3fff >> sizeclass));
         const x1 = Number((addr >> BigInt(30 - sizeclass * 2)) & BigInt(0x7f >> sizeclass));
         const x2 = Number((addr >> BigInt(37 - sizeclass * 3)) & BigInt(0x7f));
-        const seq = Number((addr >> BigInt(44 - sizeclass * 3)) & BigInt(0x7fff));
+        // The sequence (N2) field is 11 + 3*sizeclass bits wide, ending at bit 55
+        // where the 9-bit body ID starts.
+        const seq = Number(
+            (addr >> BigInt(44 - sizeclass * 3)) & ((1n << BigInt(11 + sizeclass * 3)) - 1n)
+        );
 
         const regionname = PGSectors.getSectorName(
             new ByteXYZ(x2, y2, z2)

--- a/src/app/data/pgnames/PGSystem.ts
+++ b/src/app/data/pgnames/PGSystem.ts
@@ -37,7 +37,10 @@ export class PGSystem implements IPGSystem {
         const mid3 = Math.trunc(this.mid3);
         const seq = Math.trunc(this.sequence);
 
-        return `${this.regionName} ${mid1a}${mid1b}-${mid2} ${size}${mid3}-${seq}`;
+        // Elite Dangerous omits the N1 field (and its hyphen) when it is zero,
+        // so "Synuefe WH-F c0" (N1=0, N2=0) must not render as "…c0-0".
+        const index = mid3 !== 0 ? `${mid3}-${seq}` : `${seq}`;
+        return `${this.regionName} ${mid1a}${mid1b}-${mid2} ${size}${index}`;
     }
 
     /**

--- a/src/app/data/pgnames/pgnames.spec.ts
+++ b/src/app/data/pgnames/pgnames.spec.ts
@@ -11,8 +11,10 @@ describe('PGSystem', () => {
       const sys = PGSystem.fromSystemAddress(KNOWN_ID64);
       expect(sys.regionName).toBe('Blae Eock');
       expect(sys.sizeClass).toBeGreaterThanOrEqual(0);
-      // toPGName renders the mass-code/index segment in lower case with a sequence suffix.
-      expect(sys.toPGName()).toBe('Blae Eock kc-c d0-0');
+      // toPGName renders the mass-code/index segment in lower case. N1 is zero
+      // here, and Elite Dangerous omits it (and its hyphen), so this is "d0" not
+      // "d0-0" — matching the in-game name "Blae Eock KC-C d0".
+      expect(sys.toPGName()).toBe('Blae Eock kc-c d0');
     });
 
     // Ground truth generated with the EDTS reference implementation

--- a/src/app/data/pgnames/pgnames.spec.ts
+++ b/src/app/data/pgnames/pgnames.spec.ts
@@ -15,21 +15,100 @@ describe('PGSystem', () => {
       expect(sys.toPGName()).toBe('Blae Eock kc-c d0-0');
     });
 
-    it('re-encodes a decoded address to a bigint (region origin is synthesised, so not bit-identical)', () => {
-      const sys = PGSystem.fromSystemAddress(KNOWN_ID64);
-      const addr = sys.toSystemAddress();
-      expect(typeof addr).toBe('bigint');
-      expect(addr).toBeGreaterThan(0n);
+    // Ground truth generated with the EDTS reference implementation
+    // (calculate_id64 + pgnames, systems in the Blae Eock sector), one id64 per
+    // mass code, plus the in-game-verified KNOWN_ID64. These anchor the absolute
+    // bit layout — not just that encode and decode are mutual inverses.
+    const REFERENCE_SYSTEMS = [
+      { id64: KNOWN_ID64, l1: 'k', l2: 'c', l3: 'c', mcode: 'd', n1: 0, n2: 0 },
+      { id64: 216480817500680n, l1: 'h', l2: 'x', l3: 'u', mcode: 'a', n1: 60, n2: 12 },
+      { id64: 7268822034689n, l1: 'c', l2: 'g', l3: 'y', mcode: 'b', n1: 29, n2: 3 },
+      { id64: 38841769759874n, l1: 'b', l2: 'd', l3: 'z', mcode: 'c', n1: 14, n2: 141 },
+      { id64: 319731321411n, l1: 'b', l2: 'm', l3: 'm', mcode: 'd', n1: 7, n2: 9 },
+      { id64: 9900533028n, l1: 'o', l2: 'd', l3: 't', mcode: 'e', n1: 3, n2: 2 },
+      { id64: 700940949n, l1: 'i', l2: 'm', l3: 'w', mcode: 'f', n1: 1, n2: 1 },
+      { id64: 20570446n, l1: 'e', l2: 'g', l3: 'y', mcode: 'g', n1: 0, n2: 0 },
+      { id64: 36141223n, l1: 'a', l2: 'a', l3: 'a', mcode: 'h', n1: 0, n2: 4 },
+    ];
+    const letter = (c: string) => c.charCodeAt(0) - 'a'.charCodeAt(0);
+
+    it('decodes and re-encodes reference id64s across all mass codes', () => {
+      for (const ref of REFERENCE_SYSTEMS) {
+        const sys = PGSystem.fromSystemAddress(ref.id64);
+        expect(sys.regionName).toBe('Blae Eock');
+        expect(sys.mid1a).toBe(letter(ref.l1));
+        expect(sys.mid1b).toBe(letter(ref.l2));
+        expect(sys.mid2).toBe(letter(ref.l3));
+        expect(sys.sizeClass).toBe(letter(ref.mcode));
+        expect(sys.mid3).toBe(ref.n1);
+        expect(sys.sequence).toBe(ref.n2);
+        expect(sys.toSystemAddress()).toBe(ref.id64);
+      }
     });
 
-    it('encodes and decodes the modulated-address form (lossy: toModSystemAddress uses 32-bit bitwise ops)', () => {
+    it('round-trips a sequence wider than 15 bits', () => {
+      // The sequence field is 11 + 3*sizeClass bits; for mass code d that is 20
+      // bits, so 40000 must survive decode -> encode.
       const sys = PGSystem.fromSystemAddress(KNOWN_ID64);
-      const back = PGSystem.fromModSystemAddress(sys.toModSystemAddress());
-      // NOTE: toModSystemAddress builds the result with JS bitwise (32-bit) operators, so
-      // fields packed above bit 31 are truncated — the round-trip is lossy across the board.
-      expect(back).toBeInstanceOf(PGSystem);
-      expect(typeof back.regionName).toBe('string');
-      expect(typeof back.sequence).toBe('number');
+      sys.sequence = 40000;
+      expect(PGSystem.fromSystemAddress(sys.toSystemAddress()).sequence).toBe(40000);
+    });
+
+    it('round-trips the modulated-address form losslessly', () => {
+      for (const ref of REFERENCE_SYSTEMS) {
+        const sys = PGSystem.fromSystemAddress(ref.id64);
+        const back = PGSystem.fromModSystemAddress(sys.toModSystemAddress());
+        // toPGName interpolates the region, letters, size class, n1 and n2, so
+        // one comparison covers every field.
+        expect(back.toPGName()).toBe(sys.toPGName());
+      }
+    });
+
+    it('rejects encoding instead of emitting a wrong address', () => {
+      // Unknown sector: the synthesised region origin is invalid.
+      const [okUnknown, unknown] = PGSystem.tryParse('Totally Made Up XY-Z d1-2');
+      expect(okUnknown).toBe(true);
+      expect(() => unknown.toSystemAddress()).toThrowError(/Unknown sector/);
+      expect(() => unknown.toModSystemAddress()).toThrowError(/Unknown sector/);
+
+      // Letter code outside the sector for the size class: an h-class sector
+      // holds a single boxel, so only AA-A is valid.
+      const [okRange, outOfRange] = PGSystem.tryParse('Blae Eock KC-C h0-0');
+      expect(okRange).toBe(true);
+      expect(() => outOfRange.toSystemAddress()).toThrowError(RangeError);
+
+      // Sequence too large for the field.
+      const [okSeq, seqTooBig] = PGSystem.tryParse('Blae Eock KC-C d0-70000');
+      expect(okSeq).toBe(true);
+      expect(() => seqTooBig.toModSystemAddress()).toThrowError(RangeError);
+
+      // Fragment-valid sector name that resolves outside the galaxy's 6-bit
+      // y-sector range: the address fields cannot represent it.
+      const [okGal, outOfGalaxy] = PGSystem.tryParse('Pyruetchoo AA-A d0');
+      expect(okGal).toBe(true);
+      expect(() => outOfGalaxy.toSystemAddress()).toThrowError(/does not fit/);
+      expect(() => outOfGalaxy.toModSystemAddress()).toThrowError(/does not fit/);
+    });
+
+    it('encodes a parsed PG name to the known system address', () => {
+      const [ok, sys] = PGSystem.tryParse('Blae Eock KC-C d0-0');
+      expect(ok).toBe(true);
+      expect(sys.toSystemAddress()).toBe(KNOWN_ID64);
+    });
+
+    it('encodes names in hand-authored regions with non-boxel-aligned origins', () => {
+      // Real in-game systems (id64s from EDSM). Both regions have catalogued
+      // origins that are not aligned to the boxel grid, so the letter code
+      // legitimately reaches one boxel past sizeX/boxelSize.
+      const cases = [
+        { name: 'Col 285 Sector IB-X b30-0', id64: 669612516897n },
+        { name: 'Cepheus Dark Region B Sector AF-Q b5-0', id64: 659412493657n },
+      ];
+      for (const c of cases) {
+        const [ok, sys] = PGSystem.tryParse(c.name);
+        expect(ok).toBe(true);
+        expect(sys.toSystemAddress()).toBe(c.id64);
+      }
     });
 
     it('exposes its region via the region getter', () => {
@@ -46,12 +125,21 @@ describe('PGSystem', () => {
       expect(sys.sizeClass).toBe('d'.charCodeAt(0) - 'a'.charCodeAt(0));
     });
 
-    it('currently rejects the n1-n2 form because of a substring bug in tryParse', () => {
-      // NOTE: tryParse extracts the mid3 digits with substring(i+1, vend - i + 1) — passing a
-      // *length* where an *end index* is expected — so it slices garbage, parseInt -> NaN, and
-      // every "<sector> AB-C d<n1>-<n2>" name is rejected. Flagged as a latent bug (not fixed).
-      const [ok] = PGSystem.tryParse('Blae Eock kc-c d0-0');
-      expect(ok).toBe(false);
+    it('parses the n1-n2 form into mid3 and sequence', () => {
+      // The last case checks mid3 comes from the system suffix, not from digits
+      // in the sector name itself.
+      const cases = [
+        { name: 'Blae Eock kc-c d0-0', region: 'Blae Eock', mid3: 0, seq: 0 },
+        { name: 'Synuefe EN-H d11-96', region: 'Synuefe', mid3: 11, seq: 96 },
+        { name: 'Col 285 Sector IY-W b16-8', region: 'Col 285 Sector', mid3: 16, seq: 8 },
+      ];
+      for (const c of cases) {
+        const [ok, sys] = PGSystem.tryParse(c.name);
+        expect(ok).toBe(true);
+        expect(sys.regionName).toBe(c.region);
+        expect(sys.mid3).toBe(c.mid3);
+        expect(sys.sequence).toBe(c.seq);
+      }
     });
 
     it('rejects malformed names', () => {

--- a/src/app/home/home.component.extra.spec.ts
+++ b/src/app/home/home.component.extra.spec.ts
@@ -122,9 +122,9 @@ describe('HomeComponent (extended coverage)', () => {
     });
 
     it('resolves a procedural-generation name from a known system address', () => {
+      // N1 is zero for this system, so ED omits it: "…d0", not "…d0-0".
       const name = component.getPGName(10577693187);
-      expect(name.length).toBeGreaterThan(0);
-      expect(name).toMatch(/[A-Z]{2}-[A-Z] [a-z]\d/); // mass-code + index segment
+      expect(name).toBe('Blae Eock KC-C d0');
     });
 
     it('returns an empty PG name for an invalid address', () => {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -118,7 +118,10 @@ export class HomeComponent implements OnInit, OnDestroy {
       const mid3 = Math.trunc(pgSystem.mid3);
       const seq = Math.trunc(pgSystem.sequence);
 
-      const result = `${titleCasedRegion} ${mid1a}${mid1b}-${mid2} ${mcode}${mid3}-${seq}`;
+      // Elite Dangerous omits the N1 field (and its hyphen) when it is zero, so
+      // "Synuefe WH-F c0" (N1=0, N2=0) must not render as "Synuefe WH-F c0-0".
+      const index = mid3 !== 0 ? `${mid3}-${seq}` : `${seq}`;
+      const result = `${titleCasedRegion} ${mid1a}${mid1b}-${mid2} ${mcode}${index}`;
       return result;
     } catch (e) {
       logger.error('[getPGName] Error:', e);


### PR DESCRIPTION
## Summary

Fixes the three pgnames bugs flagged in TODO.md, plus further issues found while verifying the port against the EDTS reference implementation (FuelRats SystemsAPI and KayJohnston/jackies-map copies):

- **`tryParse`**: the mid3 digit slice passed a *length* where an *end index* is expected, rejecting every `<sector> AB-C d<n1>-<n2>` name and silently mis-parsing digits out of sector names (e.g. `Col 285 Sector IY-W b16-8` got `mid3 = 285` from the region text). Fixed to `substring(i + 1, vend + 1)`.
- **`toSystemAddress` / `toModSystemAddress`**: fields were packed with 32-bit JS bitwise operators, corrupting everything at or above bit 31. Both now pack with BigInt. `toModSystemAddress` additionally split absolute boxel coordinates at a fixed 7-bit boundary; it now splits at `2^(7 − sizeClass)` boxels per sector to match `fromModSystemAddress`.
- **Sequence (N2) field width**: the field is `11 + 3·sizeClass` bits (ending at bit 55 where the 9-bit body ID starts), not a fixed 15. `fromSystemAddress`/`toSystemAddress` now use the real width.
- **Fail loudly instead of emitting a wrong address**: encoders throw for unresolvable sectors, out-of-range letter codes / n1 / sequence, and fragment-valid names that resolve outside the galaxy's 6-bit y-sector space. The letter-code bound is origin-aware, so real systems in hand-authored regions with non-boxel-aligned origins (e.g. `Col 285 Sector IB-X b30-0`, verified against its EDSM id64) still encode bit-identically.
- **PG name rendering (N1 omission)**: `toPGName` and the UI's `getPGName` unconditionally emitted the long `<mcode><N1>-<N2>` form, so a system re-rendered from its id64 with `N1 = 0` (e.g. `Synuefe WH-F c0`, `Blae Eock KC-C d0`) came out as `…c0-0` / `…d0-0`. Elite Dangerous omits the N1 field and its hyphen when N1 is zero; both renderers now drop it, matching the rule already in `formatSystemName`.

## Verification

- Specs are anchored to ground-truth id64s generated with the EDTS reference (`calculate_id64`) across all 8 mass codes, plus two real EDSM id64s in misaligned hand-authored regions — asserting the absolute bit layout, not just encode/decode mutual inversion.
- Standard and modulated round trips assert bit-identity / field losslessness.
- The port's sector-name generation was diffed against the Python reference over a 4,693-sector sweep: 100% agreement (including identical failure behaviour).
- Full suite: 710/710 tests pass; `ng build` clean.

## Not addressed (upstream algorithm limitations, unreachable in practice)

`PGSectors.getC1Name` returns null for some sector coordinates and a few C2 names alias on inversion — both reproduce identically in the upstream EDTS reference, and every affected coordinate lies at z-sector ≥ 84 (~84,500 ly beyond Sol, past the galaxy's rim), so no real in-game id64 can reference them. Encoders now throw (`Unknown sector`) for the null-name case rather than emitting garbage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)