### PR TITLE
fix: de-flake OrbitalWorkerService spec via a proxy seam

### DIFF
--- a/src/app/data/orbital-worker.service.spec.ts
+++ b/src/app/data/orbital-worker.service.spec.ts
@@ -1,42 +1,27 @@
-import * as Comlink from 'comlink';
 import { OrbitalWorkerService } from './orbital-worker.service';
 import { OrbitalRelationsCore } from './orbital-relations.core';
 import { SystemBody, CanonnBiostatsBody } from '../home/home.component';
 
-// Comlink's ESM exports can't be spied on (vitest limitation), so mock the module: `wrap` returns
-// a stub proxy we can assert against, driving the service's worker path without a real thread. The
-// other tests in this file never reach Comlink (Worker is stubbed undefined → inline path).
-const { proxyMock } = vi.hoisted(() => ({
-  proxyMock: {
-    detectCollisionStatus: vi.fn(),
-    simultaneousCollisionsWithin: vi.fn(),
-    upcomingContactsWithin: vi.fn(),
-    separationSeries: vi.fn(),
-  },
-}));
-vi.mock('comlink', () => ({ wrap: vi.fn(() => proxyMock), expose: vi.fn() }));
-
 /**
- * The main-thread facade. Under jsdom there is no `Worker`, so every method takes the inline
- * fallback path — running the framework-free engine on the live tree and resolving a Promise.
- * These tests assert the async API returns exactly what the core would, which is also how the
- * facade keeps the engine's coverage without a real thread. (The real Comlink wire is exercised
- * separately in collision-worker-api.spec.ts.)
+ * The main-thread facade. Its `createProxy()` seam is stubbed per test so these cases never touch
+ * the global `Worker` or the real `comlink` module — both of which are shared, and so leak, across
+ * files under the Angular builder's non-isolated Vitest default (that shared state made this spec
+ * flaky against collision-worker-api.spec.ts, which drives the real Comlink wire).
+ *
+ * The inline-fallback cases stub the seam to null and assert the async API returns exactly what the
+ * core would; the worker-path cases stub it with a fake proxy and assert every method is routed
+ * through that single proxy instead of the inline core.
  */
-describe('OrbitalWorkerService (inline fallback)', () => {
+describe('OrbitalWorkerService', () => {
   const now = Date.parse('2026-06-27T00:00:00Z');
-  let service: OrbitalWorkerService;
   let core: OrbitalRelationsCore;
 
   beforeEach(() => {
-    // Force the no-Worker path deterministically, regardless of the test environment.
-    vi.stubGlobal('Worker', undefined);
-    service = new OrbitalWorkerService();
     core = new OrbitalRelationsCore();
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    vi.restoreAllMocks(); // drop the per-instance createProxy spies (belt-and-braces under isolate:false)
   });
 
   function makeFamily(children: Partial<CanonnBiostatsBody>[]): SystemBody[] {
@@ -68,103 +53,135 @@ describe('OrbitalWorkerService (inline fallback)', () => {
     ]);
   }
 
-  it('resolves detectCollisionStatus with the same result as the core', async () => {
-    const [a] = collidingPair();
-    const result = await service.detectCollisionStatus(a, now);
-    expect(result.isCandidate).toBe(true);
-    expect(result).toEqual(core.detectCollisionStatus(a, now));
-  });
+  /** A service whose worker seam is forced off, so every method runs the engine inline. */
+  function inlineService(): OrbitalWorkerService {
+    const svc = new OrbitalWorkerService();
+    vi.spyOn(svc as unknown as { createProxy(): unknown }, 'createProxy').mockReturnValue(null);
+    return svc;
+  }
 
-  it('resolves upcomingContactsWithin identically to the core', async () => {
-    const [a] = collidingPair();
-    const result = await service.upcomingContactsWithin(a, 365, now);
-    expect(result.length).toBeGreaterThan(0);
-    expect(result).toEqual(core.upcomingContactsWithin(a, 365, now));
-  });
-
-  it('resolves separationSeries (flat bodyData, no tree) identically to the core', async () => {
-    const [a, b] = collidingPair();
-    const endMs = now + 200 * 24 * 60 * 60 * 1000;
-    const result = await service.separationSeries(a.bodyData, b.bodyData, now, endMs, 50);
-    expect(result.length).toBe(50);
-    expect(result).toEqual(core.separationSeries(a.bodyData, b.bodyData, now, endMs, 50));
-  });
-
-  it('resolves simultaneousCollisionsWithin identically to the core', async () => {
-    const [a] = collidingPair();
-    const result = await service.simultaneousCollisionsWithin(a, 180, now);
-    expect(result).toEqual(core.simultaneousCollisionsWithin(a, 180, now));
-  });
-
-  it('falls back cleanly for a parentless body (nothing to serialize → not a candidate)', async () => {
-    const orphan: SystemBody = {
-      bodyData: { bodyId: 1, name: 'Lonely', id64: 0n, subType: '', type: 'Planet' } as CanonnBiostatsBody,
-      subBodies: [],
-      parent: null,
-    };
-    const result = await service.detectCollisionStatus(orphan, now);
-    expect(result.isCandidate).toBe(false);
-  });
-
-  describe('worker path (Worker available)', () => {
-    /** Minimal stand-in for the browser Worker; the URL/options are ignored (no chunk is loaded). */
-    class FakeWorker {
-      constructor(_url: URL, _opts: unknown) { /* no-op */ }
-    }
+  describe('inline fallback (no worker)', () => {
+    let service: OrbitalWorkerService;
 
     beforeEach(() => {
-      vi.clearAllMocks(); // reset call counts between worker-path cases (keeps mocked implementations)
+      service = inlineService();
     });
 
-    it('routes every method through a single shared Comlink proxy instead of the inline core', async () => {
-      vi.stubGlobal('Worker', FakeWorker);
-      proxyMock.detectCollisionStatus.mockResolvedValue({
-        isCandidate: true, partnerName: 'From Worker', synodicPeriodDays: 1,
-        nextCollision: null, upcomingCollisions: [], combinedRadiiKm: 1, simultaneousPartners: [],
-      });
-      proxyMock.simultaneousCollisionsWithin.mockResolvedValue([]);
-      proxyMock.upcomingContactsWithin.mockResolvedValue([]);
-      proxyMock.separationSeries.mockResolvedValue([]);
+    it('resolves detectCollisionStatus with the same result as the core', async () => {
+      const [a] = collidingPair();
+      const result = await service.detectCollisionStatus(a, now);
+      expect(result.isCandidate).toBe(true);
+      expect(result).toEqual(core.detectCollisionStatus(a, now));
+    });
 
+    it('resolves upcomingContactsWithin identically to the core', async () => {
+      const [a] = collidingPair();
+      const result = await service.upcomingContactsWithin(a, 365, now);
+      expect(result.length).toBeGreaterThan(0);
+      expect(result).toEqual(core.upcomingContactsWithin(a, 365, now));
+    });
+
+    it('resolves separationSeries (flat bodyData, no tree) identically to the core', async () => {
+      const [a, b] = collidingPair();
+      const endMs = now + 200 * 24 * 60 * 60 * 1000;
+      const result = await service.separationSeries(a.bodyData, b.bodyData, now, endMs, 50);
+      expect(result.length).toBe(50);
+      expect(result).toEqual(core.separationSeries(a.bodyData, b.bodyData, now, endMs, 50));
+    });
+
+    it('resolves simultaneousCollisionsWithin identically to the core', async () => {
+      const [a] = collidingPair();
+      const result = await service.simultaneousCollisionsWithin(a, 180, now);
+      expect(result).toEqual(core.simultaneousCollisionsWithin(a, 180, now));
+    });
+
+    it('falls back cleanly for a parentless body (nothing to serialize → not a candidate)', async () => {
+      const orphan: SystemBody = {
+        bodyData: { bodyId: 1, name: 'Lonely', id64: 0n, subType: '', type: 'Planet' } as CanonnBiostatsBody,
+        subBodies: [],
+        parent: null,
+      };
+      const result = await service.detectCollisionStatus(orphan, now);
+      expect(result.isCandidate).toBe(false);
+    });
+  });
+
+  describe('worker path (proxy available)', () => {
+    /** A fake Comlink proxy; each method resolves the value the shared worker would post back. */
+    function fakeProxy() {
+      return {
+        detectCollisionStatus: vi.fn().mockResolvedValue({
+          isCandidate: true, partnerName: 'From Worker', synodicPeriodDays: 1,
+          nextCollision: null, upcomingCollisions: [], combinedRadiiKm: 1, simultaneousPartners: [],
+        }),
+        simultaneousCollisionsWithin: vi.fn().mockResolvedValue([]),
+        upcomingContactsWithin: vi.fn().mockResolvedValue([]),
+        separationSeries: vi.fn().mockResolvedValue([]),
+      };
+    }
+
+    /** Builds a service whose seam yields `proxy`, and returns both plus the spy on the seam. */
+    function serviceWith(proxy: unknown) {
       const svc = new OrbitalWorkerService();
+      const createSpy = vi.spyOn(svc as unknown as { createProxy(): unknown }, 'createProxy').mockReturnValue(proxy);
+      return { svc, createSpy };
+    }
+
+    it('routes every method through a single shared proxy instead of the inline core', async () => {
+      const proxy = fakeProxy();
+      const { svc, createSpy } = serviceWith(proxy);
       const [a, b] = collidingPair();
 
       const status = await svc.detectCollisionStatus(a, now);
       expect(status.partnerName).toBe('From Worker'); // came from the proxy, not the local core
-      expect(proxyMock.detectCollisionStatus).toHaveBeenCalledOnce();
+      expect(proxy.detectCollisionStatus).toHaveBeenCalledOnce();
 
       await svc.simultaneousCollisionsWithin(a, 180, now);
       await svc.upcomingContactsWithin(a, 180, now);
       await svc.separationSeries(a.bodyData, b.bodyData, now, now + 1000, 10);
-      expect(proxyMock.simultaneousCollisionsWithin).toHaveBeenCalledOnce();
-      expect(proxyMock.upcomingContactsWithin).toHaveBeenCalledOnce();
-      expect(proxyMock.separationSeries).toHaveBeenCalledOnce();
+      expect(proxy.simultaneousCollisionsWithin).toHaveBeenCalledOnce();
+      expect(proxy.upcomingContactsWithin).toHaveBeenCalledOnce();
+      expect(proxy.separationSeries).toHaveBeenCalledOnce();
 
       // The worker + its proxy are created once and reused across every call.
-      expect(Comlink.wrap).toHaveBeenCalledOnce();
+      expect(createSpy).toHaveBeenCalledOnce();
     });
 
-    it('falls back to the inline core when the worker cannot be constructed', async () => {
-      class ThrowingWorker {
-        constructor() { throw new Error('module workers blocked'); }
-      }
-      vi.stubGlobal('Worker', ThrowingWorker);
+    it('still falls back to the inline core when a body has no parent (nothing to serialize)', async () => {
+      const proxy = fakeProxy();
+      const { svc } = serviceWith(proxy);
+      const orphan: SystemBody = {
+        bodyData: { bodyId: 1, name: 'Lonely', id64: 0n, subType: '', type: 'Planet' } as CanonnBiostatsBody,
+        subBodies: [],
+        parent: null,
+      };
 
-      const svc = new OrbitalWorkerService();
+      const result = await svc.detectCollisionStatus(orphan, now);
+      expect(result.isCandidate).toBe(false);
+      expect(proxy.detectCollisionStatus).not.toHaveBeenCalled(); // never crossed the wire
+    });
+
+    it('falls back to the inline core when the proxy cannot be created, and latches (no retry)', async () => {
+      const { svc, createSpy } = serviceWith(null); // createProxy yields null → worker unavailable
       const [a] = collidingPair();
 
-      // Construction throws → getProxy latches unavailable and runs the real engine inline.
       const result = await svc.detectCollisionStatus(a, now);
       expect(result.isCandidate).toBe(true);
       expect(result.partnerName).toBe('Child 2');
       expect(result).toEqual(core.detectCollisionStatus(a, now));
-      expect(Comlink.wrap).not.toHaveBeenCalled();
-      expect(proxyMock.detectCollisionStatus).not.toHaveBeenCalled();
 
-      // A second call does not retry construction (latched) — still inline, still no proxy.
+      // A second call does not retry construction — the unavailable state is latched.
       await svc.upcomingContactsWithin(a, 365, now);
-      expect(Comlink.wrap).not.toHaveBeenCalled();
-      expect(proxyMock.upcomingContactsWithin).not.toHaveBeenCalled();
+      expect(createSpy).toHaveBeenCalledOnce();
     });
+  });
+
+  it('runs inline in a real jsdom environment, where no Worker global exists', async () => {
+    // Exercises the un-stubbed createProxy() seam: jsdom has no `Worker`, so it returns null and the
+    // facade resolves via the inline engine. Guards the production no-worker branch.
+    const svc = new OrbitalWorkerService();
+    const [a] = collidingPair();
+    const result = await svc.detectCollisionStatus(a, now);
+    expect(result).toEqual(core.detectCollisionStatus(a, now));
   });
 });

--- a/src/app/data/orbital-worker.service.ts
+++ b/src/app/data/orbital-worker.service.ts
@@ -34,19 +34,35 @@ export class OrbitalWorkerService {
 
   /** Lazily spins up the shared worker and its Comlink proxy; null when a worker can't be used. */
   private getProxy(): Comlink.Remote<CollisionWorkerApi> | null {
-    if (this.workerUnavailable || typeof Worker === 'undefined') { return null; }
+    if (this.workerUnavailable) { return null; }
     if (!this.proxy) {
-      try {
-        const worker = new Worker(new URL('./collision.worker', import.meta.url), { type: 'module' });
-        this.proxy = Comlink.wrap<CollisionWorkerApi>(worker);
-      } catch {
-        // Module workers unsupported / blocked by CSP / worker URL unresolvable: fall back to running
-        // the engine inline on the main thread rather than leaving collision status permanently blank.
+      this.proxy = this.createProxy();
+      if (!this.proxy) {
+        // No worker available (SSR/jsdom) or its construction failed: latch off so we stop retrying
+        // and run the engine inline on the main thread rather than leaving collision status blank.
         this.workerUnavailable = true;
         return null;
       }
     }
     return this.proxy;
+  }
+
+  /**
+   * Constructs the shared worker and wraps it in a Comlink proxy, or returns null when workers are
+   * unavailable (SSR/jsdom) or blocked (CSP / unresolvable worker URL). Isolated as a `protected`
+   * seam so unit tests can substitute a fake proxy on the instance — the alternative, mocking the
+   * global `Worker` and the `comlink` module, leaks across files under the Angular builder's
+   * non-isolated Vitest default and made these tests flaky. The real Comlink wire is covered by
+   * collision-worker-api.spec.ts.
+   */
+  protected createProxy(): Comlink.Remote<CollisionWorkerApi> | null {
+    if (typeof Worker === 'undefined') { return null; }
+    try {
+      const worker = new Worker(new URL('./collision.worker', import.meta.url), { type: 'module' });
+      return Comlink.wrap<CollisionWorkerApi>(worker);
+    } catch {
+      return null;
+    }
   }
 
   /** Off-thread {@link OrbitalRelationsCore.detectCollisionStatus}. */


### PR DESCRIPTION
## Problem

`OrbitalWorkerService (inline fallback) > worker path > routes every method through a single shared Comlink proxy` fails **intermittently in CI**:

```
AssertionError: expected 'Child 2' to be 'From Worker'
```

The facade ran the inline core (`'Child 2'`) instead of the mocked Comlink proxy (`'From Worker'`). A regression of #100 (the web-worker compute offload).

## Root cause

The Angular unit-test builder configures Vitest with **`isolate: false`** by default (for Karma/Jasmine parity — see `@angular/build` `plugins.js`). With isolation off, every spec shares one module registry and global scope within a worker.

- `orbital-worker.service.spec.ts` drove the worker path with `vi.mock('comlink')` + a global `Worker` stub.
- `collision-worker-api.spec.ts` imports the **real** `comlink` and exercises a live `MessageChannel` round-trip.

The two files' `comlink` module state and the shared `Worker` global raced, depending on how the runner assigned files to workers — a **Heisenbug** (adding a `console.log` flipped the result), which is why it only bit occasionally in CI.

I reproduced it deterministically by forcing a single, non-isolated worker (`isolate:false`, `fileParallelism:false`, `maxWorkers:1`) so the two comlink specs always co-reside — it failed every run; with this fix it passes every run.

## Fix

Extract the `new Worker(new URL(...))` + `Comlink.wrap` creation into a `protected createProxy()` seam on the service. Tests now stub that method **on the instance**:

- worker-path cases → return a fake proxy,
- inline cases → return `null`.

No test touches the global `Worker` or the `comlink` module, so nothing leaks across files regardless of Vitest isolation. Production behaviour is unchanged (the worker chunk still builds and runs), and the real Comlink wire stays covered by `collision-worker-api.spec.ts`.

## Verification

- Deterministic repro (single non-isolated worker): **failed before → 781 pass after**.
- `ng test` (default parallel config): **781 passed / 53 files**.
- `ng build`: clean (pre-existing bundle-budget warning only).
- Coverage: 92.3% lines / 81.4% branch globally (above the 80% bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)