### PR TITLE
Fix stale SIMBAD/EDAstro responses bleeding across systems

### DIFF
--- a/src/app/home/home.component.extra.spec.ts
+++ b/src/app/home/home.component.extra.spec.ts
@@ -433,6 +433,55 @@ describe('HomeComponent (extended coverage)', () => {
     });
   });
 
+  describe('stale-response guards', () => {
+    it('drops a slow SIMBAD response once another system has been selected', async () => {
+      const svc = TestBed.inject(AppService) as any;
+      let resolveAlpha!: (v: unknown) => void;
+      svc.getSimbad = vi.fn()
+        // First (system Alpha) hangs; the later call (Beta) resolves immediately.
+        .mockReturnValueOnce(new Promise(res => { resolveAlpha = res; }))
+        .mockImplementation(() => Promise.resolve({
+          system_address: 20n, name: 'Beta', simbad_name: 'Beta Star', simbad_ident: '@Beta',
+          ra_j2000: 1, dec_j2000: 2,
+        }));
+
+      component.fetchEdGalaxyData('Alpha', 10n);
+      component.fetchEdGalaxyData('Beta', 20n);
+      await flushPromises();
+      expect(component.edGalaxyData()?.Simbad?.Name).toBe('Beta Star');
+
+      // Alpha's response finally arrives — it must not clobber Beta.
+      resolveAlpha({
+        system_address: 10n, name: 'Alpha', simbad_name: 'Alpha Star', simbad_ident: '@Alpha',
+        ra_j2000: 9, dec_j2000: 9,
+      });
+      await flushPromises();
+      expect(component.edGalaxyData()?.Simbad?.Name).toBe('Beta Star');
+    });
+
+    it('drops a slow EDAstro response (summary + background) after switching systems', async () => {
+      const svc = TestBed.inject(AppService) as any;
+      let resolveAlpha!: (v: unknown) => void;
+      svc.getEdastroData = vi.fn()
+        .mockReturnValueOnce(new Promise(res => { resolveAlpha = res; }))
+        .mockImplementation(() => Promise.resolve({
+          name: 'Beta POI', summary: 'Beta summary', mainImage: 'https://example.com/beta.png',
+        }));
+
+      (component as any).processBodies({ system: { name: 'Alpha', id64: 111, coords: { x: 0, y: 0, z: 0 }, bodies: [] } });
+      (component as any).processBodies({ system: { name: 'Beta', id64: 222, coords: { x: 0, y: 0, z: 0 }, bodies: [] } });
+      await flushPromises();
+      expect(component.edastroData()?.name).toBe('Beta POI');
+
+      setBackgroundImage.mockClear();
+      // Alpha's EDAstro payload resolves late — must not overwrite Beta's data or background.
+      resolveAlpha({ name: 'Alpha POI', summary: 'Alpha summary', mainImage: 'https://example.com/alpha.png' });
+      await flushPromises();
+      expect(component.edastroData()?.name).toBe('Beta POI');
+      expect(setBackgroundImage).not.toHaveBeenCalledWith('https://example.com/alpha.png');
+    });
+  });
+
   describe('autocomplete suggestions', () => {
     it('debounces input and populates the suggestions signal', async () => {
       httpResponses.set('/typeahead', { values: ['Synuefe AB', 'Synuefe CD'] });

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -38,6 +38,9 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   private lastSimbadSystemName: string | null = null;
   private lastSimbadId64: bigint | null = null;
+  // Monotonic token so a slow SIMBAD response for a previously-selected system
+  // can't overwrite edGalaxyData after the user has navigated to another one.
+  private edGalaxyGeneration = 0;
   // Credits are extracted from readme.md at build time by scripts/generate-credits.js.
   // Bound via [innerHTML], which Angular sanitizes; the source is a trusted local file.
   public creditsHtml: string = CREDITS_HTML;
@@ -132,6 +135,9 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   fetchEdGalaxyData(systemName: string, id64: bigint, coords?: { x: number, y: number, z: number }) {
     const pgName = this.getPGName(id64);
+    // Claim this request's slot; a later fetch bumps the token so this one's
+    // async result is discarded rather than clobbering the newer system's data.
+    const generation = ++this.edGalaxyGeneration;
 
     // Fallback used whenever we don't (or can't) resolve Simbad data.
     const setFallback = () => {
@@ -151,6 +157,10 @@ export class HomeComponent implements OnInit, OnDestroy {
     // Call the API for Simbad data
     this.appService.getSimbad(id64, systemName, coords)
       .then(result => {
+        // Drop the response if the user has since navigated to another system.
+        if (generation !== this.edGalaxyGeneration) {
+          return;
+        }
         // Remap API response to expected structure for edGalaxyData
         const hasSimbad = result.simbad_name || result.simbad_ident
           || result.ra_j2000 !== undefined || result.dec_j2000 !== undefined;
@@ -166,8 +176,13 @@ export class HomeComponent implements OnInit, OnDestroy {
           } : undefined
         });
       })
-      // Even if the Simbad API fails, still populate edGalaxyData with PGName.
-      .catch(() => setFallback());
+      // Even if the Simbad API fails, still populate edGalaxyData with PGName —
+      // but only while this request is still the current one.
+      .catch(() => {
+        if (generation === this.edGalaxyGeneration) {
+          setFallback();
+        }
+      });
   }
 
   updateEdGalaxyData() {
@@ -741,6 +756,11 @@ export class HomeComponent implements OnInit, OnDestroy {
     if (isDifferentSystem || !this.edastroData()) {
       this.appService.getEdastroData(data.system.id64)
         .then(edastroData => {
+          // Ignore a late response once the user has loaded a different system,
+          // or it would show this system's summary/image/background on another.
+          if (this.data()?.system?.id64 !== data.system.id64) {
+            return;
+          }
           if (edastroData && (edastroData.name || edastroData.summary || edastroData.mainImage)) {
             // Sanitize the untrusted EDAstro URLs: the image flows into both an
             // <img src> and the page-background `url(...)` (which bypasses Angular's


### PR DESCRIPTION
## What

Fixes a cross-system data-bleed bug: switching systems while a slow SIMBAD or EDAstro fetch is in flight let the late response overwrite the newer system's data — showing system A's SIMBAD name/RA/Dec/PGName and A's EDAstro summary/POI/background image on system B's page.

## How

- **SIMBAD** (`fetchEdGalaxyData`): a monotonic `edGalaxyGeneration` token; the async `.then`/`.catch` apply their result only while still the current request. The token bumps *before* the procedural-system early return, so a procedural fallback also invalidates a prior in-flight lookup.
- **EDAstro** (`processBodies`): the late `.then` bails unless `data()`'s id64 still matches the system it was fetched for.

## Tests

Two regression tests resolve the superseded request *after* the new system loads and assert the new system's data survives (name and background). Both were confirmed to fail without the guards.

`npm run build` clean; unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
