### PR TITLE
Add loading skeletons to lazily-loaded dialogs

### DIFF
--- a/src/app/dialogs/lazy-dialog-host/lazy-dialog-host.component.html
+++ b/src/app/dialogs/lazy-dialog-host/lazy-dialog-host.component.html
@@ -1,0 +1,36 @@
+@if (component(); as cmp) {
+  <ng-container *ngComponentOutlet="cmp; injector: bodyInjector" />
+} @else if (failed()) {
+  <h2 mat-dialog-title>Couldn't load</h2>
+  <mat-dialog-content>
+    <p class="lazy-dialog__error" role="alert">
+      This dialog failed to load. Check your connection and try again.
+    </p>
+  </mat-dialog-content>
+  <mat-dialog-actions align="end">
+    <button mat-button mat-dialog-close>Close</button>
+  </mat-dialog-actions>
+} @else if (showSkeleton()) {
+  <h2 mat-dialog-title>
+    <span class="lazy-dialog__sr-only">Loading…</span>
+    <span class="lazy-skeleton lazy-skeleton--title" aria-hidden="true"></span>
+  </h2>
+  <mat-dialog-content>
+    @switch (config.skeleton ?? 'text') {
+      @case ('diagram') {
+        <div class="lazy-skeleton lazy-skeleton--diagram" aria-hidden="true"></div>
+        <div class="lazy-skeleton lazy-skeleton--line lazy-skeleton--w70" aria-hidden="true"></div>
+        <div class="lazy-skeleton lazy-skeleton--line lazy-skeleton--w50" aria-hidden="true"></div>
+      }
+      @default {
+        <div class="lazy-skeleton lazy-skeleton--line lazy-skeleton--w90" aria-hidden="true"></div>
+        <div class="lazy-skeleton lazy-skeleton--line lazy-skeleton--w80" aria-hidden="true"></div>
+        <div class="lazy-skeleton lazy-skeleton--line lazy-skeleton--w85" aria-hidden="true"></div>
+        <div class="lazy-skeleton lazy-skeleton--line lazy-skeleton--w60" aria-hidden="true"></div>
+      }
+    }
+  </mat-dialog-content>
+  <mat-dialog-actions align="end">
+    <button mat-button mat-dialog-close>Close</button>
+  </mat-dialog-actions>
+}

--- a/src/app/dialogs/lazy-dialog-host/lazy-dialog-host.component.scss
+++ b/src/app/dialogs/lazy-dialog-host/lazy-dialog-host.component.scss
@@ -1,0 +1,101 @@
+// Mirror the shared dialog-shell chrome so the skeleton frame lines up with the real body
+// that replaces it (same header/content/actions layout, capped at the viewport height).
+:host {
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+}
+
+h2[mat-dialog-title] {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 24px 24px 0;
+  color: var(--color-text);
+  display: flex;
+  align-items: center;
+}
+
+mat-dialog-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 24px;
+  color: var(--color-text);
+}
+
+mat-dialog-actions {
+  flex: 0 0 auto;
+}
+
+.lazy-dialog__error {
+  margin: 0;
+  color: var(--color-text);
+}
+
+// Visually-hidden text giving the loading dialog an accessible name (the shimmer bars are
+// aria-hidden, so without this the dialog would have no label until its body loads).
+.lazy-dialog__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+// Shimmer placeholders. A neutral slate tint reads on both dark and light dialog backgrounds.
+.lazy-skeleton {
+  --lazy-skeleton-base: rgba(148, 163, 184, 0.16);
+  --lazy-skeleton-highlight: rgba(148, 163, 184, 0.34);
+  border-radius: 4px;
+  background-color: var(--lazy-skeleton-base);
+  background-image: linear-gradient(
+    90deg,
+    var(--lazy-skeleton-base) 25%,
+    var(--lazy-skeleton-highlight) 37%,
+    var(--lazy-skeleton-base) 63%
+  );
+  background-size: 400% 100%;
+  animation: lazy-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+.lazy-skeleton--title {
+  display: inline-block;
+  height: 1.4rem;
+  width: 45%;
+}
+
+.lazy-skeleton--line {
+  height: 0.85rem;
+  margin-bottom: 0.85rem;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.lazy-skeleton--diagram {
+  height: 260px;
+  margin-bottom: 1.1rem;
+}
+
+.lazy-skeleton--w90 { width: 90%; }
+.lazy-skeleton--w85 { width: 85%; }
+.lazy-skeleton--w80 { width: 80%; }
+.lazy-skeleton--w70 { width: 70%; }
+.lazy-skeleton--w60 { width: 60%; }
+.lazy-skeleton--w50 { width: 50%; }
+
+@keyframes lazy-skeleton-shimmer {
+  from { background-position: 100% 0; }
+  to { background-position: 0 0; }
+}
+
+// Honour reduced-motion: keep the placeholder, drop the sweep.
+@media (prefers-reduced-motion: reduce) {
+  .lazy-skeleton {
+    animation: none;
+  }
+}

--- a/src/app/dialogs/lazy-dialog-host/lazy-dialog-host.component.spec.ts
+++ b/src/app/dialogs/lazy-dialog-host/lazy-dialog-host.component.spec.ts
@@ -1,0 +1,145 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, inject, provideZonelessChangeDetection, Type } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+
+import { LazyDialogHostComponent, SKELETON_DELAY_MS } from './lazy-dialog-host.component';
+import { LazyDialogConfig, openLazyDialog } from '../lazy-dialog';
+
+/** Stand-in dialog body: renders the payload it receives so we can assert data pass-through. */
+@Component({
+  selector: 'test-lazy-body',
+  template: `<h2>Loaded body</h2><p class="body-label">{{ label }}</p>`,
+})
+class TestLazyBodyComponent {
+  private readonly data = inject<{ label: string }>(MAT_DIALOG_DATA);
+  readonly label = this.data.label;
+}
+
+/** Flush the loader's resolved/rejected promise chain (the `.then/.catch` microtasks). */
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('LazyDialogHostComponent', () => {
+  let fixture: ComponentFixture<LazyDialogHostComponent>;
+
+  function build(config: LazyDialogConfig): ComponentFixture<LazyDialogHostComponent> {
+    TestBed.configureTestingModule({
+      imports: [LazyDialogHostComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: MAT_DIALOG_DATA, useValue: config },
+      ],
+    });
+    fixture = TestBed.createComponent(LazyDialogHostComponent);
+    return fixture;
+  }
+
+  afterEach(() => {
+    vi.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  const text = () => (fixture.nativeElement as HTMLElement).textContent ?? '';
+  const query = (sel: string) => (fixture.nativeElement as HTMLElement).querySelector(sel);
+
+  it('renders nothing before the skeleton delay, then reveals the skeleton', () => {
+    vi.useFakeTimers();
+    build({ loader: () => new Promise<Type<unknown>>(() => { /* never resolves */ }), data: {} });
+
+    fixture.detectChanges();
+    expect(query('.lazy-skeleton')).toBeNull();
+
+    vi.advanceTimersByTime(SKELETON_DELAY_MS);
+    fixture.detectChanges();
+    expect(query('.lazy-skeleton--title')).not.toBeNull();
+    expect(query('.lazy-skeleton--line')).not.toBeNull();
+    // Accessible name is present even though the shimmer bars are aria-hidden.
+    expect(text()).toContain('Loading');
+  });
+
+  it('shows the diagram skeleton layout when requested', () => {
+    vi.useFakeTimers();
+    build({ loader: () => new Promise<Type<unknown>>(() => { }), data: {}, skeleton: 'diagram' });
+
+    vi.advanceTimersByTime(SKELETON_DELAY_MS);
+    fixture.detectChanges();
+    expect(query('.lazy-skeleton--diagram')).not.toBeNull();
+  });
+
+  it('swaps in the loaded component without ever showing a skeleton on a fast load', async () => {
+    vi.useFakeTimers();
+    build({ loader: () => Promise.resolve(TestLazyBodyComponent), data: { label: 'hi' } });
+
+    await flush();
+    fixture.detectChanges();
+
+    expect(text()).toContain('Loaded body');
+    // The delay timer may still fire, but the loaded body takes precedence over the skeleton.
+    vi.advanceTimersByTime(SKELETON_DELAY_MS);
+    fixture.detectChanges();
+    expect(query('.lazy-skeleton')).toBeNull();
+  });
+
+  it('passes the wrapped data to the loaded body as MAT_DIALOG_DATA', async () => {
+    build({ loader: () => Promise.resolve(TestLazyBodyComponent), data: { label: 'orbital inclination' } });
+
+    await flush();
+    fixture.detectChanges();
+
+    expect(query('.body-label')?.textContent).toBe('orbital inclination');
+  });
+
+  it('shows an error state when the chunk fails to load', async () => {
+    build({ loader: () => Promise.reject(new Error('offline')), data: {} });
+
+    await flush();
+    fixture.detectChanges();
+
+    expect(text()).toContain('failed to load');
+    expect(query('.lazy-skeleton')).toBeNull();
+  });
+
+  it('clears the pending skeleton timer on destroy', () => {
+    vi.useFakeTimers();
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    build({ loader: () => new Promise<Type<unknown>>(() => { }), data: {} });
+
+    fixture.destroy();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});
+
+describe('openLazyDialog', () => {
+  it('opens the host, wraps loader/skeleton/data, and defaults focus to the dialog container', () => {
+    const open = vi.fn().mockReturnValue({});
+    const dialog = { open } as unknown as MatDialog;
+    const loader = () => Promise.resolve<Type<unknown>>(TestLazyBodyComponent);
+
+    openLazyDialog(dialog, { loader, data: { a: 1 }, skeleton: 'diagram', width: '640px', maxWidth: '95vw' });
+
+    expect(open).toHaveBeenCalledTimes(1);
+    const [component, matConfig] = open.mock.calls[0];
+    expect(component).toBe(LazyDialogHostComponent);
+    expect(matConfig).toEqual({
+      autoFocus: 'dialog',
+      width: '640px',
+      maxWidth: '95vw',
+      data: { loader, data: { a: 1 }, skeleton: 'diagram' },
+    });
+  });
+
+  it('lets options override the default focus target', () => {
+    const open = vi.fn().mockReturnValue({});
+    const dialog = { open } as unknown as MatDialog;
+
+    openLazyDialog(dialog, {
+      loader: () => Promise.resolve(TestLazyBodyComponent),
+      data: null,
+      autoFocus: 'first-heading',
+    });
+
+    expect(open.mock.calls[0][1].autoFocus).toBe('first-heading');
+  });
+});

--- a/src/app/dialogs/lazy-dialog-host/lazy-dialog-host.component.ts
+++ b/src/app/dialogs/lazy-dialog-host/lazy-dialog-host.component.ts
@@ -1,0 +1,79 @@
+import { NgComponentOutlet } from '@angular/common';
+import { CdkScrollable } from '@angular/cdk/scrolling';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  Injector,
+  signal,
+  Type,
+} from '@angular/core';
+import { MatButton } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import type { LazyDialogConfig } from '../lazy-dialog';
+
+/**
+ * How long the real body chunk may take to load before the skeleton is revealed. A chunk that
+ * resolves sooner (the common warm-cache case) swaps straight in, so the skeleton never flashes
+ * for loads too fast to perceive.
+ */
+export const SKELETON_DELAY_MS = 150;
+
+/**
+ * A real MatDialog opened synchronously in place of a lazily-imported dialog body. It shows the
+ * dialog chrome immediately, reveals a shimmer skeleton if the body's chunk is slow to arrive,
+ * then renders the resolved component in its place — so a slow chunk fetch no longer leaves the
+ * click with nothing on screen. The wrapped `data` is re-provided as MAT_DIALOG_DATA so the
+ * loaded component sees its own payload, not this host's config.
+ *
+ * Open it through {@link openLazyDialog} rather than directly.
+ */
+@Component({
+  selector: 'app-lazy-dialog-host',
+  templateUrl: './lazy-dialog-host.component.html',
+  styleUrls: ['./lazy-dialog-host.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    NgComponentOutlet,
+    CdkScrollable,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatButton,
+  ],
+})
+export class LazyDialogHostComponent {
+  private readonly hostInjector = inject(Injector);
+  protected readonly config = inject<LazyDialogConfig>(MAT_DIALOG_DATA);
+
+  /** The resolved dialog component, or null while its chunk is still loading. */
+  protected readonly component = signal<Type<unknown> | null>(null);
+  /** Whether the skeleton delay has elapsed with the body still loading. */
+  protected readonly showSkeleton = signal(false);
+  /** Whether the body's chunk failed to load. */
+  protected readonly failed = signal(false);
+
+  /** Exposes the wrapped `data` to the loaded body as its MAT_DIALOG_DATA. */
+  protected readonly bodyInjector = Injector.create({
+    parent: this.hostInjector,
+    providers: [{ provide: MAT_DIALOG_DATA, useValue: this.config.data }],
+  });
+
+  constructor() {
+    const timer = setTimeout(() => this.showSkeleton.set(true), SKELETON_DELAY_MS);
+    inject(DestroyRef).onDestroy(() => clearTimeout(timer));
+
+    this.config.loader()
+      .then((component) => this.component.set(component))
+      .catch(() => this.failed.set(true))
+      .finally(() => clearTimeout(timer));
+  }
+}

--- a/src/app/dialogs/lazy-dialog.ts
+++ b/src/app/dialogs/lazy-dialog.ts
@@ -1,0 +1,43 @@
+import { Type } from '@angular/core';
+import { MatDialog, MatDialogConfig, MatDialogRef } from '@angular/material/dialog';
+import { LazyDialogHostComponent } from './lazy-dialog-host/lazy-dialog-host.component';
+
+/** Skeleton layout shown while a dialog body loads: stacked text rows, or a large diagram block. */
+export type LazyDialogSkeleton = 'text' | 'diagram';
+
+/** What the host needs to render a lazily-imported dialog body once its chunk arrives. */
+export interface LazyDialogConfig {
+  /**
+   * Loads the real dialog component's chunk on demand, e.g.
+   * `() => import('./foo-dialog.component').then(m => m.FooDialogComponent)`.
+   */
+  loader: () => Promise<Type<unknown>>;
+  /** Value provided to the loaded component as its MAT_DIALOG_DATA. */
+  data: unknown;
+  /** Which skeleton to show while the chunk loads. Defaults to `'text'`. */
+  skeleton?: LazyDialogSkeleton;
+}
+
+/** {@link LazyDialogConfig} merged with the `MatDialog.open` options (width, backdrop, …). */
+export type OpenLazyDialogOptions = LazyDialogConfig & Omit<MatDialogConfig, 'data'>;
+
+/**
+ * Opens a lazily-imported dialog through {@link LazyDialogHostComponent}: the dialog appears at
+ * once with a (delayed) loading skeleton and swaps to the real body when its chunk resolves,
+ * instead of the click doing nothing until the `import()` completes.
+ *
+ * Pass the loader, the inner `data`, an optional `skeleton`, and any `MatDialog.open` options in
+ * one object. Focus defaults to the dialog container so it survives the skeleton-to-body swap;
+ * set `autoFocus` to override.
+ */
+export function openLazyDialog(
+  dialog: MatDialog,
+  options: OpenLazyDialogOptions,
+): MatDialogRef<LazyDialogHostComponent> {
+  const { loader, data, skeleton, ...matOptions } = options;
+  return dialog.open<LazyDialogHostComponent, LazyDialogConfig>(LazyDialogHostComponent, {
+    autoFocus: 'dialog',
+    ...matOptions,
+    data: { loader, data, skeleton },
+  });
+}

--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.spec.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.spec.ts
@@ -4,6 +4,7 @@ import { MatDialog } from '@angular/material/dialog';
 
 import { ConvertIconComponent } from './convert-icon.component';
 import { UnitConversionDialogComponent } from './unit-conversion-dialog.component';
+import { LazyDialogHostComponent } from '../lazy-dialog-host/lazy-dialog-host.component';
 
 describe('ConvertIconComponent', () => {
   let fixture: ComponentFixture<ConvertIconComponent>;
@@ -35,38 +36,40 @@ describe('ConvertIconComponent', () => {
     return fixture.componentInstance;
   }
 
-  // The click handler is async: it lazy-loads the dialog via a dynamic import() before opening it.
-  // Call it directly and await the returned promise so the assertion sees the resolved open() call.
-  const click = (component: ConvertIconComponent, event: Event = new MouseEvent('click')): Promise<void> =>
-    (component as unknown as { open(e: Event): Promise<void> }).open(event);
+  // The click handler synchronously opens the lazy-dialog host, which then lazy-loads the real
+  // dialog body via the config's loader. Call it directly to inspect the open() call.
+  const click = (component: ConvertIconComponent, event: Event = new MouseEvent('click')): void =>
+    (component as unknown as { open(e: Event): void }).open(event);
 
   it('opens the conversion dialog with the kind, base value and label, stopping propagation', async () => {
     const component = render('length', 6371, 'Radius');
     const event = new MouseEvent('click');
     const stop = vi.spyOn(event, 'stopPropagation');
-    await click(component, event);
+    click(component, event);
 
     expect(stop).toHaveBeenCalled();
     expect(opened).toHaveLength(1);
-    expect(opened[0].component).toBe(UnitConversionDialogComponent);
-    expect(opened[0].config.data).toEqual({
+    // The host is opened; its loader resolves to the real conversion dialog.
+    expect(opened[0].component).toBe(LazyDialogHostComponent);
+    expect(await opened[0].config.data.loader()).toBe(UnitConversionDialogComponent);
+    expect(opened[0].config.data.data).toEqual({
       title: 'Radius', kind: 'length', baseValue: 6371, uiUnit: null, sourceUnit: null,
     });
   });
 
-  it('passes the UI and source unit labels through to the dialog', async () => {
+  it('passes the UI and source unit labels through to the dialog', () => {
     const component = render('mass', 2.88e30, 'Mass', 'Solar Masses', 'Earth Masses');
-    await click(component);
+    click(component);
 
-    expect(opened[0].config.data).toEqual({
+    expect(opened[0].config.data.data).toEqual({
       title: 'Mass', kind: 'mass', baseValue: 2.88e30, uiUnit: 'Solar Masses', sourceUnit: 'Earth Masses',
     });
   });
 
-  it('does not open for a missing or non-finite value', async () => {
+  it('does not open for a missing or non-finite value', () => {
     for (const v of [null, undefined, NaN, Infinity]) {
       const component = render('mass', v, 'Mass');
-      await click(component);
+      click(component);
     }
     expect(opened).toHaveLength(0);
   });

--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
@@ -5,7 +5,8 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faRightLeft } from '@fortawesome/free-solid-svg-icons';
 import { ClickableDirective } from '../../clickable.directive';
 import { QuantityKind } from '../../data/unit-conversions';
-import type { UnitConversionDialogComponent, UnitConversionDialogData } from './unit-conversion-dialog.component';
+import { openLazyDialog } from '../lazy-dialog';
+import type { UnitConversionDialogData } from './unit-conversion-dialog.component';
 
 /**
  * Small "⇄" affordance rendered after a property value. Clicking it opens the
@@ -38,22 +39,22 @@ export class ConvertIconComponent {
   /** Conversion-row label for the unit the value is recorded in by the game journal; badged in the dialog. */
   readonly sourceUnit = input<string | null | undefined>();
 
-  protected async open(event: Event): Promise<void> {
+  protected open(event: Event): void {
     event.stopPropagation();
     const baseValue = this.value();
     if (baseValue == null || !Number.isFinite(baseValue)) { return; }
-    const { UnitConversionDialogComponent } = await import('./unit-conversion-dialog.component');
-    this.dialog.open<UnitConversionDialogComponent, UnitConversionDialogData>(UnitConversionDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('./unit-conversion-dialog.component').then(m => m.UnitConversionDialogComponent),
+      skeleton: 'text',
       width: '600px',
       maxWidth: '95vw',
-      autoFocus: 'first-heading',
       data: {
         title: this.label(),
         kind: this.kind(),
         baseValue,
         uiUnit: this.uiUnit() ?? null,
         sourceUnit: this.sourceUnit() ?? null,
-      },
+      } satisfies UnitConversionDialogData,
     });
   }
 }

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -292,8 +292,10 @@ describe('HomeComponent', () => {
 
       expect(open).toHaveBeenCalledTimes(1);
       const [, config] = open.mock.calls[0];
-      expect(config?.data).toEqual({ systemName: 'Sol', bodies, totalBodyCount: 8 });
-      expect(config?.autoFocus).toBe('first-heading');
+      // The histogram now opens through the lazy-dialog host, which wraps the real data and
+      // defaults focus to the dialog container so it survives the skeleton-to-body swap.
+      expect((config?.data as { data: unknown }).data).toEqual({ systemName: 'Sol', bodies, totalBodyCount: 8 });
+      expect(config?.autoFocus).toBe('dialog');
     });
   });
 });

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -3,7 +3,8 @@ import { AppService, EdastroData } from '../app.service';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { faChartColumn, faFileCode, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import { MatDialog } from '@angular/material/dialog';
-import type { HistogramDialogComponent, HistogramDialogData } from '../dialogs/histogram-dialog/histogram-dialog.component';
+import { openLazyDialog } from '../dialogs/lazy-dialog';
+import type { HistogramDialogData } from '../dialogs/histogram-dialog/histogram-dialog.component';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { PGSystem } from 'src/app/data/pgnames/PGSystem';
 import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
@@ -412,14 +413,18 @@ export class HomeComponent implements OnInit, OnDestroy {
   public async showBodyHistogram(): Promise<void> {
     const data = this.data();
     if (!data) return;
-    const { HistogramDialogComponent } = await import('../dialogs/histogram-dialog/histogram-dialog.component');
-    this.dialog.open<HistogramDialogComponent, HistogramDialogData>(HistogramDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/histogram-dialog/histogram-dialog.component').then(m => m.HistogramDialogComponent),
+      skeleton: 'diagram',
       width: '640px',
       maxWidth: '95vw',
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
-      autoFocus: 'first-heading',
-      data: { systemName: data.system.name, bodies: data.system.bodies, totalBodyCount: data.system.bodyCount ?? null },
+      data: {
+        systemName: data.system.name,
+        bodies: data.system.bodies,
+        totalBodyCount: data.system.bodyCount ?? null,
+      } satisfies HistogramDialogData,
     });
   }
   private readonly _searching = signal(false);

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -24,9 +24,9 @@ describe('SystemBodyComponent (extended coverage)', () => {
   let dialogOpenCalls: number;
   let dialogOpenArgs: { component: unknown; config: { data?: any } }[];
 
-  /** The data object handed to the most recent dialog.open call. */
+  /** The inner data the most recent dialog.open routes to its lazily-loaded dialog body. */
   function lastDialogData(): any {
-    return dialogOpenArgs[dialogOpenArgs.length - 1].config.data;
+    return dialogOpenArgs[dialogOpenArgs.length - 1].config.data.data;
   }
 
   beforeEach(() => {
@@ -1051,8 +1051,8 @@ describe('SystemBodyComponent (extended coverage)', () => {
       await component.showTidalLockDialog();
       expect(dialogOpenCalls).toBe(1);
       const { config } = dialogOpenArgs[0];
-      expect(config.data!.resonance).toBe('1:1');
-      expect(config.data!.body.bodyData.rotationalPeriod).toBe(5);
+      expect(config.data!.data.resonance).toBe('1:1');
+      expect(config.data!.data.body.bodyData.rotationalPeriod).toBe(5);
     });
 
     it('opens the JSON dialog with the body and galaxy data', async () => {

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -16,6 +16,7 @@ import { OrbitalRelationsService, CollisionStatus, LagrangeConfiguration, Lagran
 import { RocheChartData, HillChartData } from '../data/chart-rendering.service';
 import { BODY_TYPE } from '../data/body-types';
 import { WHITE_DWARF_CLASSES, whiteDwarfSpectralCode, whiteDwarfSpectralTypeKey } from '../data/white-dwarf';
+import { openLazyDialog } from '../dialogs/lazy-dialog';
 import type { WhiteDwarfTypesDialogData } from '../dialogs/white-dwarf-types-dialog/white-dwarf-types-dialog.component';
 import { MATERIAL_DATA } from '../data/materials';
 import { GENUS_NAMES } from '../data/genus';
@@ -564,8 +565,9 @@ export class SystemBodyComponent implements OnChanges {
   public async showWhiteDwarfSpectralDialog(): Promise<void> {
     const code = this.getWhiteDwarfSpectralCode();
     if (!code) { return; }
-    const { WhiteDwarfTypesDialogComponent } = await import('../dialogs/white-dwarf-types-dialog/white-dwarf-types-dialog.component');
-    this.dialog.open(WhiteDwarfTypesDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/white-dwarf-types-dialog/white-dwarf-types-dialog.component').then(m => m.WhiteDwarfTypesDialogComponent),
+      skeleton: 'text',
       width: '900px',
       maxWidth: '95vw',
       data: { typeKey: whiteDwarfSpectralTypeKey(code) } satisfies WhiteDwarfTypesDialogData,
@@ -639,11 +641,11 @@ export class SystemBodyComponent implements OnChanges {
       };
     }
 
-    const { OrbitalDiagramDialogComponent } = await import('../dialogs/orbital-diagram-dialog/orbital-diagram-dialog.component');
-    this.dialog.open(OrbitalDiagramDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/orbital-diagram-dialog/orbital-diagram-dialog.component').then(m => m.OrbitalDiagramDialogComponent),
+      skeleton: 'diagram',
       width: '900px',
       maxWidth: '95vw',
-      autoFocus: 'first-heading',
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
       data: { type, degrees, eccentricity: bodyData.orbitalEccentricity, bodyName, parentName, orbit },
@@ -657,11 +659,11 @@ export class SystemBodyComponent implements OnChanges {
   public async showHrDiagram(): Promise<void> {
     const body = this.body();
     const bodyData = body.bodyData;
-    const { HrDiagramDialogComponent } = await import('../dialogs/hr-diagram-dialog/hr-diagram-dialog.component');
-    this.dialog.open(HrDiagramDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/hr-diagram-dialog/hr-diagram-dialog.component').then(m => m.HrDiagramDialogComponent),
+      skeleton: 'diagram',
       width: '900px',
       maxWidth: '95vw',
-      autoFocus: 'first-heading',
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
       data: {
@@ -975,11 +977,11 @@ export class SystemBodyComponent implements OnChanges {
   }
 
   public async showBodyJsonDialog(): Promise<void> {
-    const { JsonDialogComponent } = await import('../dialogs/json-dialog/json-dialog.component');
-    this.dialog.open(JsonDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/json-dialog/json-dialog.component').then(m => m.JsonDialogComponent),
+      skeleton: 'text',
       width: '900px',
       maxWidth: '95vw',
-      autoFocus: 'first-heading',
       restoreFocus: false,
       data: { body: this.body(), edGalaxyData: this.edGalaxyData() } satisfies JsonDialogData,
     });
@@ -1007,11 +1009,11 @@ export class SystemBodyComponent implements OnChanges {
 
     const ringName = body.bodyData.name.split(' ').slice(1).join(' ') || body.bodyData.name;
 
-    const { InvisibleRingDialogComponent } = await import('../dialogs/invisible-ring-dialog/invisible-ring-dialog.component');
-    this.dialog.open(InvisibleRingDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/invisible-ring-dialog/invisible-ring-dialog.component').then(m => m.InvisibleRingDialogComponent),
+      skeleton: 'diagram',
       width: '900px',
       maxWidth: '95vw',
-      autoFocus: 'first-heading',
       data: {
         ringName,
         innerRadius,
@@ -1027,11 +1029,11 @@ export class SystemBodyComponent implements OnChanges {
 
   /** Opens the Roche-limit chart dialog with the prepared chart data. */
   private async openRocheLimitDialog(data: RocheChartData): Promise<void> {
-    const { RocheLimitDialogComponent } = await import('../dialogs/roche-limit-dialog/roche-limit-dialog.component');
-    this.dialog.open(RocheLimitDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/roche-limit-dialog/roche-limit-dialog.component').then(m => m.RocheLimitDialogComponent),
+      skeleton: 'diagram',
       width: '900px',
       maxWidth: '95vw',
-      autoFocus: 'first-heading',
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
       data,
@@ -1154,11 +1156,11 @@ export class SystemBodyComponent implements OnChanges {
       degreesToEvent = this.orbitalRelations.degreesToEvent(currentMeanAnomaly, type);
     }
 
-    const { ApoPeriDialogComponent } = await import('../dialogs/apo-peri-dialog/apo-peri-dialog.component');
-    this.dialog.open(ApoPeriDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/apo-peri-dialog/apo-peri-dialog.component').then(m => m.ApoPeriDialogComponent),
+      skeleton: 'diagram',
       width: '900px',
       maxWidth: '95vw',
-      autoFocus: 'first-heading',
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
       data: {
@@ -1182,11 +1184,11 @@ export class SystemBodyComponent implements OnChanges {
     const meanAnomalyAtEpoch = this.getMeanAnomaly();
     if (bd.meanAnomaly == null || !bd.orbitalPeriod || !bd.timestamps?.meanAnomaly || !epoch || meanAnomalyAtEpoch === undefined) return;
 
-    const { AnomalyDialogComponent } = await import('../dialogs/anomaly-dialog/anomaly-dialog.component');
-    this.dialog.open(AnomalyDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/anomaly-dialog/anomaly-dialog.component').then(m => m.AnomalyDialogComponent),
+      skeleton: 'diagram',
       width: '900px',
       maxWidth: '95vw',
-      autoFocus: 'first-heading',
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
       data: {
@@ -1222,11 +1224,11 @@ export class SystemBodyComponent implements OnChanges {
       info: this.buildCollisionBodyInfo(siblings.find(s => s.bodyData.name === name) ?? null),
     }));
 
-    const { CollisionDialogComponent } = await import('../dialogs/collision-dialog/collision-dialog.component');
-    this.dialog.open(CollisionDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/collision-dialog/collision-dialog.component').then(m => m.CollisionDialogComponent),
+      skeleton: 'diagram',
       width: '900px',
       maxWidth: '95vw',
-      autoFocus: 'first-heading',
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
       data: {
@@ -1359,11 +1361,11 @@ export class SystemBodyComponent implements OnChanges {
     // truth in BodyPhysicsService (shared with the isActualShepherd badge).
     const shepherdStatus = this.physics.shepherdStatus(hillData);
 
-    const { HillLimitDialogComponent } = await import('../dialogs/hill-limit-dialog/hill-limit-dialog.component');
-    this.dialog.open(HillLimitDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/hill-limit-dialog/hill-limit-dialog.component').then(m => m.HillLimitDialogComponent),
+      skeleton: 'diagram',
       width: '900px',
       maxWidth: '95vw',
-      autoFocus: 'first-heading',
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
       data: {
@@ -1668,11 +1670,11 @@ export class SystemBodyComponent implements OnChanges {
     };
     const data: LagrangeDialogData = { config: displayConfig, systemName: this.edGalaxyData()?.Name ?? '' };
 
-    const { LagrangeDialogComponent } = await import('../dialogs/lagrange-dialog/lagrange-dialog.component');
-    this.dialog.open(LagrangeDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/lagrange-dialog/lagrange-dialog.component').then(m => m.LagrangeDialogComponent),
+      skeleton: 'diagram',
       width: '900px',
       maxWidth: '95vw',
-      autoFocus: 'first-heading',
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
       data,
@@ -1736,11 +1738,11 @@ export class SystemBodyComponent implements OnChanges {
     const surfTemp = bd.surfaceTemperature ?? null;
     const estRange = surfTemp ? estimateTempRange(surfTemp, bd.subType, bd.atmosphereType, bd.surfacePressure) : null;
     const { delta, source } = lookupTempDelta(bd.subType, bd.atmosphereType, bd.surfacePressure);
-    const { OnFootSafetyDialogComponent } = await import('../dialogs/on-foot-safety-dialog/on-foot-safety-dialog.component');
-    this.dialog.open(OnFootSafetyDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/on-foot-safety-dialog/on-foot-safety-dialog.component').then(m => m.OnFootSafetyDialogComponent),
+      skeleton: 'text',
       width: '900px',
       maxWidth: '95vw',
-      autoFocus: 'first-heading',
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
       data: {
@@ -1761,16 +1763,13 @@ export class SystemBodyComponent implements OnChanges {
   }
 
   public async showTidalLockDialog(): Promise<void> {
-    const { TidalLockDialogComponent } = await import('../dialogs/tidal-lock-dialog/tidal-lock-dialog.component');
-    this.dialog.open(TidalLockDialogComponent, {
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/tidal-lock-dialog/tidal-lock-dialog.component').then(m => m.TidalLockDialogComponent),
+      skeleton: 'text',
       width: '900px',
       maxWidth: '95vw',
       hasBackdrop: true,
       backdropClass: 'cdk-overlay-dark-backdrop',
-      // Focus the dialog heading rather than the default first tabbable element
-      // (a "Further reading" link near the bottom), which would scroll the long
-      // content to the end on open.
-      autoFocus: 'first-heading',
       data: {
         body: this.body(),
         resonance: this.getSpinResonance()


### PR DESCRIPTION
## Problem

Every dialog is opened with `await import()` **then** `dialog.open()`, so the actual chunk load happens *before* the dialog appears. On a cold cache / slow connection, clicking leaves nothing on screen until the import resolves — and a skeleton placed inside a dialog would never be seen, because no dialog exists yet during the `await`.

## Approach

Introduce `LazyDialogHostComponent`, a real `MatDialog` opened **synchronously** in the body's place:

- Shows the dialog chrome immediately.
- Reveals a shimmer **skeleton only after ~150ms** — fast warm-cache loads swap straight to the body with no skeleton flash.
- Swaps in the resolved component via `ngComponentOutlet`, re-providing the wrapped `data` as `MAT_DIALOG_DATA` so the body sees its own payload (not the host's config).
- Shows an **error state** if the chunk fails to load, instead of hanging.
- `text` and `diagram` skeleton layouts; honours `prefers-reduced-motion`.

All **15** open call-sites (convert-icon, home histogram, 13 in system-body) now route through a small helper:

```ts
openLazyDialog(this.dialog, {
  loader: () => import('./foo-dialog.component').then(m => m.FooDialogComponent),
  skeleton: 'diagram',
  width: '900px', maxWidth: '95vw', hasBackdrop: true,
  data: { ... } satisfies FooDialogData,
});
```

Focus now defaults to the dialog container (`autoFocus: 'dialog'`) so it survives the skeleton→body swap; Material still announces the title via `aria-labelledby` once the body loads.

## Notes

- **Each dialog stays its own lazy chunk** — verified in the build output; `loader: () => import(...)` preserves the per-component code-splitting.
- The old per-call `autoFocus: 'first-heading'` was dropped in favour of the container default (a focused heading element would be destroyed on the swap).

## Testing

- `ng build` (dev) — compiles, strict templates pass, all 15 dialogs emit as separate lazy chunks.
- Unit tests — **714/714 pass**, including 8 new `LazyDialogHostComponent` / `openLazyDialog` specs (skeleton delay, fast-load no-flash, data pass-through, error state, diagram layout, helper wiring).
- e2e — **full suite green: 543 passed, 3 skipped, 0 failed** across all 6 projects (desktop/tablet/mobile × Chromium/Firefox). The 3 skips are pre-existing intentional skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)