### PR TITLE
Harden deploy pipeline: SHA-pin Actions + fail-closed e2e network

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,12 +28,17 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
+      # Actions are pinned to commit SHAs (not mutable major tags) so a tag-move on a
+      # third-party action can't silently run new code in this pages:write / id-token
+      # deploy job. The trailing comment records the human-readable version — bump both
+      # together when updating. (configure-pages is a major behind its siblings; kept on
+      # v3 here to avoid an untested behaviour change — bump separately if desired.)
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 11
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
       - run: pnpm install
@@ -41,12 +46,11 @@ jobs:
       - run: pnpm run build #-- --base-href "/canonn-signals/"
       - run: echo 'signals.canonn.tech' > dist/CNAME
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@b8130d9ab958b325bbde9786d62f2c97a9885a0e # v3.0.7
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          # Upload entire repository
           path: 'dist/'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/e2e/support/system-fixture.ts
+++ b/e2e/support/system-fixture.ts
@@ -85,6 +85,21 @@ export interface FixtureOptions {
 export async function loadFixtureSystem(page: Page, opts: FixtureOptions): Promise<void> {
   const fixturePath = path.join(FIXTURES_DIR, opts.fixture);
 
+  // Fail-closed catch-all: block any request to a non-local host that isn't explicitly
+  // stubbed below. Registered first so the specific stubs (added after) take precedence —
+  // Playwright checks route handlers in reverse registration order. This keeps the
+  // "deterministic and offline" contract real: a newly-added remote endpoint surfaces as
+  // a broken test instead of silently reaching the live internet (Canonn/EDAstro/SIMBAD/
+  // analytics) and making specs pass or fail on live data. Same-origin requests — the dev
+  // server, its JS chunks and local assets — pass through untouched.
+  await page.route('**/*', (route) => {
+    const { hostname } = new URL(route.request().url());
+    if (hostname === 'localhost' || hostname === '127.0.0.1') {
+      return route.continue();
+    }
+    return route.abort();
+  });
+
   await page.route('**/query/codex/biostats*', (route) => route.fulfill({ path: fixturePath }));
   await page.route('**/query/typeahead*', (route) =>
     route.fulfill({ json: { min_max: [{ name: opts.systemName, id64: opts.id64 }] } }),


### PR DESCRIPTION
## What

Two supply-chain / test-hygiene hardening changes for the deploy pipeline.

## Changes

- **Pin GitHub Actions to commit SHAs** (`.github/workflows/main.yml`). The deploy job holds `pages:write` + `id-token:write`, so a moved major tag on any third-party action could run new code with those privileges. Each of the six actions is pinned to the commit its major tag currently resolves to, with the human-readable version in a trailing comment (verified each SHA↔version against the GitHub tags API). No behaviour change. `configure-pages` is kept on v3 deliberately (a bump is a separate, untested change).
- **Fail-closed e2e network catch-all** (`e2e/support/system-fixture.ts`). `loadFixtureSystem` stubbed six endpoints but had no catch-all, so a newly-added remote endpoint would silently reach the live internet and make "deterministic, offline" specs pass or fail on live data. Adds a catch-all — registered first, so the specific stubs still win under Playwright's reverse-order matching — that lets localhost through and aborts any other host. Verified `e2e/merope.spec.ts` still green.

> Note: an earlier draft of this branch also added a CSP `<meta>` tag; it was dropped as not worth the maintenance/verification cost for a static SPA that renders arbitrary external images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
