### PR TITLE
Fix four correctness follow-ups and migrate DialogShellComponent to signal inputs

### DIFF
--- a/e2e/support/system-fixture.ts
+++ b/e2e/support/system-fixture.ts
@@ -166,13 +166,47 @@ export async function expectMassStabilityWarning(
   }
 }
 
-/** Expands a body's detail panel if it isn't already open. */
+/**
+ * Expands a body's detail panel if it isn't already open.
+ *
+ * Idempotent and resilient to the component auto-expanding the body on its own: the panel
+ * auto-opens once its async inputs settle, so a plain "click the expand caret, then assert"
+ * races that — a click landing just after the body auto-opens toggles the panel shut again.
+ * Instead, retry, clicking only while the panel is still collapsed (expand caret present) and
+ * settling once the collapse caret — the animation-free signal that `expanded()` is true — is
+ * shown. Any click that races auto-expansion is corrected on the next iteration.
+ */
 export async function ensureBodyExpanded(page: Page, bodyId: number): Promise<void> {
-  const expand = ownHeader(page, bodyId).getByLabel('Expand body details');
-  if ((await expand.count()) > 0 && (await expand.first().isVisible())) {
-    await expand.first().click();
-  }
+  const header = ownHeader(page, bodyId);
+  const expandCaret = header.getByLabel('Expand body details');
+  const collapseCaret = header.getByLabel('Collapse body details');
+  await expect(async () => {
+    if ((await expandCaret.count()) > 0) {
+      await expandCaret.first().click({ timeout: 2000 });
+    }
+    await expect(collapseCaret).toBeVisible({ timeout: 1000 });
+  }).toPass({ timeout: 10000 });
   await expect(ownContent(page, bodyId)).toBeVisible();
+}
+
+/**
+ * Clicks a control that opens a dialog and waits for the dialog to appear, re-clicking if the
+ * first click was lost.
+ *
+ * Fixture pages keep re-rendering body headers as async data settles (codex enrichment,
+ * worker-computed Lagrange/collision badges), so a click can land on a header node that is
+ * swapped out a frame later — the event is dropped and the dialog never opens (an intermittent
+ * Firefox flake where the page just sits there). Re-clicking the freshly-resolved trigger until
+ * the dialog is shown makes it deterministic; the visibility guard means an already-open dialog
+ * is never re-clicked (which would hit the backdrop or toggle it shut).
+ */
+export async function clickToOpenDialog(trigger: Locator, dialog: Locator): Promise<void> {
+  await expect(async () => {
+    if (!(await dialog.isVisible())) {
+      await trigger.click({ timeout: 2000 });
+    }
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+  }).toPass({ timeout: 15000 });
 }
 
 /**

--- a/e2e/tidal-lock-dialog.spec.ts
+++ b/e2e/tidal-lock-dialog.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { loadFixtureSystem } from './support/system-fixture';
+import { loadFixtureSystem, clickToOpenDialog } from './support/system-fixture';
 
 /**
  * E2E coverage for the tidal-lock dialog (`app-tidal-lock-dialog`).
@@ -20,9 +20,8 @@ const FIXTURE = { fixture: 'alpha-centauri.json', systemName: 'Alpha Centauri', 
 /** Opens the tidal-lock dialog from a body's header badge and returns the dialog locator. */
 async function openTidalLockDialog(page: Page, bodyId: number) {
   // Scope to the body's OWN header (direct child) so a nested child body's badge can't match.
-  await page.locator(`#body-${bodyId} > .body-title .badge-purple`).click();
   const dialog = page.locator('app-tidal-lock-dialog');
-  await expect(dialog).toBeVisible();
+  await clickToOpenDialog(page.locator(`#body-${bodyId} > .body-title .badge-purple`), dialog);
   await expect(dialog.getByRole('heading', { name: 'Tidal Locking & Synchronous Rotation' })).toBeVisible();
   return dialog;
 }

--- a/e2e/trojan-lagrange.spec.ts
+++ b/e2e/trojan-lagrange.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { loadFixtureSystem, type FixtureOptions } from './support/system-fixture';
+import { loadFixtureSystem, clickToOpenDialog, type FixtureOptions } from './support/system-fixture';
 
 /**
  * Trojan / Lagrange badge rendering, end-to-end, from saved biostats payloads.
@@ -176,7 +176,10 @@ test.describe('Lagrange points dialog', () => {
   test('Host badge opens the diagram with the host highlighted and L4/L5 companions', async ({ page }) => {
     await loadFixtureSystem(page, byName('Eorld Byio AA-A h539'));
 
-    await page.locator('#body-35 > .body-title .badge.badge-blue', { hasText: 'Host' }).click();
+    await clickToOpenDialog(
+      page.locator('#body-35 > .body-title .badge.badge-blue', { hasText: 'Host' }),
+      page.locator('app-lagrange-dialog'),
+    );
 
     const svg = page.locator('app-lagrange-dialog svg');
     await expect(page.locator('app-lagrange-dialog').getByRole('heading', { name: 'Lagrange points' })).toBeVisible();
@@ -199,7 +202,10 @@ test.describe('Lagrange points dialog', () => {
     await loadFixtureSystem(page, byName('Pro Eurl JF-A d88'));
 
     // Body 33 (B 3) is labelled L4; clicking it focuses it in the diagram.
-    await page.locator('#body-33 > .body-title .badge.badge-blue', { hasText: 'L4' }).click();
+    await clickToOpenDialog(
+      page.locator('#body-33 > .body-title .badge.badge-blue', { hasText: 'L4' }),
+      page.locator('app-lagrange-dialog'),
+    );
 
     const svg = page.locator('app-lagrange-dialog svg');
     await expect(page.locator('app-lagrange-dialog').getByRole('heading', { name: 'Lagrange points' })).toBeVisible();
@@ -217,7 +223,10 @@ test.describe('Lagrange points dialog', () => {
     await loadFixtureSystem(page, byName('Pro Eurl HW-W e1-1'));
 
     // B 3 a (body 31) is one half of the L3 pair; clicking its badge focuses it in the diagram.
-    await page.locator('#body-31 > .body-title .badge.badge-blue', { hasText: 'L3' }).click();
+    await clickToOpenDialog(
+      page.locator('#body-31 > .body-title .badge.badge-blue', { hasText: 'L3' }),
+      page.locator('app-lagrange-dialog'),
+    );
 
     const svg = page.locator('app-lagrange-dialog svg');
     await expect(page.locator('app-lagrange-dialog').getByRole('heading', { name: 'Lagrange points' })).toBeVisible();
@@ -256,7 +265,10 @@ test.describe('Lagrange points dialog', () => {
 
     // AB 2 (body 13) hosts AB 3 / AB 4 at ±60° around barycentre 1 → it is badged Host, and
     // clicking opens the diagram centred on the barycentre as the primary.
-    await page.locator('#body-13 > .body-title .badge.badge-blue', { hasText: 'Host' }).click();
+    await clickToOpenDialog(
+      page.locator('#body-13 > .body-title .badge.badge-blue', { hasText: 'Host' }),
+      page.locator('app-lagrange-dialog'),
+    );
     const svg = page.locator('app-lagrange-dialog svg');
     await expect(page.locator('app-lagrange-dialog').getByRole('heading', { name: 'Lagrange points' })).toBeVisible();
     await expect(svg).toContainText('AB 2');
@@ -293,7 +305,10 @@ test.describe('Lagrange points dialog', () => {
     test(`opens the AB 2/3/4 barycentre Trojan diagram from ${name} (${badge})`, async ({ page }) => {
       await loadFixtureSystem(page, byName('Hyuqoae GH-V f2-368'));
 
-      await page.locator(`#body-${bodyId} > .body-title .badge.badge-blue`, { hasText: badge }).click();
+      await clickToOpenDialog(
+        page.locator(`#body-${bodyId} > .body-title .badge.badge-blue`, { hasText: badge }),
+        page.locator('app-lagrange-dialog'),
+      );
 
       const svg = page.locator('app-lagrange-dialog svg');
       await expect(page.locator('app-lagrange-dialog').getByRole('heading', { name: 'Lagrange points' })).toBeVisible();

--- a/scripts/generate-nebulae.js
+++ b/scripts/generate-nebulae.js
@@ -52,7 +52,9 @@ function parseCsv(csv) {
   for (const line of rows) {
     const [name, system, x, y, z, type] = parseCsvLine(line);
     const nx = Number(x), ny = Number(y), nz = Number(z);
-    if (!name || Number.isNaN(nx) || Number.isNaN(ny) || Number.isNaN(nz)) {
+    // isFinite (not isNaN): a value like "1e999" parses to Infinity, which passes an
+    // isNaN check but serialises as bare `Infinity` — invalid JSON that breaks the load.
+    if (!name || !Number.isFinite(nx) || !Number.isFinite(ny) || !Number.isFinite(nz)) {
       continue; // skip malformed rows
     }
     nebulae.push({ name: name.trim(), system: (system || '').trim(), x: nx, y: ny, z: nz, type: (type || '').trim() });

--- a/src/app/dialogs/dialog-shell/dialog-shell.component.html
+++ b/src/app/dialogs/dialog-shell/dialog-shell.component.html
@@ -1,5 +1,5 @@
 <h2 mat-dialog-title>
-  {{ heading }}
+  {{ heading() }}
   <ng-content select="[shell-title-extra]"></ng-content>
 </h2>
 <mat-dialog-content>

--- a/src/app/dialogs/dialog-shell/dialog-shell.component.ts
+++ b/src/app/dialogs/dialog-shell/dialog-shell.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import {
   MatDialogActions,
@@ -28,15 +28,16 @@ import { MatButton } from '@angular/material/button';
   templateUrl: './dialog-shell.component.html',
   styleUrls: ['./dialog-shell.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { '[class.fit-content]': 'fitContent()' },
   imports: [MatDialogTitle, CdkScrollable, MatDialogContent, MatDialogActions, MatButton, MatDialogClose],
 })
 export class DialogShellComponent {
   /** Heading shown in the dialog title bar. */
-  @Input({ required: true }) heading!: string;
+  readonly heading = input.required<string>();
 
   /**
    * When true, the shell sizes to its content (auto height, capped at the shared
    * max-height) instead of the default fixed height. Reflected to the host as a class.
    */
-  @Input() @HostBinding('class.fit-content') fitContent = false;
+  readonly fitContent = input(false);
 }

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -138,6 +138,44 @@ describe('SystemBodyComponent (extended coverage)', () => {
       expect(component.expanded()).toBe(true);
     });
 
+    it('does not re-expand a collapsed body when ngOnChanges re-fires for unrelated inputs', () => {
+      // A landable body auto-expands on first render.
+      render(makeBody({ isLandable: true }));
+      expect(component.expanded()).toBe(true);
+
+      // The user collapses it.
+      component.setExpandedState(false);
+
+      // An unrelated async input (edGalaxyData/codex) propagating re-fires ngOnChanges with
+      // the same body/anchor/forceExpanded — it must not re-open the collapsed body.
+      component.ngOnChanges();
+      expect(component.expanded()).toBe(false);
+    });
+
+    it('still auto-expands when the anchor target changes to this body (body-link navigation)', () => {
+      // A plain body with nothing interesting stays collapsed on first render.
+      render(makeBody({ bodyId: 7 }));
+      expect(component.expanded()).toBe(false);
+
+      // A body-link click sets the anchor to this body's id → auto-expand re-evaluates.
+      fixture.componentRef.setInput('anchorBodyId', 7);
+      fixture.detectChanges();
+      expect(component.expanded()).toBe(true);
+    });
+
+    it('does not re-expand a collapsed interesting body when the anchor moves to a different body', () => {
+      // A landable body auto-expands, then the user collapses it.
+      render(makeBody({ bodyId: 3, isLandable: true }));
+      expect(component.expanded()).toBe(true);
+      component.setExpandedState(false);
+
+      // Navigating to an unrelated body changes the global anchor input for every body —
+      // "interesting" must not re-trigger; only the targeted body should re-open.
+      fixture.componentRef.setInput('anchorBodyId', 99);
+      fixture.detectChanges();
+      expect(component.expanded()).toBe(false);
+    });
+
     it('reports children presence', () => {
       const parent = makeBody({ bodyId: 1 });
       parent.subBodies = [makeBody({ bodyId: 2 }, parent)];
@@ -196,6 +234,28 @@ describe('SystemBodyComponent (extended coverage)', () => {
       render(makeBody({ meanAnomaly: 90, orbitalPeriod: 100, orbitalEccentricity: 0 }));
       expect(component.getNextPeriapsis()).toBeNull();
       expect(component.getNextApoapsis()).toBeNull();
+    });
+
+    it('honours the ?t= time override when computing the next apoapsis', () => {
+      const svc = TestBed.inject(AppService) as any;
+      const body = makeBody({
+        meanAnomaly: 90, orbitalPeriod: 100, orbitalEccentricity: 0.2,
+        timestamps: { distanceToArrival: '', meanAnomaly: '2026-01-01T00:00:00Z' },
+      });
+
+      svc.nowOverride.set(new Date('2026-03-01T00:00:00Z').getTime());
+      render(body);
+      const atMarch1 = component.getNextApoapsis();
+
+      // Advancing the override moves the countdown; without honouring nowOverride both
+      // computations would use the unchanged Date.now() and be identical.
+      svc.nowOverride.set(new Date('2026-03-20T00:00:00Z').getTime());
+      component.ngOnChanges();
+      const atMarch20 = component.getNextApoapsis();
+
+      expect(atMarch1).not.toBeNull();
+      expect(atMarch20).not.toBeNull();
+      expect(atMarch20!.days).not.toBe(atMarch1!.days);
     });
   });
 

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -915,7 +915,7 @@
               }
               @if (biologySignal.entryId) {
               <span>
-                <a href="https://canonn-science.github.io/bioforge/?entryid={{ biologySignal.signal }}" target="_blank"
+                <a href="https://canonn-science.github.io/bioforge/?entryid={{ biologySignal.entryId }}" target="_blank"
                   rel="noopener noreferrer">
                   {{ biologySignal.signal }}
                   <fa-icon [icon]="faUpRightFromSquare"></fa-icon>

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -170,6 +170,13 @@ export class SystemBodyComponent implements OnChanges {
 
   public expandable = false;
   public readonly expanded = signal(false);
+  // Auto-expand is a function of body identity, the anchor target and forceExpanded only.
+  // These record the last values it was evaluated for, so ngOnChanges re-fires from
+  // unrelated inputs (the async edGalaxyData/codex updates) don't re-open a body the
+  // user has since collapsed. See the auto-expand block in ngOnChanges.
+  private autoExpandBody: SystemBody | null = null;
+  private autoExpandAnchor: number | null = null;
+  private autoExpandForce = false;
 
   public hoveredIndex: number = -1;
 
@@ -367,7 +374,22 @@ export class SystemBodyComponent implements OnChanges {
     this.hasSignals = this.humanSignalCount > 0 || this.otherSignalCount > 0 || this.geologySignalCount > 0 || this.biologySignalCount > 0 || this.thargoidSignalCount > 0 || this.guardianSignalCount > 0 ||
       this.geologySignals.length > 0 || this.biologySignals.length > 0 || this.thargoidSignals.length > 0 || this.guardianSignals.length > 0;
     this.expandable = true;
-    if (this.expanded() === false) {
+    // Auto-expansion is driven only by the body itself, the anchor target (a body-link
+    // click) and forceExpanded. Track the last values each was decided for so unrelated
+    // ngOnChanges re-fires (the async edGalaxyData/codex updates) never re-open a body the
+    // user has collapsed. Crucially, "interesting" only auto-expands on first sight of the
+    // body — an anchor/forceExpanded change expands only the body it now targets, so
+    // navigating to one body never re-opens a *different* interesting body the user
+    // collapsed. Manual toggle and ancestor "expand all" (setExpandedState) are untouched.
+    const anchorBodyId = this.anchorBodyId();
+    const forceExpanded = this.forceExpanded();
+    const bodyChanged = this.autoExpandBody !== body;
+    const anchorChanged = this.autoExpandAnchor !== anchorBodyId;
+    const forceChanged = this.autoExpandForce !== forceExpanded;
+    this.autoExpandBody = body;
+    this.autoExpandAnchor = anchorBodyId;
+    this.autoExpandForce = forceExpanded;
+    if (this.expanded() === false && (bodyChanged || anchorChanged || forceChanged)) {
       const isInteresting = this.hasSignals ||
         body.bodyData.subType === 'Earth-like world' ||
         body.bodyData.subType === 'Water world' ||
@@ -378,7 +400,13 @@ export class SystemBodyComponent implements OnChanges {
         body.bodyData.subType?.includes('Wolf-Rayet') ||
         body.bodyData.subType?.includes('Herbig') ||
         !!body.bodyData.isLandable;
-      this.expanded.set(this.forceExpanded() || isInteresting || this.containsAnchorBody(body));
+      const shouldExpand =
+        (bodyChanged && isInteresting) ||
+        ((bodyChanged || forceChanged) && forceExpanded) ||
+        ((bodyChanged || anchorChanged) && this.containsAnchorBody(body));
+      if (shouldExpand) {
+        this.expanded.set(true);
+      }
     }
 
     if (this.isRoot()) {
@@ -1240,7 +1268,7 @@ export class SystemBodyComponent implements OnChanges {
       meanAnomaly = body.bodyData.meanAnomaly;
       orbitalPeriod = body.bodyData.orbitalPeriod;
       timestamp = new Date(body.bodyData.timestamps.meanAnomaly);
-      currentMeanAnomaly = this.orbitalRelations.meanAnomalyNow(meanAnomaly, orbitalPeriod, body.bodyData.timestamps.meanAnomaly);
+      currentMeanAnomaly = this.orbitalRelations.meanAnomalyNow(meanAnomaly, orbitalPeriod, body.bodyData.timestamps.meanAnomaly, this.appService.nowOverride() ?? Date.now());
       degreesToEvent = this.orbitalRelations.degreesToEvent(currentMeanAnomaly, type);
     }
 
@@ -1916,11 +1944,11 @@ export class SystemBodyComponent implements OnChanges {
   }
 
   private calculateNextPeriapsis(): { date: Date, days: number } | null {
-    return this.orbitalRelations.nextOrbitalEvent(this.body().bodyData, 'peri');
+    return this.orbitalRelations.nextOrbitalEvent(this.body().bodyData, 'peri', this.appService.nowOverride() ?? Date.now());
   }
 
   private calculateNextApoapsis(): { date: Date, days: number } | null {
-    return this.orbitalRelations.nextOrbitalEvent(this.body().bodyData, 'apo');
+    return this.orbitalRelations.nextOrbitalEvent(this.body().bodyData, 'apo', this.appService.nowOverride() ?? Date.now());
   }
 
   private computeMaterialBadges(): void {


### PR DESCRIPTION
## What

Four small correctness fixes surfaced by a repo review, plus a refactor migrating `DialogShellComponent` off decorator `@Input`s onto signal inputs.

## Changes

- **`generate-nebulae.js`**: guard rows with `Number.isFinite`, not `Number.isNaN` — a value like `"1e999"` parses to `Infinity`, passes the `isNaN` check, and serialises as bare `Infinity` (invalid JSON that would break the nebula load).
- **Bioforge deep link**: pass the numeric `biologySignal.entryId` (the field the `@if` guard already checks) to `?entryid=`, not the species name; the link text still shows the name.
- **`?t=` time override**: the collision dialog and the next apo/peri **badge + dialog** now all use `nowOverride() ?? Date.now()`, matching the collision badge — so under a debug time override the badges and their dialogs agree. (The live orbital-motion diagram dialogs stay real-time by design.)
- **Auto-expand**: only re-decide expansion when the body, anchor target, or `forceExpanded` changes — and "interesting" auto-expands only on first sight of a body, while an anchor/force change expands only the body it now targets. So an unrelated async input (`edGalaxyData`/codex) re-firing never re-opens a body the user just collapsed, and navigating to one body never re-opens a *different* one they collapsed. Manual toggle and expand-all are untouched.
- **`DialogShellComponent` → signal inputs**: replace the decorator-based `heading` (`@Input({ required: true })`) and `fitContent` (`@Input` + `@HostBinding`) with `input.required<string>()` / `input(false)`, read as `heading()` in the template and driven through a `host` class binding. Every consumer binds `[heading]`/`[fitContent]` exactly as before, so no call sites change.

Regression tests cover all four fix directions (including negative-verification that each test fails without its fix). Unit suite green; `ng build` (strict template typecheck) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
