### PR TITLE
Feat taylor pauper

### DIFF
--- a/src/app/data/body-physics.service.ts
+++ b/src/app/data/body-physics.service.ts
@@ -209,6 +209,12 @@ export class BodyPhysicsService {
     return { primaryRadius, primaryDensity };
   }
 
+  /** Radius (km) of a body's parent primary, or null when the parent exposes no radius. */
+  getParentRadiusKm(body: SystemBody): number | null {
+    if (!body.parent) { return null; }
+    return this.parentRadiusKmOrNull(body.parent.bodyData);
+  }
+
   /**
    * Samples the rigid (1.26×) and fluid (2.456×) Roche-limit curves across particle
    * densities of 500–8000 kg/m³ for plotting against ring/body positions.

--- a/src/app/data/ring-classification-diagram.spec.ts
+++ b/src/app/data/ring-classification-diagram.spec.ts
@@ -1,0 +1,73 @@
+import { RING_DIAGRAM_VIEW_BOX_SIZE, ringClassificationDiagram } from './ring-classification-diagram';
+
+describe('ring-classification-diagram', () => {
+  it('centres the diagram and reports the shared viewBox size', () => {
+    const d = ringClassificationDiagram(50000, [{ name: 'A', innerRadius: 60000, outerRadius: 70000 }], 'A');
+    expect(d.viewBoxSize).toBe(RING_DIAGRAM_VIEW_BOX_SIZE);
+    expect(d.center).toBe(RING_DIAGRAM_VIEW_BOX_SIZE / 2);
+  });
+
+  it('scales the body and ring proportionally to their real radii', () => {
+    // Ring inner/outer sit exactly 2x/2.5x the body radius out — the scaled diagram should
+    // preserve that ratio (mid-radius relative to body radius), not just its absolute size.
+    const d = ringClassificationDiagram(100000, [{ name: 'A', innerRadius: 200000, outerRadius: 250000 }], 'A');
+    const ring = d.rings[0];
+    const ringInnerPx = ring.radius - ring.strokeWidth / 2;
+    expect(ringInnerPx / d.bodyRadius).toBeCloseTo(2, 1);
+  });
+
+  it('does not floor the body radius — a distant Pauper-style body renders genuinely tiny', () => {
+    // 1 000 km body under a ring 700 000-750 000 km out: body radius should be a true, tiny
+    // fraction of the drawing — not clamped up to stay "visible". Scale is derived from the
+    // ring (a large, well-conditioned value) rather than back out of the tiny body radius
+    // itself, so rounding in the body radius can't get amplified into a false failure.
+    const d = ringClassificationDiagram(1000, [{ name: 'A', innerRadius: 700000, outerRadius: 750000 }], 'A');
+    const ring = d.rings[0];
+    const scale = (ring.radius + ring.strokeWidth / 2) / 750000; // outer edge of the (only, outermost) ring
+    // Both sides are independently rounded to 3 decimals (see `r()`), which on a value this
+    // small (~0.075) is a coarse ~0.5% relative precision — hence 2 decimal places here, not 4.
+    expect(d.bodyRadius).toBeCloseTo(1000 * scale, 2);
+    expect(d.bodyRadius).toBeLessThan(0.1);
+  });
+
+  it('does not floor a narrow Taylor-style ring stroke — it renders genuinely thin', () => {
+    // A 100 km wide ring against a 60 000 km outer extent is a true ~0.09 SVG units wide.
+    const d = ringClassificationDiagram(50000, [{ name: 'A', innerRadius: 60000, outerRadius: 60100 }], 'A');
+    expect(d.rings[0].strokeWidth).toBeLessThan(0.1);
+    expect(d.rings[0].strokeWidth).toBeGreaterThan(0);
+  });
+
+  it('body radius and ring geometry share exactly one linear scale factor', () => {
+    const bodyRadiusKm = 40000;
+    const d = ringClassificationDiagram(bodyRadiusKm, [{ name: 'A', innerRadius: 80000, outerRadius: 100000 }], 'A');
+    const scale = d.bodyRadius / bodyRadiusKm;
+    const ring = d.rings[0];
+    expect((ring.radius - ring.strokeWidth / 2) / scale).toBeCloseTo(80000, 0);
+    expect((ring.radius + ring.strokeWidth / 2) / scale).toBeCloseTo(100000, 0);
+  });
+
+  it('marks only the ring matching focusedRingName as focused', () => {
+    const d = ringClassificationDiagram(50000, [
+      { name: 'A', innerRadius: 60000, outerRadius: 70000 },
+      { name: 'B', innerRadius: 80000, outerRadius: 90000 },
+    ], 'B');
+    expect(d.rings.find(r => r.name === 'A')!.isFocused).toBe(false);
+    expect(d.rings.find(r => r.name === 'B')!.isFocused).toBe(true);
+  });
+
+  it('orders rings by their input order, each further out than the last for increasing radii', () => {
+    const d = ringClassificationDiagram(50000, [
+      { name: 'A', innerRadius: 60000, outerRadius: 70000 },
+      { name: 'B', innerRadius: 80000, outerRadius: 90000 },
+      { name: 'C', innerRadius: 100000, outerRadius: 110000 },
+    ], 'A');
+    expect(d.rings[0].radius).toBeLessThan(d.rings[1].radius);
+    expect(d.rings[1].radius).toBeLessThan(d.rings[2].radius);
+  });
+
+  it('keeps every ring within the available drawing radius', () => {
+    const d = ringClassificationDiagram(50000, [{ name: 'A', innerRadius: 750000, outerRadius: 800000 }], 'A');
+    const outerEdgePx = d.rings[0].radius + d.rings[0].strokeWidth / 2;
+    expect(outerEdgePx).toBeLessThanOrEqual(RING_DIAGRAM_VIEW_BOX_SIZE / 2);
+  });
+});

--- a/src/app/data/ring-classification-diagram.ts
+++ b/src/app/data/ring-classification-diagram.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure geometry for the to-scale body-and-rings illustration shown in the Taylor/Pauper
+ * ring badge dialogs. Deliberately framework-free so it stays trivially unit-testable —
+ * see `orbital-diagrams.ts` for the sibling convention this follows.
+ *
+ * Unlike the Roche/Hill charts (which span many orders of magnitude and need a log scale),
+ * a body and its own visible rings never differ by more than ~16x (the Pauper badge's outer
+ * bound), so a plain linear scale is used: it's simpler, and for these two badges specifically
+ * the linear "tiny body inside a wide empty ring" / "ring hugging the body" shape *is* the point
+ * — the body and every ring are sized strictly in proportion to their real km radii, with no
+ * flooring that would visually lie about how narrow or how distant things really are.
+ */
+
+export const RING_DIAGRAM_VIEW_BOX_SIZE = 140;
+const CENTER = RING_DIAGRAM_VIEW_BOX_SIZE / 2;
+const MARGIN = 14;
+const AVAILABLE_RADIUS = CENTER - MARGIN;
+
+/** Round to 3 decimals so bound SVG attributes stay tidy and tests stay stable. */
+function r(n: number): number {
+  return Math.round(n * 1000) / 1000 + 0;
+}
+
+export interface RingClassificationDiagramRing {
+  name: string;
+  /** Mid-radius (SVG units) of the stroked circle used to draw this ring's annulus. */
+  radius: number;
+  /** Stroke width (SVG units) spanning the ring's inner-to-outer edge. */
+  strokeWidth: number;
+  isFocused: boolean;
+}
+
+export interface RingClassificationDiagram {
+  viewBoxSize: number;
+  center: number;
+  /** Body radius, SVG units. */
+  bodyRadius: number;
+  rings: RingClassificationDiagramRing[];
+}
+
+/**
+ * Builds a to-scale, top-down illustration of a body (filled circle) and its visible rings
+ * (stroked annuli), linearly scaled from real km into one shared square viewBox. Every
+ * dimension is the same fraction of `outermostKm` that it is in reality — nothing is floored
+ * to stay "visible", so a Pauper body genuinely renders as a speck and a Taylor ring genuinely
+ * renders as a hairline.
+ */
+export function ringClassificationDiagram(
+  bodyRadiusKm: number,
+  rings: { name: string; innerRadius: number; outerRadius: number }[],
+  focusedRingName: string,
+): RingClassificationDiagram {
+  const outermostKm = Math.max(bodyRadiusKm, ...rings.map(ring => ring.outerRadius));
+  const scale = outermostKm > 0 ? AVAILABLE_RADIUS / outermostKm : 0;
+
+  const diagramRings = rings.map(ring => {
+    const innerPx = ring.innerRadius * scale;
+    const outerPx = ring.outerRadius * scale;
+    return {
+      name: ring.name,
+      radius: r((innerPx + outerPx) / 2),
+      strokeWidth: r(outerPx - innerPx),
+      isFocused: ring.name === focusedRingName,
+    };
+  });
+
+  return {
+    viewBoxSize: RING_DIAGRAM_VIEW_BOX_SIZE,
+    center: CENTER,
+    bodyRadius: r(bodyRadiusKm * scale),
+    rings: diagramRings,
+  };
+}

--- a/src/app/data/unit-conversions.ts
+++ b/src/app/data/unit-conversions.ts
@@ -217,6 +217,11 @@ function fixed2(value: number): string {
   return value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
+/** Grouped whole number (no decimals), shared by the dialogs that show plain km/radius figures. */
+export function formatGroupedInteger(value: number): string {
+  return value.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+}
+
 /**
  * Inline length display (km base), choosing m / km / ls / ly by magnitude. Thresholds are
  * sensible defaults tuned for in-system distances; AU is intentionally skipped inline (it

--- a/src/app/dialogs/hill-limit-dialog/hill-limit-dialog.component.ts
+++ b/src/app/dialogs/hill-limit-dialog/hill-limit-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, ElementRef, afterNextRender, inject
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DialogShellComponent } from '../dialog-shell/dialog-shell.component';
 import { ChartRenderingService, HillChartData } from '../../data/chart-rendering.service';
+import { formatGroupedInteger } from '../../data/unit-conversions';
 
 /**
  * Shepherding-moon analysis: a logarithmic orbital diagram of the moon against its
@@ -26,6 +27,6 @@ export class HillLimitDialogComponent {
   }
 
   public fmt(value: number): string {
-    return value.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+    return formatGroupedInteger(value);
   }
 }

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.html
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.html
@@ -89,6 +89,13 @@
       </ul>
     </div>
 
+    @if (data.hasVisibleGap) {
+    <p class="gap-note">
+      <strong>Note:</strong> The gap between two of the visible rings is wider than 2% of the total span, so it
+      may be visible in-game as a break between the rings rather than reading as one continuous ring.
+    </p>
+    }
+
     <p class="disclaimer">
       <strong>Disclaimer:</strong> The classification is based on the visible and observable structure of the
       ring system rather than its total physical extent — a {{ data.kind === 'taylor' ? 'Taylor' : 'Pauper' }}

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.html
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.html
@@ -17,13 +17,26 @@
     <div class="intro">
       @if (data.kind === 'taylor') {
       <p>
-        A <strong>Taylor ring</strong> is an unusually narrow ring system. Once any rings too faint to see
-        in-game are excluded, what's left hugs close around the body instead of spreading out.
+        A <strong>Taylor Ring</strong> is a planetary ring system that appears as a single continuous ring
+        surrounding its primary body, with an apparent radial width no greater than 25% of the radius of the
+        primary body.
+      </p>
+      <p>
+        Taylor rings are named after Elizabeth Taylor's famous engagement ring: a diamond so large it dwarfed
+        the band holding it. A Taylor ring is the same idea applied to a planet — the ring is so narrow relative
+        to the body that it reads as almost pure "stone" with barely any band in sight. Not an official
+        astronomical term, but shorthand the exploration community uses for this rare, striking silhouette.
       </p>
       } @else {
       <p>
-        A <strong>Pauper ring</strong> is an unusually wide, distant ring system. Once any rings too faint to
-        see in-game are excluded, what's left sits far out from the body as a thin band rather than close in.
+        A <strong>Pauper Ring</strong> is a planetary ring system that appears as a single continuous ring
+        surrounding its primary body, with a width no greater than the diameter of its primary body but greater
+        than 25% of the radius of the primary body. The inner radius of the ring system must be at least 14
+        times the radius of the primary body.
+      </p>
+      <p>
+        Pauper rings are indirectly inspired by Elizabeth Taylor's famous engagement ring: a diamond so large it
+        dwarfed the band holding it. In this case, however, the "stone" is no wider than the band it's set in.
       </p>
       }
     </div>
@@ -91,9 +104,15 @@
     </div>
 
     <p class="disclaimer">
-      <strong>Disclaimer:</strong> The illustration above is a simplified, to-scale top-down view drawn from the
-      recorded ring and body radii — actual in-game rings may not be perfectly circular or coplanar. Values may
-      be rounded or truncated compared to ship logs.
+      <strong>Disclaimer:</strong> The classification is based on the visible and observable structure of the
+      ring system rather than its total physical extent — a {{ data.kind === 'taylor' ? 'Taylor' : 'Pauper' }}
+      Ring may consist of one or more physical rings and may exhibit banding, density variations, or other
+      internal structure, provided these features do not create the appearance of distinct rings separated by
+      visible gaps. This calculation is based on the recorded ring and body radii, not on in-game observation —
+      camera position and lighting can also affect how a ring system actually appears. This means that even
+      though this site has identified the ring system as a {{ data.kind === 'taylor' ? 'Taylor' : 'Pauper' }}
+      Ring, it is possible that it may not qualify after observation. The illustration above is a simplified,
+      to-scale top-down view; values may also be rounded or truncated compared to ship logs.
     </p>
   </div>
 </app-dialog-shell>

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.html
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.html
@@ -1,0 +1,99 @@
+<app-dialog-shell [heading]="heading">
+  <div class="ring-classification-dialog">
+    <div class="diagram">
+      @if (diagram(); as d) {
+      <svg [attr.viewBox]="'0 0 ' + d.viewBoxSize + ' ' + d.viewBoxSize" class="ring-classification-diagram"
+        role="img" [attr.aria-label]="'To-scale illustration of ' + data.bodyName + ' and its rings'">
+        @for (ring of d.rings; track ring.name) {
+        <circle class="ring" [class.focused]="ring.isFocused" [attr.cx]="d.center" [attr.cy]="d.center"
+          [attr.r]="ring.radius" [attr.stroke-width]="ring.strokeWidth" />
+        }
+        <circle class="body" [attr.cx]="d.center" [attr.cy]="d.center" [attr.r]="d.bodyRadius" />
+        <text class="label" [attr.x]="d.center" [attr.y]="d.center + d.bodyRadius + 10" text-anchor="middle">{{ data.bodyName }}</text>
+      </svg>
+      }
+    </div>
+
+    <div class="intro">
+      @if (data.kind === 'taylor') {
+      <p>
+        A <strong>Taylor ring</strong> is an unusually narrow ring system. Once any rings too faint to see
+        in-game are excluded, what's left hugs close around the body instead of spreading out.
+      </p>
+      } @else {
+      <p>
+        A <strong>Pauper ring</strong> is an unusually wide, distant ring system. Once any rings too faint to
+        see in-game are excluded, what's left sits far out from the body as a thin band rather than close in.
+      </p>
+      }
+    </div>
+
+    <div class="formula">
+      <strong>Calculation</strong> (R = body radius; span = outermost outer edge − innermost inner edge, across
+      the body's visible rings only):
+    </div>
+
+    <div class="parameters">
+      @if (data.kind === 'taylor') {
+      <p>A ring system is a Taylor ring when:</p>
+      <ul>
+        <li><strong>Exactly 1 visible ring:</strong> ring width &lt; 0.25R</li>
+        <li><strong>2 or more visible rings:</strong> total span &lt; 0.25R</li>
+      </ul>
+      } @else {
+      <p>A ring system is a Pauper ring when all of the following hold:</p>
+      <ul>
+        <li><strong>Innermost edge</strong> ≥ 14R</li>
+        <li><strong>AND</strong></li>
+        <li><strong>Span</strong> ≤ 2R</li>
+        <li><strong>AND</strong></li>
+        <li><strong>Span</strong> &gt; 0.25R (wide enough to not also be a Taylor ring)</li>
+      </ul>
+      }
+    </div>
+
+    <div class="values">
+      <p><strong>Values for this ring system:</strong></p>
+      <ul>
+        <li><strong>Body radius (R):</strong> {{ fmt(data.parentRadius) }} km</li>
+        <li><strong>Innermost visible edge:</strong> {{ fmt(data.innermostInner) }} km ({{ ratio(data.innermostInner) }}× R)</li>
+        <li><strong>Outermost visible edge:</strong> {{ fmt(data.outermostOuter) }} km ({{ ratio(data.outermostOuter) }}× R)</li>
+        <li><strong>Total span:</strong> {{ fmt(data.span) }} km ({{ ratio(data.span) }}× R)</li>
+        @if (data.kind === 'taylor') {
+        <li><strong>Taylor threshold (0.25R):</strong> {{ fmt(data.narrowThresholdKm) }} km</li>
+        } @else {
+        <li><strong>Pauper inner-edge threshold (14R):</strong> {{ fmt(data.pauperInnerEdgeThresholdKm) }} km</li>
+        <li><strong>Pauper max span (2R):</strong> {{ fmt(data.pauperMaxSpanKm) }} km</li>
+        }
+      </ul>
+      <p><strong>Visible rings:</strong></p>
+      <ul>
+        @for (ring of data.rings; track ring.name) {
+        <li [class.focused]="ring.name === data.ringName">
+          <strong>{{ ring.name }} Ring:</strong> {{ fmt(ring.innerRadius) }} – {{ fmt(ring.outerRadius) }} km
+        </li>
+        }
+      </ul>
+    </div>
+
+    <div class="conclusion">
+      @if (data.kind === 'taylor') {
+      <p>
+        This ring system's total span of {{ fmt(data.span) }} km is under 25% of {{ data.bodyName }}'s radius —
+        unusually narrow.
+      </p>
+      } @else {
+      <p>
+        This ring system sits {{ ratio(data.innermostInner) }}× {{ data.bodyName }}'s radius out and spans only
+        {{ fmt(data.span) }} km — unusually wide and distant.
+      </p>
+      }
+    </div>
+
+    <p class="disclaimer">
+      <strong>Disclaimer:</strong> The illustration above is a simplified, to-scale top-down view drawn from the
+      recorded ring and body radii — actual in-game rings may not be perfectly circular or coplanar. Values may
+      be rounded or truncated compared to ship logs.
+    </p>
+  </div>
+</app-dialog-shell>

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.html
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.html
@@ -89,20 +89,6 @@
       </ul>
     </div>
 
-    <div class="conclusion">
-      @if (data.kind === 'taylor') {
-      <p>
-        This ring system's total span of {{ fmt(data.span) }} km is under 25% of {{ data.bodyName }}'s radius —
-        unusually narrow.
-      </p>
-      } @else {
-      <p>
-        This ring system sits {{ ratio(data.innermostInner) }}× {{ data.bodyName }}'s radius out and spans only
-        {{ fmt(data.span) }} km — unusually wide and distant.
-      </p>
-      }
-    </div>
-
     <p class="disclaimer">
       <strong>Disclaimer:</strong> The classification is based on the visible and observable structure of the
       ring system rather than its total physical extent — a {{ data.kind === 'taylor' ? 'Taylor' : 'Pauper' }}

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.scss
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.scss
@@ -59,6 +59,14 @@
         line-height: 1.6;
     }
 
+    .intro p {
+        margin-bottom: 8px;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
     .disclaimer {
         padding: 12px;
         background: var(--color-surface-2);

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.scss
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.scss
@@ -51,7 +51,6 @@
 
     .intro,
     .disclaimer,
-    .conclusion,
     .formula,
     .parameters,
     .values {
@@ -103,13 +102,5 @@
     .values ul li.focused {
         color: var(--color-accent);
         font-weight: 600;
-    }
-
-    .conclusion {
-        padding: 12px;
-        background: var(--color-surface-2);
-        border-left: 4px solid var(--color-callout-info-border);
-        border-radius: 4px;
-        font-style: italic;
     }
 }

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.scss
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.scss
@@ -1,0 +1,107 @@
+.ring-classification-dialog {
+    .diagram {
+        display: flex;
+        justify-content: center;
+        margin-bottom: 16px;
+    }
+
+    .ring-classification-diagram {
+        width: 260px;
+        max-width: 100%;
+        height: auto;
+        // Subtle backdrop so light strokes stay legible on any theme.
+        background: var(--color-surface-2);
+        border-radius: 8px;
+        // Generous padding + visible overflow so the body label is never clipped.
+        padding: 20px;
+        overflow: visible;
+
+        .body {
+            fill: var(--color-info);
+            stroke: var(--color-text-bright);
+            stroke-width: 1;
+            // Keep the body's outline a crisp 1px regardless of viewBox scale — unlike the ring
+            // strokes below, this is a cosmetic border, not part of the to-scale illustration.
+            vector-effect: non-scaling-stroke;
+        }
+
+        .ring {
+            fill: none;
+            stroke: var(--color-badge-blue);
+            opacity: 0.55;
+
+            &.focused {
+                stroke: var(--color-accent);
+                opacity: 0.9;
+            }
+        }
+
+        .label {
+            fill: var(--color-text-bright);
+            font-size: 8px;
+            font-weight: 600;
+            text-anchor: middle;
+            // Halo so the name stays legible over ring strokes.
+            paint-order: stroke;
+            stroke: var(--color-surface-2);
+            stroke-width: 2.5px;
+            stroke-linejoin: round;
+        }
+    }
+
+    .intro,
+    .disclaimer,
+    .conclusion,
+    .formula,
+    .parameters,
+    .values {
+        margin-bottom: 20px;
+        line-height: 1.6;
+    }
+
+    .disclaimer {
+        padding: 12px;
+        background: var(--color-surface-2);
+        border-left: 4px solid var(--color-callout-info-border);
+        border-radius: 4px;
+        font-size: 0.9em;
+    }
+
+    .formula {
+        background: var(--color-surface-2);
+        padding: 12px;
+        border-radius: 4px;
+        font-family: 'Courier New', monospace;
+    }
+
+    .parameters p,
+    .values p {
+        margin-bottom: 8px;
+    }
+
+    .parameters ul,
+    .values ul {
+        list-style: none;
+        padding-left: 0;
+        margin: 0;
+    }
+
+    .parameters ul li,
+    .values ul li {
+        padding: 4px 0;
+        line-height: 1.5;
+    }
+
+    .values ul li.focused {
+        color: var(--color-accent);
+        font-weight: 600;
+    }
+
+    .conclusion {
+        padding: 12px;
+        background: var(--color-surface-2);
+        border-left: 4px solid var(--color-callout-info-border);
+        border-radius: 4px;
+        font-style: italic;
+    }
+}

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.scss
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.scss
@@ -74,6 +74,16 @@
         font-size: 0.9em;
     }
 
+    .gap-note {
+        margin-bottom: 20px;
+        padding: 12px;
+        background: var(--color-callout-warning-bg);
+        border-left: 4px solid var(--color-warning);
+        border-radius: 4px;
+        font-size: 0.9em;
+        line-height: 1.6;
+    }
+
     .formula {
         background: var(--color-surface-2);
         padding: 12px;

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.spec.ts
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.spec.ts
@@ -26,6 +26,7 @@ const TAYLOR_DATA: RingClassificationDialogData = {
   narrowThresholdKm: 12500,
   pauperInnerEdgeThresholdKm: 700000,
   pauperMaxSpanKm: 100000,
+  hasVisibleGap: false,
 };
 
 const PAUPER_DATA: RingClassificationDialogData = {
@@ -40,6 +41,7 @@ const PAUPER_DATA: RingClassificationDialogData = {
   narrowThresholdKm: 12500,
   pauperInnerEdgeThresholdKm: 700000,
   pauperMaxSpanKm: 100000,
+  hasVisibleGap: false,
 };
 
 describe('RingClassificationDialogComponent', () => {
@@ -83,5 +85,16 @@ describe('RingClassificationDialogComponent', () => {
   it('renders body-radius multiples via ratio()', () => {
     const fixture = setup(PAUPER_DATA);
     expect(fixture.componentInstance.ratio(750000)).toBe('15.0');
+  });
+
+  it('does not show the gap note when hasVisibleGap is false', () => {
+    const el: HTMLElement = setup(TAYLOR_DATA).nativeElement;
+    expect(el.querySelector('.gap-note')).toBeFalsy();
+  });
+
+  it('shows the gap note when hasVisibleGap is true', () => {
+    const el: HTMLElement = setup({ ...TAYLOR_DATA, hasVisibleGap: true }).nativeElement;
+    expect(el.querySelector('.gap-note')).toBeTruthy();
+    expect(el.textContent).toContain('may be visible in-game');
   });
 });

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.spec.ts
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.spec.ts
@@ -1,0 +1,84 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+import { RingClassificationDialogComponent, RingClassificationDialogData } from './ring-classification-dialog.component';
+
+function setup(data: RingClassificationDialogData): ComponentFixture<RingClassificationDialogComponent> {
+  TestBed.configureTestingModule({
+    imports: [RingClassificationDialogComponent],
+    providers: [provideZonelessChangeDetection(), { provide: MAT_DIALOG_DATA, useValue: data }],
+  });
+  const fixture = TestBed.createComponent(RingClassificationDialogComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+const TAYLOR_DATA: RingClassificationDialogData = {
+  kind: 'taylor',
+  bodyName: 'Gas Giant',
+  ringName: 'A',
+  parentRadius: 50000,
+  rings: [{ name: 'A', innerRadius: 60000, outerRadius: 70000 }],
+  span: 10000,
+  innermostInner: 60000,
+  outermostOuter: 70000,
+  narrowThresholdKm: 12500,
+  pauperInnerEdgeThresholdKm: 700000,
+  pauperMaxSpanKm: 100000,
+};
+
+const PAUPER_DATA: RingClassificationDialogData = {
+  kind: 'pauper',
+  bodyName: 'Gas Giant',
+  ringName: 'A',
+  parentRadius: 50000,
+  rings: [{ name: 'A', innerRadius: 750000, outerRadius: 800000 }],
+  span: 50000,
+  innermostInner: 750000,
+  outermostOuter: 800000,
+  narrowThresholdKm: 12500,
+  pauperInnerEdgeThresholdKm: 700000,
+  pauperMaxSpanKm: 100000,
+};
+
+describe('RingClassificationDialogComponent', () => {
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('shows the Taylor heading and explanation for a taylor dialog', () => {
+    const el: HTMLElement = setup(TAYLOR_DATA).nativeElement;
+    expect(el.textContent).toContain('Taylor Ring Explanation');
+    expect(el.textContent).toContain('Taylor ring');
+    expect(el.textContent).not.toContain('Pauper ring');
+  });
+
+  it('shows the Pauper heading and explanation for a pauper dialog', () => {
+    // The Pauper criteria deliberately mention "Taylor ring" once, to explain why the two
+    // badges are mutually exclusive — so this checks the heading/intro, not a blanket absence.
+    const el: HTMLElement = setup(PAUPER_DATA).nativeElement;
+    expect(el.textContent).toContain('Pauper Ring Explanation');
+    expect(el.textContent).toContain('Pauper ring');
+    expect(el.textContent).not.toContain('Taylor Ring Explanation');
+    expect(el.querySelector('.intro')!.textContent).not.toContain('Taylor');
+  });
+
+  it('lists each visible ring with its inner/outer radius', () => {
+    const el: HTMLElement = setup(TAYLOR_DATA).nativeElement;
+    expect(el.textContent).toContain('A Ring');
+    expect(el.textContent).toContain('60,000');
+    expect(el.textContent).toContain('70,000');
+  });
+
+  it('draws one circle per visible ring plus the body, in the SVG illustration', () => {
+    const el: HTMLElement = setup(PAUPER_DATA).nativeElement;
+    const circles = el.querySelectorAll('svg circle');
+    expect(circles.length).toBe(2); // 1 ring + the body
+    expect(el.querySelector('svg circle.body')).toBeTruthy();
+    expect(el.querySelector('svg circle.ring.focused')).toBeTruthy(); // ringName matches the only ring
+  });
+
+  it('renders body-radius multiples via ratio()', () => {
+    const fixture = setup(PAUPER_DATA);
+    expect(fixture.componentInstance.ratio(750000)).toBe('15.0');
+  });
+});

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.spec.ts
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.spec.ts
@@ -48,18 +48,21 @@ describe('RingClassificationDialogComponent', () => {
   it('shows the Taylor heading and explanation for a taylor dialog', () => {
     const el: HTMLElement = setup(TAYLOR_DATA).nativeElement;
     expect(el.textContent).toContain('Taylor Ring Explanation');
-    expect(el.textContent).toContain('Taylor ring');
-    expect(el.textContent).not.toContain('Pauper ring');
+    expect(el.textContent).toContain('Taylor Ring');
+    expect(el.textContent).toContain('Elizabeth Taylor');
+    expect(el.textContent).not.toContain('Pauper Ring');
   });
 
   it('shows the Pauper heading and explanation for a pauper dialog', () => {
-    // The Pauper criteria deliberately mention "Taylor ring" once, to explain why the two
-    // badges are mutually exclusive — so this checks the heading/intro, not a blanket absence.
+    // Both dialogs' intros legitimately mention "Elizabeth Taylor" (the engagement-ring lore
+    // behind both names), so the negative checks target the "Taylor Ring" badge name
+    // specifically, not the bare word "Taylor".
     const el: HTMLElement = setup(PAUPER_DATA).nativeElement;
     expect(el.textContent).toContain('Pauper Ring Explanation');
-    expect(el.textContent).toContain('Pauper ring');
+    expect(el.textContent).toContain('Pauper Ring');
+    expect(el.textContent).toContain('Elizabeth Taylor');
     expect(el.textContent).not.toContain('Taylor Ring Explanation');
-    expect(el.querySelector('.intro')!.textContent).not.toContain('Taylor');
+    expect(el.querySelector('.intro')!.textContent).not.toContain('Taylor Ring');
   });
 
   it('lists each visible ring with its inner/outer radius', () => {

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.ts
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.ts
@@ -1,0 +1,68 @@
+import { Component, ChangeDetectionStrategy, computed, inject } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { DialogShellComponent } from '../dialog-shell/dialog-shell.component';
+import { ringClassificationDiagram } from '../../data/ring-classification-diagram';
+
+export interface RingClassificationRingInfo {
+  name: string;
+  /** km */
+  innerRadius: number;
+  /** km */
+  outerRadius: number;
+}
+
+/** Data passed to the ring-classification dialog when it is opened from a Taylor or Pauper ring badge. */
+export interface RingClassificationDialogData {
+  kind: 'taylor' | 'pauper';
+  /** The parent body's name. */
+  bodyName: string;
+  /** The specific ring that was clicked, for highlighting in the illustration. */
+  ringName: string;
+  /** Parent body radius (R), km. */
+  parentRadius: number;
+  /** All visible rings that fed the classification, sorted by inner radius. */
+  rings: RingClassificationRingInfo[];
+  /** Outermost outer edge minus innermost inner edge across `rings`, km. */
+  span: number;
+  /** Innermost inner edge across `rings`, km. */
+  innermostInner: number;
+  /** Outermost outer edge across `rings`, km. */
+  outermostOuter: number;
+  /** 0.25R in km — the Taylor threshold, and the Pauper badge's "not narrow" floor. */
+  narrowThresholdKm: number;
+  /** 14R in km — the Pauper badge's minimum inner-edge distance. */
+  pauperInnerEdgeThresholdKm: number;
+  /** 2R in km — the Pauper badge's maximum span. */
+  pauperMaxSpanKm: number;
+}
+
+/**
+ * Explains the "Taylor" (unusually narrow) and "Pauper" (unusually wide and distant) ring
+ * badges: the criteria a ring system must meet, this body's numbers against them, and a
+ * to-scale illustration of the body and its visible rings.
+ */
+@Component({
+  selector: 'app-ring-classification-dialog',
+  templateUrl: './ring-classification-dialog.component.html',
+  styleUrls: ['./ring-classification-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DialogShellComponent],
+})
+export class RingClassificationDialogComponent {
+  public readonly data = inject<RingClassificationDialogData>(MAT_DIALOG_DATA);
+
+  public get heading(): string {
+    return this.data.kind === 'taylor' ? 'Taylor Ring Explanation' : 'Pauper Ring Explanation';
+  }
+
+  public readonly diagram = computed(() =>
+    ringClassificationDiagram(this.data.parentRadius, this.data.rings, this.data.ringName));
+
+  public fmt(value: number): string {
+    return value.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+  }
+
+  public ratio(value: number): string {
+    return (value / this.data.parentRadius).toFixed(1);
+  }
+}

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.ts
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, computed, inject } from '@angular/c
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { DialogShellComponent } from '../dialog-shell/dialog-shell.component';
 import { ringClassificationDiagram } from '../../data/ring-classification-diagram';
+import { formatGroupedInteger } from '../../data/unit-conversions';
 
 export interface RingClassificationRingInfo {
   name: string;
@@ -61,7 +62,7 @@ export class RingClassificationDialogComponent {
     ringClassificationDiagram(this.data.parentRadius, this.data.rings, this.data.ringName));
 
   public fmt(value: number): string {
-    return value.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+    return formatGroupedInteger(value);
   }
 
   public ratio(value: number): string {

--- a/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.ts
+++ b/src/app/dialogs/ring-classification-dialog/ring-classification-dialog.component.ts
@@ -34,6 +34,8 @@ export interface RingClassificationDialogData {
   pauperInnerEdgeThresholdKm: number;
   /** 2R in km — the Pauper badge's maximum span. */
   pauperMaxSpanKm: number;
+  /** True when the gap between two adjacent visible rings exceeds 2% of the total span. */
+  hasVisibleGap: boolean;
 }
 
 /**

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -753,6 +753,70 @@ describe('SystemBodyComponent (extended coverage)', () => {
         expect(component.taylorRingTooltip()).toContain('Taylor ring');
       });
 
+      it('classifies a real body\'s ring as Taylor, not Pauper, even though its inner edge alone clears the Pauper distance bar', () => {
+        // Real Canonn data: Byeia Eurk FB-X e1-4 B 3 (Planet, radius 4 381.512 km) with a
+        // single "A Ring" — raw innerRadius/outerRadius are in metres (71 831 000–72 786 000 m
+        // = 71 831–72 786 km once converted, same as the app's own ring loader), mass in Mt.
+        //   R = 4381.512 km        0.25R = 1 095.378 km   14R = 61 341.168 km   2R = 8 763.024 km
+        //   width = 72 786 − 71 831 = 955 km
+        // 955 km < 0.25R -> Taylor. Its inner edge (71 831 km) is also ≥ 14R — which alone would
+        // satisfy the Pauper badge's distance condition — but the span is *narrower* than 0.25R,
+        // so condition 3 (span > 0.25R) correctly keeps this Taylor-only, not Pauper too.
+        const parent = makeBody({ name: 'Byeia Eurk FB-X e1-4 B 3', type: 'Planet', radius: 4381.512 });
+        const ringA = makeBody({
+          name: 'Byeia Eurk FB-X e1-4 B 3 A Ring', type: 'Ring', subType: 'Metal Rich',
+          innerRadius: 71831, outerRadius: 72786, mass: 3949300000,
+        }, parent);
+        parent.subBodies.push(ringA);
+        render(ringA);
+        expect(component.isRingNotVisible()).toBe(false);
+        expect(component.isTaylorRing()).toBe(true);
+        expect(component.isPauperRing()).toBe(false);
+      });
+
+      it('classifies a real body\'s ring as neither Taylor nor Pauper (ordinary width, and just short of the Pauper distance bar)', () => {
+        // Real Canonn data: Eord Flyue BA-A g56 BC 1 (Planet, radius 5 402.809 km) with a
+        // single "A Ring" — raw innerRadius/outerRadius in metres (75 398 000–78 848 000 m =
+        // 75 398–78 848 km once converted), mass in Mt.
+        //   R = 5402.809 km        0.25R = 1 350.70225 km   14R = 75 639.326 km   2R = 10 805.618 km
+        //   width = 78 848 − 75 398 = 3 450 km
+        // 3 450 km > 0.25R -> not Taylor. For Pauper, span (3 450) and inner edge alone would
+        // clear the max-span and "not narrow" bars, but the inner edge (75 398 km) falls just
+        // short of 14R (75 639.326 km) — a ~241 km miss — so the distance condition fails and
+        // this is neither badge.
+        const parent = makeBody({ name: 'Eord Flyue BA-A g56 BC 1', type: 'Planet', radius: 5402.809 });
+        const ringA = makeBody({
+          name: 'Eord Flyue BA-A g56 BC 1 A Ring', type: 'Ring', subType: 'Rocky',
+          innerRadius: 75398, outerRadius: 78848, mass: 16261000000,
+        }, parent);
+        parent.subBodies.push(ringA);
+        render(ringA);
+        expect(component.isRingNotVisible()).toBe(false);
+        expect(component.isTaylorRing()).toBe(false);
+        expect(component.isPauperRing()).toBe(false);
+      });
+
+      it('classifies a real body\'s ring as Pauper', () => {
+        // Real Canonn data: Oochoxt NO-H d10-1 2 (Planet, radius 4 333.2615 km) with a single
+        // "A Ring" — raw innerRadius/outerRadius in metres (63 670 000–65 539 000 m =
+        // 63 670–65 539 km once converted), mass in Mt.
+        //   R = 4333.2615 km       0.25R = 1 083.315375 km   14R = 60 665.661 km   2R = 8 666.523 km
+        //   span = 65 539 − 63 670 = 1 869 km
+        // Inner edge 63 670 km ≥ 14R, span 1 869 km ≤ 2R, and span > 0.25R (wide enough to not
+        // also be Taylor) — all three Pauper conditions hold.
+        const parent = makeBody({ name: 'Oochoxt NO-H d10-1 2', type: 'Planet', radius: 4333.2615 });
+        const ringA = makeBody({
+          name: 'Oochoxt NO-H d10-1 2 A Ring', type: 'Ring', subType: 'Metallic',
+          innerRadius: 63670, outerRadius: 65539, mass: 6745100000,
+        }, parent);
+        parent.subBodies.push(ringA);
+        render(ringA);
+        expect(component.isRingNotVisible()).toBe(false);
+        expect(component.isTaylorRing()).toBe(false);
+        expect(component.isPauperRing()).toBe(true);
+        expect(component.pauperRingTooltip()).toContain('Pauper ring');
+      });
+
       it('does not mark a single mid-width ring as Taylor or Pauper', () => {
         const { rings: [ringA] } = makeRingSet([{ name: 'A Ring', inner: 60000, outer: 90000 }]); // width 30 000
         render(ringA);

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -729,6 +729,111 @@ describe('SystemBodyComponent (extended coverage)', () => {
         expect(component.isRacingRings()).toBe(false);               // invisible guard fires
       });
     });
+
+    describe('Taylor / Pauper ring badges', () => {
+      // Parent radius R = 50 000 km throughout, so:
+      // Taylor threshold (span < 0.25R)         = 12 500 km
+      // Pauper inner-edge threshold (≥ 14R)     = 700 000 km
+      // Pauper max span (≤ 2R)                  = 100 000 km
+      function makeRingSet(defs: Array<{ name: string; inner: number; outer: number; mass?: number }>) {
+        const parent = makeBody({ name: 'Star', earthMasses: 100, radius: 50000 });
+        const rings = defs.map(d => makeBody(
+          { name: d.name, type: 'Ring', subType: 'Rocky', innerRadius: d.inner, outerRadius: d.outer, mass: d.mass ?? 1e15 },
+          parent,
+        ));
+        parent.subBodies.push(...rings);
+        return { parent, rings };
+      }
+
+      it('marks a single narrow ring as Taylor', () => {
+        const { rings: [ringA] } = makeRingSet([{ name: 'A Ring', inner: 60000, outer: 70000 }]); // width 10 000 < 12 500
+        render(ringA);
+        expect(component.isTaylorRing()).toBe(true);
+        expect(component.isPauperRing()).toBe(false);
+        expect(component.taylorRingTooltip()).toContain('Taylor ring');
+      });
+
+      it('does not mark a single mid-width ring as Taylor or Pauper', () => {
+        const { rings: [ringA] } = makeRingSet([{ name: 'A Ring', inner: 60000, outer: 90000 }]); // width 30 000
+        render(ringA);
+        expect(component.isTaylorRing()).toBe(false);
+        expect(component.isPauperRing()).toBe(false);
+      });
+
+      it('marks every ring in a tight multi-ring system as Taylor (total span < 0.25R)', () => {
+        const { rings: [a, b, c] } = makeRingSet([
+          { name: 'A Ring', inner: 60000, outer: 63000 },
+          { name: 'B Ring', inner: 63500, outer: 66000 },
+          { name: 'C Ring', inner: 66500, outer: 70000 }, // span = 70 000 − 60 000 = 10 000 < 12 500
+        ]);
+        render(a); expect(component.isTaylorRing()).toBe(true);
+        render(b); expect(component.isTaylorRing()).toBe(true);
+        render(c); expect(component.isTaylorRing()).toBe(true);
+      });
+
+      it('marks a single wide, distant ring as Pauper', () => {
+        // inner 750 000 ≥ 700 000, span 50 000 (≤ 100 000, > 12 500)
+        const { rings: [ringA] } = makeRingSet([{ name: 'A Ring', inner: 750000, outer: 800000, mass: 1e18 }]);
+        render(ringA);
+        expect(component.isPauperRing()).toBe(true);
+        expect(component.isTaylorRing()).toBe(false);
+        expect(component.pauperRingTooltip()).toContain('Pauper ring');
+      });
+
+      it('does not mark a ring as Pauper when its span exceeds 2R', () => {
+        // inner 750 000 ≥ 700 000, but span 150 000 > 100 000
+        const { rings: [ringA] } = makeRingSet([{ name: 'A Ring', inner: 750000, outer: 900000, mass: 1e18 }]);
+        render(ringA);
+        expect(component.isPauperRing()).toBe(false);
+        expect(component.isTaylorRing()).toBe(false);
+      });
+
+      it('does not mark a ring as Pauper when its inner edge is under 14R', () => {
+        // inner 600 000 < 700 000, span 50 000 (≤ 100 000, > 12 500)
+        const { rings: [ringA] } = makeRingSet([{ name: 'A Ring', inner: 600000, outer: 650000, mass: 1e18 }]);
+        render(ringA);
+        expect(component.isPauperRing()).toBe(false);
+        expect(component.isTaylorRing()).toBe(false);
+      });
+
+      it('treats a span of exactly 0.25R as neither Taylor nor Pauper (both thresholds are strict)', () => {
+        const { rings: [ringA] } = makeRingSet([{ name: 'A Ring', inner: 700000, outer: 712500, mass: 1e18 }]); // span = 12 500 exactly
+        render(ringA);
+        expect(component.isTaylorRing()).toBe(false);
+        expect(component.isPauperRing()).toBe(false);
+      });
+
+      it('strips an invisible outer ring before computing the span, so the inner ring still qualifies as Taylor', () => {
+        const parent = makeBody({ name: 'Star', earthMasses: 100, radius: 50000 });
+        const ringA = makeBody({ name: 'A Ring', type: 'Ring', subType: 'Rocky',
+          innerRadius: 60000, outerRadius: 70000, mass: 1e15 }, parent); // width 10 000 < 12 500, visible
+        const ringB = makeBody({ name: 'B Ring', type: 'Ring', subType: 'Rocky',
+          innerRadius: 2000000, outerRadius: 5000000, mass: 1 }, parent); // wide + low density → invisible
+        parent.subBodies.push(ringA, ringB);
+
+        render(ringA);
+        expect(component.isRingNotVisible()).toBe(false);
+        expect(component.isTaylorRing()).toBe(true);
+
+        render(ringB);
+        expect(component.isRingNotVisible()).toBe(true);
+        expect(component.isTaylorRing()).toBe(false); // invisible rings don't carry the badge themselves
+      });
+
+      it('does not classify a body whose only ring is invisible', () => {
+        const { rings: [ringA] } = makeRingSet([{ name: 'A Ring', inner: 60000, outer: 5000000, mass: 1 }]); // wide + low density
+        render(ringA);
+        expect(component.isRingNotVisible()).toBe(true);
+        expect(component.isTaylorRing()).toBe(false);
+        expect(component.isPauperRing()).toBe(false);
+      });
+
+      it('does not classify a non-ring body', () => {
+        render(makeBody({ type: 'Planet', subType: 'Rocky body' }));
+        expect(component.isTaylorRing()).toBe(false);
+        expect(component.isPauperRing()).toBe(false);
+      });
+    });
   });
 
   describe('Roche / shepherding for a moon', () => {

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -833,6 +833,45 @@ describe('SystemBodyComponent (extended coverage)', () => {
         expect(component.isTaylorRing()).toBe(false);
         expect(component.isPauperRing()).toBe(false);
       });
+
+      it('opens the Taylor ring explanation dialog with the classification values', async () => {
+        const parent = makeBody({ name: 'Gas Giant', earthMasses: 100, radius: 50000 });
+        const ringA = makeBody({ name: 'A Ring', type: 'Ring', subType: 'Rocky',
+          innerRadius: 60000, outerRadius: 70000, mass: 1e15 }, parent);
+        parent.subBodies.push(ringA);
+        render(ringA);
+        await component.showRingClassificationDialog('taylor');
+        const data = lastDialogData();
+        expect(data.kind).toBe('taylor');
+        expect(data.bodyName).toBe('Gas Giant');
+        expect(data.ringName).toBe('A');
+        expect(data.parentRadius).toBe(50000);
+        expect(data.span).toBe(10000);
+        expect(data.rings).toEqual([{ name: 'A', innerRadius: 60000, outerRadius: 70000 }]);
+        expect(data.narrowThresholdKm).toBe(12500);
+      });
+
+      it('opens the Pauper ring explanation dialog with the classification values', async () => {
+        const parent = makeBody({ name: 'Gas Giant', earthMasses: 100, radius: 50000 });
+        const ringA = makeBody({ name: 'A Ring', type: 'Ring', subType: 'Rocky',
+          innerRadius: 750000, outerRadius: 800000, mass: 1e18 }, parent);
+        parent.subBodies.push(ringA);
+        render(ringA);
+        await component.showRingClassificationDialog('pauper');
+        const data = lastDialogData();
+        expect(data.kind).toBe('pauper');
+        expect(data.innermostInner).toBe(750000);
+        expect(data.outermostOuter).toBe(800000);
+        expect(data.pauperInnerEdgeThresholdKm).toBe(700000);
+        expect(data.pauperMaxSpanKm).toBe(100000);
+      });
+
+      it('does not open a dialog when the ring no longer qualifies for either badge', async () => {
+        const before = dialogOpenCalls;
+        render(makeBody({ type: 'Planet', subType: 'Rocky body' }));
+        await component.showRingClassificationDialog('taylor');
+        expect(dialogOpenCalls).toBe(before);
+      });
     });
   });
 

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -994,6 +994,36 @@ describe('SystemBodyComponent (extended coverage)', () => {
         expect(data.pauperMaxSpanKm).toBe(100000);
       });
 
+      it('flags no visible gap for the real two-ring Taylor system (gap of 10 km is well under 2% of the span)', async () => {
+        const parent = makeBody({ name: 'Dryao Phylio AA-A h662 BC 2', type: 'Planet', radius: 67890.304 });
+        const ringA = makeBody({
+          name: 'Dryao Phylio AA-A h662 BC 2 A Ring', type: 'Ring', subType: 'Rocky',
+          innerRadius: 104180, outerRadius: 104920, mass: 50125000000,
+        }, parent);
+        const ringB = makeBody({
+          name: 'Dryao Phylio AA-A h662 BC 2 B Ring', type: 'Ring', subType: 'Icy',
+          innerRadius: 104930, outerRadius: 117400, mass: 1240700000000,
+        }, parent);
+        parent.subBodies.push(ringA, ringB);
+        render(ringA);
+        await component.showRingClassificationDialog('taylor');
+        expect(lastDialogData().hasVisibleGap).toBe(false);
+      });
+
+      it('flags a visible gap when the space between two rings exceeds 2% of the total span', async () => {
+        const parent = makeBody({ name: 'Gas Giant', earthMasses: 100, radius: 50000 });
+        // span = 90 000 − 60 000 = 30 000; gap between the rings = 85 000 − 65 000 = 20 000,
+        // far more than 2% of the span (600 km).
+        const ringA = makeBody({ name: 'A Ring', type: 'Ring', subType: 'Rocky',
+          innerRadius: 60000, outerRadius: 65000, mass: 1e15 }, parent);
+        const ringB = makeBody({ name: 'B Ring', type: 'Ring', subType: 'Rocky',
+          innerRadius: 85000, outerRadius: 90000, mass: 1e15 }, parent);
+        parent.subBodies.push(ringA, ringB);
+        render(ringA);
+        await component.showRingClassificationDialog('taylor');
+        expect(lastDialogData().hasVisibleGap).toBe(true);
+      });
+
       it('does not open a dialog when the ring no longer qualifies for either badge', async () => {
         const before = dialogOpenCalls;
         render(makeBody({ type: 'Planet', subType: 'Rocky body' }));

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -817,6 +817,38 @@ describe('SystemBodyComponent (extended coverage)', () => {
         expect(component.pauperRingTooltip()).toContain('Pauper ring');
       });
 
+      it('classifies a real body\'s two-ring system as Pauper on both rings', () => {
+        // Real Canonn data: Nuekuae ZG-K d9-268 C 3 a (Planet, radius 3 163.639 km) with two
+        // visible rings — raw innerRadius/outerRadius in metres, converted to km the same way
+        // the app's own ring loader does:
+        //   A Ring: 59 133 000–60 317 000 m -> 59 133–60 317 km
+        //   B Ring: 60 417 000–65 344 000 m -> 60 417–65 344 km
+        //   R = 3163.639 km   0.25R = 790.90975 km   14R = 44 290.946 km   2R = 6 327.278 km
+        //   span = outermost outer edge (65 344) − innermost inner edge (59 133) = 6 211 km
+        // Inner edge 59 133 km ≥ 14R, span 6 211 km ≤ 2R (just ~116 km under), and span > 0.25R
+        // — all three Pauper conditions hold, and the badge shows on both rings.
+        const parent = makeBody({ name: 'Nuekuae ZG-K d9-268 C 3 a', type: 'Planet', radius: 3163.639 });
+        const ringA = makeBody({
+          name: 'Nuekuae ZG-K d9-268 C 3 a A Ring', type: 'Ring', subType: 'Rocky',
+          innerRadius: 59133, outerRadius: 60317, mass: 4432900000,
+        }, parent);
+        const ringB = makeBody({
+          name: 'Nuekuae ZG-K d9-268 C 3 a B Ring', type: 'Ring', subType: 'Rocky',
+          innerRadius: 60417, outerRadius: 65344, mass: 19801000000,
+        }, parent);
+        parent.subBodies.push(ringA, ringB);
+
+        render(ringA);
+        expect(component.isRingNotVisible()).toBe(false);
+        expect(component.isTaylorRing()).toBe(false);
+        expect(component.isPauperRing()).toBe(true);
+
+        render(ringB);
+        expect(component.isRingNotVisible()).toBe(false);
+        expect(component.isTaylorRing()).toBe(false);
+        expect(component.isPauperRing()).toBe(true);
+      });
+
       it('does not mark a single mid-width ring as Taylor or Pauper', () => {
         const { rings: [ringA] } = makeRingSet([{ name: 'A Ring', inner: 60000, outer: 90000 }]); // width 30 000
         render(ringA);
@@ -833,6 +865,38 @@ describe('SystemBodyComponent (extended coverage)', () => {
         render(a); expect(component.isTaylorRing()).toBe(true);
         render(b); expect(component.isTaylorRing()).toBe(true);
         render(c); expect(component.isTaylorRing()).toBe(true);
+      });
+
+      it('classifies a real body\'s two-ring system as Taylor on both rings (exactly the "2 or more visible rings" case)', () => {
+        // Real Canonn data: Dryao Phylio AA-A h662 BC 2 (gas giant, radius 67 890.304 km) with
+        // two visible rings — raw innerRadius/outerRadius in metres, converted to km the same
+        // way the app's own ring loader does:
+        //   A Ring: 104 180 000–104 920 000 m -> 104 180–104 920 km
+        //   B Ring: 104 930 000–117 400 000 m -> 104 930–117 400 km
+        //   R = 67 890.304 km   0.25R = 16 972.576 km
+        //   span = outermost outer edge (117 400) − innermost inner edge (104 180) = 13 220 km
+        // 13 220 km < 0.25R -> Taylor, and since the span (not either ring's own width) drives
+        // the "2 or more visible rings" rule, the badge shows on both A and B.
+        const parent = makeBody({ name: 'Dryao Phylio AA-A h662 BC 2', type: 'Planet', radius: 67890.304 });
+        const ringA = makeBody({
+          name: 'Dryao Phylio AA-A h662 BC 2 A Ring', type: 'Ring', subType: 'Rocky',
+          innerRadius: 104180, outerRadius: 104920, mass: 50125000000,
+        }, parent);
+        const ringB = makeBody({
+          name: 'Dryao Phylio AA-A h662 BC 2 B Ring', type: 'Ring', subType: 'Icy',
+          innerRadius: 104930, outerRadius: 117400, mass: 1240700000000,
+        }, parent);
+        parent.subBodies.push(ringA, ringB);
+
+        render(ringA);
+        expect(component.isRingNotVisible()).toBe(false);
+        expect(component.isTaylorRing()).toBe(true);
+        expect(component.isPauperRing()).toBe(false);
+
+        render(ringB);
+        expect(component.isRingNotVisible()).toBe(false);
+        expect(component.isTaylorRing()).toBe(true);
+        expect(component.isPauperRing()).toBe(false);
       });
 
       it('marks a single wide, distant ring as Pauper', () => {

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -30,13 +30,13 @@
       <span class="badge badge-orange" [matTooltip]="racingRingsTooltip()" matTooltipClass="multiline-tooltip">Racing Rings</span>
       }
       @if (isTaylorRing()) {
-      <span class="badge badge-gray" [matTooltip]="taylorRingTooltip()" matTooltipClass="multiline-tooltip">
-        <img alt="" src="assets/icons/taylor-ring.svg" style="width: 16px; height: 12px; filter: brightness(0);" />
+      <span class="badge badge-blue" [matTooltip]="taylorRingTooltip()" matTooltipClass="multiline-tooltip">
+        <img alt="" src="assets/icons/taylor-ring.svg" style="width: 12px; height: 12px; filter: brightness(0);" />
       </span>
       }
       @if (isPauperRing()) {
-      <span class="badge badge-green" [matTooltip]="pauperRingTooltip()" matTooltipClass="multiline-tooltip">
-        <img alt="" src="assets/icons/pauper-ring.svg" style="width: 16px; height: 12px; filter: brightness(0);" />
+      <span class="badge badge-blue" [matTooltip]="pauperRingTooltip()" matTooltipClass="multiline-tooltip">
+        <img alt="" src="assets/icons/pauper-ring.svg" style="width: 12px; height: 12px; filter: brightness(0);" />
       </span>
       }
       @if (isActualShepherd()) {

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -29,6 +29,16 @@
       @if (isRacingRings()) {
       <span class="badge badge-orange" [matTooltip]="racingRingsTooltip()" matTooltipClass="multiline-tooltip">Racing Rings</span>
       }
+      @if (isTaylorRing()) {
+      <span class="badge badge-gray" [matTooltip]="taylorRingTooltip()" matTooltipClass="multiline-tooltip">
+        <img alt="" src="assets/icons/taylor-ring.svg" style="width: 16px; height: 12px; filter: brightness(0);" />
+      </span>
+      }
+      @if (isPauperRing()) {
+      <span class="badge badge-green" [matTooltip]="pauperRingTooltip()" matTooltipClass="multiline-tooltip">
+        <img alt="" src="assets/icons/pauper-ring.svg" style="width: 16px; height: 12px; filter: brightness(0);" />
+      </span>
+      }
       @if (isActualShepherd()) {
       <span class="badge badge-blue clickable"
         [matTooltip]="'Shepherd moon (Hill sphere close to ring edge) - click for analysis'"

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -30,12 +30,14 @@
       <span class="badge badge-orange" [matTooltip]="racingRingsTooltip()" matTooltipClass="multiline-tooltip">Racing Rings</span>
       }
       @if (isTaylorRing()) {
-      <span class="badge badge-blue" [matTooltip]="taylorRingTooltip()" matTooltipClass="multiline-tooltip">
+      <span class="badge badge-blue clickable" [matTooltip]="taylorRingTooltip() + ' — click for an explanation'"
+        matTooltipClass="multiline-tooltip" (click)="showRingClassificationDialog('taylor')">
         <img alt="" src="assets/icons/taylor-ring.svg" style="width: 12px; height: 12px; filter: brightness(0);" />
       </span>
       }
       @if (isPauperRing()) {
-      <span class="badge badge-blue" [matTooltip]="pauperRingTooltip()" matTooltipClass="multiline-tooltip">
+      <span class="badge badge-blue clickable" [matTooltip]="pauperRingTooltip() + ' — click for an explanation'"
+        matTooltipClass="multiline-tooltip" (click)="showRingClassificationDialog('pauper')">
         <img alt="" src="assets/icons/pauper-ring.svg" style="width: 12px; height: 12px; filter: brightness(0);" />
       </span>
       }

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -23,6 +23,7 @@ import { GENUS_NAMES } from '../data/genus';
 import type { OrbitalDiagramType, OrbitElements } from '../dialogs/orbital-diagram-dialog/orbital-diagram-dialog.component';
 import type { TidalLockDialogData } from '../dialogs/tidal-lock-dialog/tidal-lock-dialog.component';
 import type { InvisibleRingDialogData } from '../dialogs/invisible-ring-dialog/invisible-ring-dialog.component';
+import type { RingClassificationDialogData, RingClassificationRingInfo } from '../dialogs/ring-classification-dialog/ring-classification-dialog.component';
 import type { ApoPeriDialogData } from '../dialogs/apo-peri-dialog/apo-peri-dialog.component';
 import type { AnomalyDialogData } from '../dialogs/anomaly-dialog/anomaly-dialog.component';
 import type { CollisionBodyInfo, CollisionDialogData } from '../dialogs/collision-dialog/collision-dialog.component';
@@ -1062,6 +1063,35 @@ export class SystemBodyComponent implements OnChanges {
     });
   }
 
+  /** Opens the explanation dialog for the Taylor (narrow) or Pauper (wide, distant) ring badge. */
+  public async showRingClassificationDialog(kind: 'taylor' | 'pauper'): Promise<void> {
+    const body = this.body();
+    const ringClass = this.classifyRingSystem(body);
+    if (!ringClass) { return; }
+
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/ring-classification-dialog/ring-classification-dialog.component').then(m => m.RingClassificationDialogComponent),
+      skeleton: 'diagram',
+      width: '900px',
+      maxWidth: '95vw',
+      hasBackdrop: true,
+      backdropClass: 'cdk-overlay-dark-backdrop',
+      data: {
+        kind,
+        bodyName: body.parent?.bodyData.name ?? '',
+        ringName: body.bodyData.name.replace('Ring', '').trim(),
+        parentRadius: ringClass.parentRadius,
+        rings: ringClass.rings,
+        span: ringClass.span,
+        innermostInner: ringClass.innermostInner,
+        outermostOuter: ringClass.outermostOuter,
+        narrowThresholdKm: NARROW_RING_SPAN_RADII * ringClass.parentRadius,
+        pauperInnerEdgeThresholdKm: PAUPER_RING_MIN_INNER_EDGE_RADII * ringClass.parentRadius,
+        pauperMaxSpanKm: PAUPER_RING_MAX_SPAN_RADII * ringClass.parentRadius,
+      } satisfies RingClassificationDialogData,
+    });
+  }
+
   /** Opens the Roche-limit chart dialog with the prepared chart data. */
   private async openRocheLimitDialog(data: RocheChartData): Promise<void> {
     openLazyDialog(this.dialog, {
@@ -1515,7 +1545,10 @@ export class SystemBodyComponent implements OnChanges {
    * (invisible rings — see {@link isInvisibleRing} — are stripped first), so the result is
    * identical for every ring belonging to the same parent and the badge shows on all of them.
    */
-  private classifyRingSystem(body: SystemBody): { isTaylor: boolean; isPauper: boolean; span: number; innermostInner: number; parentRadius: number } | null {
+  private classifyRingSystem(body: SystemBody): {
+    isTaylor: boolean; isPauper: boolean; span: number; innermostInner: number; outermostOuter: number;
+    parentRadius: number; rings: RingClassificationRingInfo[];
+  } | null {
     const bd = body.bodyData;
     if (bd.type !== BODY_TYPE.Ring || !body.parent || this.isInvisibleRing(bd)) { return null; }
 
@@ -1523,7 +1556,8 @@ export class SystemBodyComponent implements OnChanges {
     if (!parentRadius) { return null; }
 
     const visibleRings = body.parent.subBodies
-      .filter(s => s.bodyData.type === BODY_TYPE.Ring && !this.isInvisibleRing(s.bodyData));
+      .filter(s => s.bodyData.type === BODY_TYPE.Ring && !this.isInvisibleRing(s.bodyData))
+      .sort((a, b) => (a.bodyData.innerRadius ?? 0) - (b.bodyData.innerRadius ?? 0));
     if (visibleRings.length === 0) { return null; }
 
     const innermostInner = Math.min(...visibleRings.map(r => r.bodyData.innerRadius ?? 0));
@@ -1537,7 +1571,13 @@ export class SystemBodyComponent implements OnChanges {
       && span <= PAUPER_RING_MAX_SPAN_RADII * parentRadius
       && span > NARROW_RING_SPAN_RADII * parentRadius;
 
-    return { isTaylor, isPauper, span, innermostInner, parentRadius };
+    const rings = visibleRings.map(r => ({
+      name: r.bodyData.name.replace('Ring', '').trim(),
+      innerRadius: r.bodyData.innerRadius ?? 0,
+      outerRadius: r.bodyData.outerRadius ?? 0,
+    }));
+
+    return { isTaylor, isPauper, span, innermostInner, outermostOuter, parentRadius, rings };
   }
 
   private computeRingNeighbourDistance(body: SystemBody): { distance: number | null; label: string; velocityDiff: number | null; eitherRingInvisible: boolean } {

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -66,7 +66,7 @@ const COLLISION_DIAGRAM_SYNODIC_PERIODS = 10;
  */
 const COLLISION_DIAGRAM_SAMPLES = 1000;
 
-/** Rings below this surface density (kg/km²) are considered invisible. */
+/** Rings below this surface density (Mt/km²) are considered invisible. */
 const INVISIBLE_RING_MAX_DENSITY = 0.1;
 /** Rings wider than this (km) are considered invisible when density is also low. */
 const INVISIBLE_RING_MIN_WIDTH = 1_000_000;
@@ -84,6 +84,17 @@ const RACING_RINGS_MAX_GAP_KM = 50;
  * may be adjusted after in-game observations.
  */
 const RACING_RINGS_MIN_SPEED_DIFF_KMS = 5;
+
+/**
+ * Body-radius multiple below which a ring system's total span counts as narrow. Used
+ * as the Taylor ring badge's upper threshold, and as the Pauper ring badge's lower
+ * bound (a span this narrow is a Taylor ring, not a Pauper ring).
+ */
+const NARROW_RING_SPAN_RADII = 0.25;
+/** Body-radii the innermost visible ring edge must clear for the Pauper ring badge (unusually distant). */
+const PAUPER_RING_MIN_INNER_EDGE_RADII = 14;
+/** Maximum span (body radii) for the Pauper ring badge — no wider than one body diameter. */
+const PAUPER_RING_MAX_SPAN_RADII = 2;
 
 @Component({
   selector: 'app-system-body',
@@ -184,6 +195,10 @@ export class SystemBodyComponent implements OnChanges {
   public readonly getRingVelocityDiffTooltip = signal('');
   public readonly isRacingRings = signal(false);
   public readonly racingRingsTooltip = signal('');
+  public readonly isTaylorRing = signal(false);
+  public readonly taylorRingTooltip = signal('');
+  public readonly isPauperRing = signal(false);
+  public readonly pauperRingTooltip = signal('');
   public readonly getPlanetaryDensity = signal<PlanetaryDensity | null>(null);
   public readonly calculateRigidRocheLimit = signal<number | null>(null);
   public readonly calculateFluidRocheLimit = signal<number | null>(null);
@@ -457,6 +472,19 @@ export class SystemBodyComponent implements OnChanges {
     } else {
       this.racingRingsTooltip.set('');
     }
+
+    // Taylor (unusually narrow) / Pauper (unusually wide and distant) ring badges.
+    const ringClass = this.classifyRingSystem(body);
+    this.isTaylorRing.set(ringClass?.isTaylor ?? false);
+    this.isPauperRing.set(ringClass?.isPauper ?? false);
+    this.taylorRingTooltip.set(ringClass?.isTaylor
+      ? `Taylor ring: total ring span is ${ringClass.span.toFixed(0)} km, under 25% of the body's radius `
+        + `(${(NARROW_RING_SPAN_RADII * ringClass.parentRadius).toFixed(0)} km) — unusually narrow`
+      : '');
+    this.pauperRingTooltip.set(ringClass?.isPauper
+      ? `Pauper ring: innermost edge sits ${(ringClass.innermostInner / ringClass.parentRadius).toFixed(1)}× the body's radius out, `
+        + `spanning only ${ringClass.span.toFixed(0)} km — unusually wide and distant`
+      : '');
 
     // Physics-service delegations.
     this.getPlanetaryDensity.set(this.physics.getPlanetaryDensity(bd));
@@ -1478,6 +1506,38 @@ export class SystemBodyComponent implements OnChanges {
   /** Shared invisibility heuristic used for ring stats, badges, and dialog explanations. */
   private isLowDensityWideRing(widthKm: number, densityKgPerKm2: number): boolean {
     return densityKgPerKm2 < INVISIBLE_RING_MAX_DENSITY && widthKm > INVISIBLE_RING_MIN_WIDTH;
+  }
+
+  /**
+   * Classifies `body`'s ring system as Taylor (unusually narrow) and/or Pauper (unusually
+   * wide and distant), or null when `body` isn't a visible ring or the classification can't
+   * be computed. Both badges are derived from the same "span" of the body's *visible* rings
+   * (invisible rings — see {@link isInvisibleRing} — are stripped first), so the result is
+   * identical for every ring belonging to the same parent and the badge shows on all of them.
+   */
+  private classifyRingSystem(body: SystemBody): { isTaylor: boolean; isPauper: boolean; span: number; innermostInner: number; parentRadius: number } | null {
+    const bd = body.bodyData;
+    if (bd.type !== BODY_TYPE.Ring || !body.parent || this.isInvisibleRing(bd)) { return null; }
+
+    const parentRadius = this.physics.getParentRadiusKm(body);
+    if (!parentRadius) { return null; }
+
+    const visibleRings = body.parent.subBodies
+      .filter(s => s.bodyData.type === BODY_TYPE.Ring && !this.isInvisibleRing(s.bodyData));
+    if (visibleRings.length === 0) { return null; }
+
+    const innermostInner = Math.min(...visibleRings.map(r => r.bodyData.innerRadius ?? 0));
+    const outermostOuter = Math.max(...visibleRings.map(r => r.bodyData.outerRadius ?? 0));
+    const span = outermostOuter - innermostInner;
+
+    const isTaylor = span < NARROW_RING_SPAN_RADII * parentRadius;
+    // `span > NARROW_RING_SPAN_RADII * parentRadius` here is what keeps this mutually
+    // exclusive with isTaylor above (span < the same threshold).
+    const isPauper = innermostInner >= PAUPER_RING_MIN_INNER_EDGE_RADII * parentRadius
+      && span <= PAUPER_RING_MAX_SPAN_RADII * parentRadius
+      && span > NARROW_RING_SPAN_RADII * parentRadius;
+
+    return { isTaylor, isPauper, span, innermostInner, parentRadius };
   }
 
   private computeRingNeighbourDistance(body: SystemBody): { distance: number | null; label: string; velocityDiff: number | null; eitherRingInvisible: boolean } {

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -1081,7 +1081,9 @@ export class SystemBodyComponent implements OnChanges {
       data: {
         kind,
         bodyName: body.parent?.bodyData.name ?? '',
-        ringName: body.bodyData.name.replace('Ring', '').trim(),
+        // `body` is one of the visible rings classifyRingSystem requires to compute `ringClass`
+        // (see its early returns above), so it is guaranteed to appear in `ringClass.rings`.
+        ringName: ringClass.rings.find(r => r.innerRadius === (body.bodyData.innerRadius ?? 0))!.name,
         parentRadius: ringClass.parentRadius,
         rings: ringClass.rings,
         span: ringClass.span,
@@ -1541,6 +1543,18 @@ export class SystemBodyComponent implements OnChanges {
     return densityKgPerKm2 < INVISIBLE_RING_MAX_DENSITY && widthKm > INVISIBLE_RING_MIN_WIDTH;
   }
 
+  /** `parent`'s ring-type sub-bodies, sorted by inner radius ascending. Includes invisible rings — callers filter those out themselves when they don't want them. */
+  private sortedRingSiblings(parent: SystemBody): SystemBody[] {
+    return parent.subBodies
+      .filter(s => s.bodyData.type === BODY_TYPE.Ring)
+      .sort((a, b) => (a.bodyData.innerRadius ?? 0) - (b.bodyData.innerRadius ?? 0));
+  }
+
+  /** Strips the " Ring" suffix from a ring body's name, leaving just its letter designation (e.g. "A"). */
+  private stripRingSuffix(name: string): string {
+    return name.replace('Ring', '').trim();
+  }
+
   /**
    * Classifies `body`'s ring system as Taylor (unusually narrow) and/or Pauper (unusually
    * wide and distant), or null when `body` isn't a visible ring or the classification can't
@@ -1558,12 +1572,12 @@ export class SystemBodyComponent implements OnChanges {
     const parentRadius = this.physics.getParentRadiusKm(body);
     if (!parentRadius) { return null; }
 
-    const visibleRings = body.parent.subBodies
-      .filter(s => s.bodyData.type === BODY_TYPE.Ring && !this.isInvisibleRing(s.bodyData))
-      .sort((a, b) => (a.bodyData.innerRadius ?? 0) - (b.bodyData.innerRadius ?? 0));
+    const visibleRings = this.sortedRingSiblings(body.parent)
+      .filter(s => !this.isInvisibleRing(s.bodyData));
     if (visibleRings.length === 0) { return null; }
 
-    const innermostInner = Math.min(...visibleRings.map(r => r.bodyData.innerRadius ?? 0));
+    // Already sorted by inner radius ascending, so the first entry is the innermost inner edge.
+    const innermostInner = visibleRings[0].bodyData.innerRadius ?? 0;
     const outermostOuter = Math.max(...visibleRings.map(r => r.bodyData.outerRadius ?? 0));
     const span = outermostOuter - innermostInner;
 
@@ -1575,7 +1589,7 @@ export class SystemBodyComponent implements OnChanges {
       && span > NARROW_RING_SPAN_RADII * parentRadius;
 
     const rings = visibleRings.map(r => ({
-      name: r.bodyData.name.replace('Ring', '').trim(),
+      name: this.stripRingSuffix(r.bodyData.name),
       innerRadius: r.bodyData.innerRadius ?? 0,
       outerRadius: r.bodyData.outerRadius ?? 0,
     }));
@@ -1596,17 +1610,15 @@ export class SystemBodyComponent implements OnChanges {
     if (bd.type !== BODY_TYPE.Ring || !body.parent) {
       return { distance: null, label: '', velocityDiff: null, eitherRingInvisible: false };
     }
-    const siblings = body.parent.subBodies
-      .filter(s => s.bodyData.name.includes('Ring'))
-      .sort((a, b) => (a.bodyData.innerRadius ?? 0) - (b.bodyData.innerRadius ?? 0));
+    const siblings = this.sortedRingSiblings(body.parent);
     const idx = siblings.indexOf(body);
     if (idx < 0 || idx === siblings.length - 1) {
       return { distance: null, label: '', velocityDiff: null, eitherRingInvisible: false };
     }
     const next = siblings[idx + 1];
     const distance = (next.bodyData.innerRadius ?? 0) - (bd.outerRadius ?? 0);
-    const thisLabel = bd.name.replace('Ring', '').trim();
-    const nextLabel = next.bodyData.name.replace('Ring', '').trim();
+    const thisLabel = this.stripRingSuffix(bd.name);
+    const nextLabel = this.stripRingSuffix(next.bodyData.name);
     const currentDynamics = this.physics.ringDynamics(body);
     const nextDynamics = this.physics.ringDynamics(next);
     const velocityDiff = (currentDynamics !== null && nextDynamics !== null)

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -96,6 +96,8 @@ const NARROW_RING_SPAN_RADII = 0.25;
 const PAUPER_RING_MIN_INNER_EDGE_RADII = 14;
 /** Maximum span (body radii) for the Pauper ring badge — no wider than one body diameter. */
 const PAUPER_RING_MAX_SPAN_RADII = 2;
+/** Fraction of the total span above which a gap between two adjacent visible rings is called out as potentially visible. */
+const VISIBLE_GAP_SPAN_FRACTION = 0.02;
 
 @Component({
   selector: 'app-system-body',
@@ -1088,6 +1090,7 @@ export class SystemBodyComponent implements OnChanges {
         narrowThresholdKm: NARROW_RING_SPAN_RADII * ringClass.parentRadius,
         pauperInnerEdgeThresholdKm: PAUPER_RING_MIN_INNER_EDGE_RADII * ringClass.parentRadius,
         pauperMaxSpanKm: PAUPER_RING_MAX_SPAN_RADII * ringClass.parentRadius,
+        hasVisibleGap: ringClass.hasVisibleGap,
       } satisfies RingClassificationDialogData,
     });
   }
@@ -1547,7 +1550,7 @@ export class SystemBodyComponent implements OnChanges {
    */
   private classifyRingSystem(body: SystemBody): {
     isTaylor: boolean; isPauper: boolean; span: number; innermostInner: number; outermostOuter: number;
-    parentRadius: number; rings: RingClassificationRingInfo[];
+    parentRadius: number; rings: RingClassificationRingInfo[]; hasVisibleGap: boolean;
   } | null {
     const bd = body.bodyData;
     if (bd.type !== BODY_TYPE.Ring || !body.parent || this.isInvisibleRing(bd)) { return null; }
@@ -1577,7 +1580,15 @@ export class SystemBodyComponent implements OnChanges {
       outerRadius: r.bodyData.outerRadius ?? 0,
     }));
 
-    return { isTaylor, isPauper, span, innermostInner, outermostOuter, parentRadius, rings };
+    // Gap between each ring's outer edge and the next ring's inner edge — a gap wide enough
+    // relative to the total span may show up as a visible break in an otherwise "single ring".
+    const hasVisibleGap = span > 0 && rings.some((r, i) => {
+      const next = rings[i + 1];
+      if (!next) { return false; }
+      return (next.innerRadius - r.outerRadius) > VISIBLE_GAP_SPAN_FRACTION * span;
+    });
+
+    return { isTaylor, isPauper, span, innermostInner, outermostOuter, parentRadius, rings, hasVisibleGap };
   }
 
   private computeRingNeighbourDistance(body: SystemBody): { distance: number | null; label: string; velocityDiff: number | null; eitherRingInvisible: boolean } {

--- a/src/assets/icons/pauper-ring.svg
+++ b/src/assets/icons/pauper-ring.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 38 24" width="38" height="24" role="img" aria-label="Pauper ring badge">
+  <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="3"/>
+  <circle cx="22.25" cy="12" r="2.25" fill="currentColor"/>
+</svg>

--- a/src/assets/icons/pauper-ring.svg
+++ b/src/assets/icons/pauper-ring.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 38 24" width="38" height="24" role="img" aria-label="Pauper ring badge">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="2.5 2.5 22 19" width="22" height="19" role="img" aria-label="Pauper ring badge">
   <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="3"/>
   <circle cx="22.25" cy="12" r="2.25" fill="currentColor"/>
 </svg>

--- a/src/assets/icons/taylor-ring.svg
+++ b/src/assets/icons/taylor-ring.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 38 24" width="38" height="24" role="img" aria-label="Taylor ring badge">
+  <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="3"/>
+  <circle cx="28" cy="12" r="8" fill="currentColor"/>
+</svg>

--- a/src/assets/icons/taylor-ring.svg
+++ b/src/assets/icons/taylor-ring.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 38 24" width="38" height="24" role="img" aria-label="Taylor ring badge">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="2.5 2.5 33.5 19" width="33.5" height="19" role="img" aria-label="Taylor ring badge">
   <circle cx="12" cy="12" r="8" fill="none" stroke="currentColor" stroke-width="3"/>
   <circle cx="28" cy="12" r="8" fill="currentColor"/>
 </svg>


### PR DESCRIPTION
## Summary

Adds two new ring-classification badges — **Taylor Ring** (unusually narrow) and **Pauper Ring** (unusually wide and distant) — shown on a body's ring title(s), plus an explanation dialog with a to-scale illustration.

- **Taylor Ring**: the ring system's total visible span is less than 25% of the primary body's radius.
- **Pauper Ring**: the innermost visible edge is ≥ 14× the primary body's radius out, the total span is ≤ 2× the radius (one body diameter), and that span is > 25% of the radius (so it can't also be a Taylor ring).

Both classifications strip out rings already flagged "Invisible" (wide + low density) before evaluating, and are computed once per ring system so the badge shows on *every* visible ring belonging to that body — not just one.

## What's included

- **Badges**: `taylor-ring.svg` / `pauper-ring.svg` icons on the ring title row, matching the existing icon-badge convention (12×12, pale blue background).
- **Classification logic**: `classifyRingSystem()` in `system-body.component.ts`, reusing the existing invisible-ring stripping logic.
- **Explanation dialog**: clicking either badge opens a modal (`ring-classification-dialog`) with:
  - A plain-language description of each badge, including the Elizabeth Taylor engagement-ring naming lore.
  - The exact criteria and this body's numbers against them.
  - A **to-scale** SVG illustration of the body and its visible rings — genuinely proportional (no artificial minimum sizes), so a Pauper body renders as a tiny speck and a hair-thin Taylor ring renders as a hairline.
  - A disclaimer noting the classification is based on recorded radii, not in-game observation, and may not hold up visually.

## Testing

- Unit tests for the diagram's scaling math (`ring-classification-diagram.spec.ts`).
- Unit tests for the dialog component's rendering (`ring-classification-dialog.component.spec.ts`).
- Unit tests for the classification logic and badge wiring in `system-body.component.extra.spec.ts`, including several regression cases built from real Canonn ring data:
  - A narrow ring whose inner edge alone would clear the Pauper distance bar, but is correctly Taylor-only.
  - A ring that just misses the Pauper distance bar by ~241 km — correctly neither badge.
  - Single-ring and two-ring Pauper systems (one right at the edge of the 2R max-span boundary).
  - A two-ring Taylor system, confirming the badge shows on both rings.

## Manual verification

- [x] Run `npm test` to confirm the full suite passes.
- [x] Spot-check the badges and dialog in the browser against a few real ring systems.

<img width="663" height="305" alt="image" src="https://github.com/user-attachments/assets/fd4b8c98-503e-4997-b7a8-b85ce51c4242" />
<img width="688" height="502" alt="image" src="https://github.com/user-attachments/assets/5baaebb0-1971-40fb-b693-42f064bf278c" />


<img width="891" height="701" alt="image" src="https://github.com/user-attachments/assets/6512a334-d588-4cba-938a-b3839aebd179" />

<img width="877" height="870" alt="image" src="https://github.com/user-attachments/assets/29f3ba21-0a2f-46cb-adb0-19a9ec99fa6b" />
