### PR TITLE
Fix flaky mobile-chromium tooltip e2e (hover the tooltip span, not the cell)

### DIFF
--- a/e2e/support/system-fixture.ts
+++ b/e2e/support/system-fixture.ts
@@ -247,8 +247,13 @@ export async function assertBody(page: Page, spec: BodySpec): Promise<void> {
         .filter({ has: page.getByText(label, { exact: true }) })
         .locator('> div')
         .last();
-      await valueCell.scrollIntoViewIfNeeded();
-      await valueCell.hover();
+      // Hover the value text itself (the `<span>` that carries the matTooltip), not the cell wrapper.
+      // At narrow widths a wrapped label makes the flex row tall; the value cell stretches to that
+      // height while its single-line text stays at the top, so the cell's geometric centre — where
+      // `.hover()` aims — falls into empty space below the text and never fires the span's mouseenter.
+      const tooltipTarget = valueCell.locator('> span').first();
+      await tooltipTarget.scrollIntoViewIfNeeded();
+      await tooltipTarget.hover();
       // Scope to the *shown* tooltip — Material keeps hidden tooltips in the DOM
       // (toggling -show/-hide classes), so `.mat-mdc-tooltip` alone is ambiguous.
       await expect(


### PR DESCRIPTION
## Summary

Fixes a deterministic **mobile-chromium** e2e failure: `alpha-centauri-bodies.spec.ts` → "renders Alpha Centauri (G star)" failed on the "Next apoapsis" tooltip assertion (`.mat-mdc-tooltip-show` never appeared), while passing on the other five projects (desktop/tablet Chromium and all three Firefox). It reproduces on `main`.

## Root cause

It's a **test-helper bug, not an app bug**. `assertBody()` in [e2e/support/system-fixture.ts](e2e/support/system-fixture.ts) hovered the value cell's wrapper `<div>` and relied on `.hover()` aiming at its geometric centre:

- `.body-data-entry` is `display: flex; justify-content: space-between`, and the value cell (`> div`, default `align-items: stretch`).
- At 390px the label ("Next apoapsis") wraps to multiple lines, so the flex row grows tall and the value cell stretches to match — but its single-line value text stays at the **top**.
- `.hover()` moves the pointer to the cell's centre, which now sits in empty space **below** the text, so the `matTooltip`-bearing `<span>` never receives `mouseenter` and the tooltip doesn't show.

On wider viewports the label doesn't wrap, the row is short, and the centre is over the text — hence it only failed at the mobile viewport on Chromium.

Real users are unaffected: they hover the value text and the tooltip shows normally.

## Fix

Hover the value `<span>` directly (the element that carries the `matTooltip`) instead of the wrapper cell, so the trigger fires regardless of viewport. Only this spec's tooltip assertions use that code path; app behaviour is unchanged.

## Testing

- `alpha-centauri-bodies.spec.ts` — **36/36 pass** (6 bodies × 6 projects), including the previously-failing mobile-chromium.
- Full e2e suite — **573 passed, 3 skipped, 0 failed** (was 572 passed / 1 failed before the fix); no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
