### PR TITLE
a11y: accessible names for icon-only controls & signal badges

### DIFF
--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.spec.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.spec.ts
@@ -85,4 +85,10 @@ describe('ConvertIconComponent', () => {
     }
     expect(opened).toHaveLength(0);
   });
+
+  it('exposes a value-specific accessible name so screen readers can tell the buttons apart', () => {
+    render('length', 6371, 'Orbital distance');
+    const icon = fixture.nativeElement.querySelector('.convert-icon');
+    expect(icon?.getAttribute('aria-label')).toBe('Show Orbital distance in other units');
+  });
 });

--- a/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
+++ b/src/app/dialogs/unit-conversion-dialog/convert-icon.component.ts
@@ -19,6 +19,7 @@ import type { UnitConversionDialogData } from './unit-conversion-dialog.componen
   selector: 'app-convert-icon',
   template: `<fa-icon class="convert-icon clickable"
                       matTooltip="Show in other units"
+                      [attr.aria-label]="'Show ' + label() + ' in other units'"
                       [icon]="faRightLeft"
                       (click)="open($event)"></fa-icon>`,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -102,52 +102,52 @@
       @if (getRocheExcess() !== null) {
       <span class="badge badge-red"
         [matTooltip]="'Roche limit exceeded by ' + (getRocheExcess()! | number:'0.0-0') + ' km'">
-        <img alt="" src="assets/icons/roche.svg" style="width: 12px; height: 12px; filter: brightness(0);" />
+        <img alt="Roche limit exceeded" src="assets/icons/roche.svg" style="width: 12px; height: 12px; filter: brightness(0);" />
       </span>
       }
       @if ((geologySignals.length || geologySignalCount) && body().bodyData.type !== 'Star') {
       <div matTooltip="Geological signals">
-        <img alt="" src="assets/icons/Geology.svg" />
+        <img alt="Geological signals" src="assets/icons/Geology.svg" />
       </div>
       }
       @if ((biologySignals.length || biologySignalCount) && body().bodyData.type !== 'Star') {
       <div matTooltip="Biological signals">
-        <img alt="" src="assets/icons/Biology.svg" />
+        <img alt="Biological signals" src="assets/icons/Biology.svg" />
       </div>
       }
       @if (thargoidSignals.length || thargoidSignalCount) {
       <div matTooltip="Thargoid signals">
-        <img alt="" src="assets/icons/Thargoid.svg" />
+        <img alt="Thargoid signals" src="assets/icons/Thargoid.svg" />
       </div>
       }
       @if (guardianSignals.length || guardianSignalCount) {
       <div matTooltip="Guardian signals">
-        <img alt="" src="assets/icons/Guardian.svg" />
+        <img alt="Guardian signals" src="assets/icons/Guardian.svg" />
       </div>
       }
       @if (humanSignalCount) {
       <div matTooltip="Human signals">
-        <img alt="" src="assets/icons/Human.svg" />
+        <img alt="Human signals" src="assets/icons/Human.svg" />
       </div>
       }
       @if (body().bodyData.type === 'Ring' && getRingResourceTypes().has('Gemstone')) {
-      <div matTooltip="Contains gemstones">
-        <span style="font-size: 16px;">💎</span>
+      <div matTooltip="Contains gemstones" role="img" aria-label="Contains gemstones">
+        <span style="font-size: 16px;" aria-hidden="true">💎</span>
       </div>
       }
       @if (body().bodyData.type === 'Ring' && getRingResourceTypes().has('Metal')) {
-      <div matTooltip="Contains metals">
-        <span style="font-size: 16px;">⚙️</span>
+      <div matTooltip="Contains metals" role="img" aria-label="Contains metals">
+        <span style="font-size: 16px;" aria-hidden="true">⚙️</span>
       </div>
       }
       @if (body().bodyData.type === 'Ring' && getRingResourceTypes().has('Mineral')) {
-      <div matTooltip="Contains minerals">
-        <span style="font-size: 16px;">🪨</span>
+      <div matTooltip="Contains minerals" role="img" aria-label="Contains minerals">
+        <span style="font-size: 16px;" aria-hidden="true">🪨</span>
       </div>
       }
       @if (body().bodyData.type === 'Ring' && getRingResourceTypes().has('Fuel')) {
-      <div matTooltip="Contains fuel">
-        <span style="font-size: 16px;">⚡</span>
+      <div matTooltip="Contains fuel" role="img" aria-label="Contains fuel">
+        <span style="font-size: 16px;" aria-hidden="true">⚡</span>
       </div>
       }
       @if (expandable && !expanded()) {


### PR DESCRIPTION
## What

Gives icon-only controls and signal badges accessible names, so screen-reader users aren't tabbing through nameless controls.

## Changes

- **Convert (⇄) buttons**: `aria-label` derived from the value's label (e.g. "Show Orbital period in other units"), so the many per-row buttons are distinguishable rather than all announcing the same thing.
- **Header signal badges** (previously `<img alt="">` / bare emoji inside mouse-only `matTooltip` divs, invisible to assistive tech): meaningful `alt` on the roche/Geology/Biology/Thargoid/Guardian/Human images; `role="img"` + `aria-label` on the emoji ring-resource badges, with the emoji itself `aria-hidden`.
- **Left decorative**: the detail-section icons keep `alt=""` — they sit beside their visible text labels, so a name there would be redundant.

Adds a test pinning the convert-icon accessible name. Unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
