### PR TITLE
Add live Parent Distance row with explanatory dialog

### DIFF
--- a/e2e/alpha-centauri-bodies.spec.ts
+++ b/e2e/alpha-centauri-bodies.spec.ts
@@ -34,21 +34,10 @@ const BODY_SPECS: BodySpec[] = [
           'Semi-major axis': '2,311.74 ls',
           'Orbital eccentricity': '0.5179 Eccentric',
           Apoapsis: '3,508.99 ls',
-          // Day-count to the next apsis. Wall-clock-dependent, but deterministic because
-          // the fixture loader pins `now` to 2026-06-14T00:00:00Z (see loadFixtureSystem).
-          'Next apoapsis': '3,721.9 days',
           Periapsis: '1,114.49 ls',
-          'Next periapsis': '8,396.3 days',
           'Orbital inclination': '79.21°',
           'Argument of periapsis': '116.66°',
           'Ascending node': '-155.15°',
-        },
-        // The day-count above changes with `now`; the tooltip is the fixed event *date*
-        // (now-independent). Timezone is pinned to UTC in playwright.config.ts, so
-        // 2036-08-21 20:55 UTC (= 22:55 CEST) renders verbatim.
-        tooltips: {
-          'Next apoapsis': '2036-08-21 20:55',
-          'Next periapsis': '2049-06-09 07:48',
         },
       },
       {
@@ -62,7 +51,29 @@ const BODY_SPECS: BodySpec[] = [
         },
       },
       { header: 'Atmosphere & Environment', rows: { 'Surface Temperature': '6,557.00 K' } },
-      { header: 'Dynamics', rows: { 'Rotational period': '4.16 days', 'Distance to arrival': '0.00 ls' } },
+      {
+        header: 'Dynamics',
+        rows: {
+          'Rotational period': '4.16 days',
+          'Distance to arrival': '0.00 ls',
+          // Live "right now" distance from the parent (r = a(1 − e²)/(1 + e·cos ν)), propagated
+          // from the recorded mean anomaly to the fixture's pinned `now` — deterministic for the
+          // same reason as the day-counts below. Sits between Periapsis (1,114.49 ls) and
+          // Apoapsis (3,508.99 ls) in the Orbit section above, as it must.
+          'Parent distance': '1,771.13 ls',
+          // Day-count to the next apsis. Wall-clock-dependent, but deterministic because
+          // the fixture loader pins `now` to 2026-06-14T00:00:00Z (see loadFixtureSystem).
+          'Next apoapsis': '3,721.9 days',
+          'Next periapsis': '8,396.3 days',
+        },
+        // The day-count above changes with `now`; the tooltip is the fixed event *date*
+        // (now-independent). Timezone is pinned to UTC in playwright.config.ts, so
+        // 2036-08-21 20:55 UTC (= 22:55 CEST) renders verbatim.
+        tooltips: {
+          'Next apoapsis': '2036-08-21 20:55',
+          'Next periapsis': '2049-06-09 07:48',
+        },
+      },
       {
         header: 'Stellar Properties',
         rows: { 'Spectral class': 'G2', 'Luminosity class': 'V', 'Absolute magnitude': '4.36' },

--- a/src/app/data/orbital-diagrams.spec.ts
+++ b/src/app/data/orbital-diagrams.spec.ts
@@ -283,6 +283,13 @@ describe('orbital-diagrams', () => {
       const d = parentDistanceDiagram(90, 0.5);
       expect(d.distanceLine).toEqual({ x1: d.focus.x, y1: d.focus.y, x2: d.bodyPoint.x, y2: d.bodyPoint.y });
     });
+
+    it('preserves high eccentricities instead of clamping them down to a different orbit', () => {
+      const e = 0.95;
+      const d = parentDistanceDiagram(0, e);
+      const expectedPeriapsis = 46 * (1 - e) / (1 + e);
+      expect(dist(d.focus, d.periapsisPoint)).toBeCloseTo(expectedPeriapsis, 2);
+    });
   });
 
   describe('lagrangeDiagram', () => {

--- a/src/app/data/orbital-diagrams.spec.ts
+++ b/src/app/data/orbital-diagrams.spec.ts
@@ -5,6 +5,7 @@ import {
   axialTiltDiagram,
   inclinationDiagram,
   lagrangeDiagram,
+  parentDistanceDiagram,
   periapsisDiagram,
 } from './orbital-diagrams';
 
@@ -236,6 +237,51 @@ describe('orbital-diagrams', () => {
       // periapsis carries it to 180° absolute — the far side of the circle from the unrotated case.
       expect(dist(unrotated.focus, unrotated.meanPoint)).toBeCloseTo(dist(rotated.focus, rotated.meanPoint), 3);
       expect(rotated.meanPoint.x).toBeLessThan(unrotated.meanPoint.x);
+    });
+  });
+
+  describe('parentDistanceDiagram', () => {
+    it('places the body at the periapsis marker when ν = 0', () => {
+      const d = parentDistanceDiagram(0, 0.5);
+      expect(dist(d.bodyPoint, d.periapsisPoint)).toBeCloseTo(0, 2);
+    });
+
+    it('places the body at the apoapsis marker when ν = 180', () => {
+      const d = parentDistanceDiagram(180, 0.5);
+      expect(dist(d.bodyPoint, d.apoapsisPoint)).toBeCloseTo(0, 2);
+    });
+
+    it('matches r = a(1 − e²) / (1 + e·cos ν) at an arbitrary true anomaly', () => {
+      // maxApo = 46, e = 0.5 => a = 46 / 1.5; at ν = 90° the formula reduces to a·(1 − e²) = 23.
+      const d = parentDistanceDiagram(90, 0.5);
+      expect(dist(d.focus, d.bodyPoint)).toBeCloseTo(23, 1);
+    });
+
+    it('holds the body at a constant radius (= a) for a circular orbit regardless of ν', () => {
+      const atZero = parentDistanceDiagram(0, 0);
+      const atNinety = parentDistanceDiagram(90, 0);
+      expect(dist(atZero.focus, atZero.bodyPoint)).toBeCloseTo(dist(atNinety.focus, atNinety.bodyPoint), 2);
+    });
+
+    it('orients the ellipse and markers by the body\'s own argument of periapsis, like periapsisDiagram/anomalyDiagram', () => {
+      const unrotated = parentDistanceDiagram(0, 0.5);
+      const rotated = parentDistanceDiagram(0, 0.5, 90);
+
+      expect(rotated.ellipse.rotation).toBe(-90);
+      expect(dist(rotated.focus, rotated.bodyPoint)).toBeCloseTo(dist(unrotated.focus, unrotated.bodyPoint), 3);
+
+      // Unrotated periapsis sits along +x from the focus (screen y unchanged).
+      expect(unrotated.bodyPoint.y).toBeCloseTo(unrotated.focus.y, 2);
+      expect(unrotated.bodyPoint.x).toBeGreaterThan(unrotated.focus.x);
+
+      // A 90° argument of periapsis rotates periapsis to screen "up" (x unchanged, y decreases).
+      expect(rotated.bodyPoint.x).toBeCloseTo(rotated.focus.x, 2);
+      expect(rotated.bodyPoint.y).toBeLessThan(rotated.focus.y);
+    });
+
+    it('draws the distance line from the focus to the body point', () => {
+      const d = parentDistanceDiagram(90, 0.5);
+      expect(d.distanceLine).toEqual({ x1: d.focus.x, y1: d.focus.y, x2: d.bodyPoint.x, y2: d.bodyPoint.y });
     });
   });
 

--- a/src/app/data/orbital-diagrams.ts
+++ b/src/app/data/orbital-diagrams.ts
@@ -332,10 +332,10 @@ export interface ParentDistanceDiagram {
  */
 export function parentDistanceDiagram(trueAnomalyDeg: number, eccentricity: number, argOfPeriapsisDeg?: number): ParentDistanceDiagram {
   const nu = Number.isFinite(trueAnomalyDeg) ? trueAnomalyDeg : 0;
-  // e = 0 is a valid and useful case here (a circular orbit — constant r = a), unlike
-  // periapsisDiagram's 0.45 floor, which exists only to keep that diagram's ellipse visibly
-  // elliptical; matches anomalyDiagram's clamp for the same reason.
-  const e = clamp(Number.isFinite(eccentricity) ? eccentricity : 0.5, 0, 0.85);
+  // e = 0 is a valid and useful case here (a circular orbit — constant r = a). Unlike
+  // anomaly/periapsis diagrams this one should stay numerically faithful to the body's real
+  // bound orbit, so accept the full elliptical range right up to (but not including) 1.
+  const e = clamp(Number.isFinite(eccentricity) ? eccentricity : 0.5, 0, 0.999);
   const arg = Number.isFinite(argOfPeriapsisDeg as number) ? (argOfPeriapsisDeg as number) : 0;
 
   const maxApo = 46;            // apoapsis distance from the focus

--- a/src/app/data/orbital-diagrams.ts
+++ b/src/app/data/orbital-diagrams.ts
@@ -309,6 +309,64 @@ function roundPoint(p: Point): Point {
   return { x: r(p.x), y: r(p.y) };
 }
 
+export interface ParentDistanceDiagram {
+  focus: Point;            // parent body, sits at a focus of the ellipse
+  focusRadius: number;
+  ellipse: EllipseShape;   // the orbit — an ellipse, never a circle
+  periapsisPoint: Point;   // closest approach, for reference
+  apoapsisPoint: Point;    // farthest point, for reference
+  bodyPoint: Point;        // the body's current position, at true anomaly ν
+  distanceLine: Line;      // focus -> bodyPoint, the straight-line distance (r) being explained
+  distanceLabel: Point;    // anchor for the live "r = …" text, near the line's midpoint
+  parentLabel: Point;
+  bodyLabel: Point;
+}
+
+/**
+ * Current parent distance: the body's position on its elliptical orbit at true anomaly
+ * `trueAnomalyDeg`, and the straight-line distance from the parent (at a focus) to that
+ * point — r = a(1 − e²) / (1 + e·cos ν). Shares its ellipse construction with
+ * {@link periapsisDiagram}/{@link anomalyDiagram} (focus offset `c = a·e` from the ellipse
+ * centre toward periapsis), oriented by `argOfPeriapsisDeg` on the same shared 0° reference
+ * convention as those diagrams.
+ */
+export function parentDistanceDiagram(trueAnomalyDeg: number, eccentricity: number, argOfPeriapsisDeg?: number): ParentDistanceDiagram {
+  const nu = Number.isFinite(trueAnomalyDeg) ? trueAnomalyDeg : 0;
+  // e = 0 is a valid and useful case here (a circular orbit — constant r = a), unlike
+  // periapsisDiagram's 0.45 floor, which exists only to keep that diagram's ellipse visibly
+  // elliptical; matches anomalyDiagram's clamp for the same reason.
+  const e = clamp(Number.isFinite(eccentricity) ? eccentricity : 0.5, 0, 0.85);
+  const arg = Number.isFinite(argOfPeriapsisDeg as number) ? (argOfPeriapsisDeg as number) : 0;
+
+  const maxApo = 46;            // apoapsis distance from the focus
+  const a = maxApo / (1 + e);   // semi-major axis
+  const b = a * Math.sqrt(1 - e * e);
+  const c = a * e;              // focus offset from the ellipse centre
+
+  const focus = { x: CENTER, y: CENTER };
+  const phi = arg * DEG;
+  const u = { x: Math.cos(phi), y: -Math.sin(phi) }; // periapsis direction (screen)
+
+  const ellipse: EllipseShape = {
+    cx: r(focus.x - c * u.x), cy: r(focus.y - c * u.y), rx: r(a), ry: r(b), rotation: r(-arg),
+  };
+
+  const periapsisPoint = roundPoint({ x: focus.x + a * (1 - e) * u.x, y: focus.y + a * (1 - e) * u.y });
+  const apoapsisPoint = roundPoint({ x: focus.x - a * (1 + e) * u.x, y: focus.y - a * (1 + e) * u.y });
+
+  const nuRad = nu * DEG;
+  const rNu = (a * (1 - e * e)) / (1 + e * Math.cos(nuRad));
+  const absNu = (arg + nu) * DEG;
+  const bodyPoint = roundPoint({ x: focus.x + rNu * Math.cos(absNu), y: focus.y - rNu * Math.sin(absNu) });
+
+  const distanceLine: Line = { x1: focus.x, y1: focus.y, x2: bodyPoint.x, y2: bodyPoint.y };
+  const distanceLabel: Point = { x: r((focus.x + bodyPoint.x) / 2), y: r((focus.y + bodyPoint.y) / 2) };
+
+  const { parentLabel, bodyLabel } = labelAnchors(focus, bodyPoint);
+
+  return { focus, focusRadius: 4, ellipse, periapsisPoint, apoapsisPoint, bodyPoint, distanceLine, distanceLabel, parentLabel, bodyLabel };
+}
+
 /**
  * The canonical five-point Lagrange schematic of a two-body system: a primary at the
  * centre, a secondary on a circular reference orbit to the right (angle 0), and the five

--- a/src/app/dialogs/parent-distance-dialog/parent-distance-dialog.component.html
+++ b/src/app/dialogs/parent-distance-dialog/parent-distance-dialog.component.html
@@ -1,0 +1,72 @@
+<app-dialog-shell heading="Parent Distance">
+  <div class="parent-distance-dialog">
+    <div class="values">
+      <ul>
+        <li><strong>Body:</strong> {{ data.bodyName || 'This body' }}</li>
+        <li><strong>Parent:</strong> {{ data.parentName || 'the parent body' }}</li>
+        <li><strong>Semi-major axis (a):</strong> {{ formatKm(data.semiMajorAxisKm) }}</li>
+        <li><strong>Eccentricity (e):</strong> {{ data.eccentricity | number:'0.4-4' }}</li>
+        <li><strong>Periapsis distance:</strong> {{ formatKm(data.periapsisKm) }}</li>
+        <li><strong>Apoapsis distance:</strong> {{ formatKm(data.apoapsisKm) }}</li>
+        <li><strong>Recorded mean anomaly (M₀):</strong> {{ data.recordedMeanAnomaly | number:'0.1-1' }}° at
+          {{ data.recordedTimestamp | date:'yyyy-MM-dd HH:mm' }} UTC</li>
+        <li><strong>Live, right now:</strong>
+          M = {{ meanAnomalyLive() | number:'0.1-1' }}°,
+          ν = {{ trueAnomalyLive() | number:'0.1-1' }}°,
+          r = {{ formatKm(parentDistanceLiveKm()) }}
+        </li>
+      </ul>
+    </div>
+
+    @if (diagram(); as d) {
+    <div class="diagram">
+      <svg viewBox="0 0 120 120" class="parent-distance-diagram" role="img" aria-label="Parent distance diagram">
+        <!-- The real orbit -->
+        <ellipse class="orbit-plane" [attr.cx]="d.ellipse.cx" [attr.cy]="d.ellipse.cy"
+          [attr.rx]="d.ellipse.rx" [attr.ry]="d.ellipse.ry"
+          [attr.transform]="'rotate(' + d.ellipse.rotation + ' ' + d.ellipse.cx + ' ' + d.ellipse.cy + ')'" />
+        <!-- Distance line: parent (focus) to the body's current position -->
+        <line class="distance-line" [attr.x1]="d.distanceLine.x1" [attr.y1]="d.distanceLine.y1"
+          [attr.x2]="d.distanceLine.x2" [attr.y2]="d.distanceLine.y2" />
+        <!-- Parent body at the focus -->
+        <circle class="planet" [attr.cx]="d.focus.x" [attr.cy]="d.focus.y" [attr.r]="d.focusRadius" />
+        <!-- Periapsis / apoapsis reference points -->
+        <circle class="marker-periapsis" [attr.cx]="d.periapsisPoint.x" [attr.cy]="d.periapsisPoint.y" r="2.5" />
+        <circle class="marker-apoapsis" [attr.cx]="d.apoapsisPoint.x" [attr.cy]="d.apoapsisPoint.y" r="2.5" />
+        <!-- The body's current, live position -->
+        <circle class="marker" [attr.cx]="d.bodyPoint.x" [attr.cy]="d.bodyPoint.y" r="3.5" />
+        <text class="value-label" [attr.x]="d.distanceLabel.x" [attr.y]="d.distanceLabel.y - 4"
+          text-anchor="middle">{{ formatKm(parentDistanceLiveKm()) }}</text>
+        @if (data.parentName) {
+        <text class="label" [attr.x]="d.parentLabel.x" [attr.y]="d.parentLabel.y" text-anchor="middle">{{ data.parentName }}</text>
+        }
+        @if (data.bodyName) {
+        <text class="label" [attr.x]="d.bodyLabel.x" [attr.y]="d.bodyLabel.y" text-anchor="middle">{{ data.bodyName }}</text>
+        }
+      </svg>
+      <div class="legend">
+        <span class="legend-entry"><span class="swatch swatch-periapsis"></span> Periapsis — closest approach</span>
+        <span class="legend-entry"><span class="swatch swatch-apoapsis"></span> Apoapsis — farthest point</span>
+        <span class="legend-entry"><span class="swatch swatch-current"></span> Current position — live</span>
+      </div>
+    </div>
+    }
+
+    <div class="explanation">
+      <p>
+        The straight-line distance from a body to its parent varies continuously along an elliptical orbit: it is
+        shortest at periapsis and longest at apoapsis. At any other point it's given by
+        <strong>r = a(1 − e²) / (1 + e·cos ν)</strong>, where <strong>a</strong> is the semi-major axis,
+        <strong>e</strong> is the eccentricity, and <strong>ν</strong> (true anomaly) is the body's current angle
+        from periapsis.
+      </p>
+      <p>
+        The value is recalculated here from the recorded mean anomaly (M₀) and its timestamp: elapsed time since
+        that timestamp, divided by the orbital period, gives the number of orbits completed, which advances M₀ to
+        right now; that mean anomaly is then converted to true anomaly (ν) and plugged into the formula above.
+        This tracks live, wall-clock time — the same basis the Next Apoapsis/Periapsis rows use — rather than the
+        shared system-epoch snapshot the Mean/True Anomaly rows show elsewhere.
+      </p>
+    </div>
+  </div>
+</app-dialog-shell>

--- a/src/app/dialogs/parent-distance-dialog/parent-distance-dialog.component.scss
+++ b/src/app/dialogs/parent-distance-dialog/parent-distance-dialog.component.scss
@@ -1,0 +1,133 @@
+.parent-distance-dialog {
+    .values ul {
+        list-style: none;
+        padding-left: 0;
+        margin: 0 0 20px;
+    }
+
+    .values ul li {
+        padding: 4px 0;
+        line-height: 1.5;
+    }
+
+    .diagram {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 16px;
+    }
+
+    .parent-distance-diagram {
+        width: 320px;
+        max-width: 100%;
+        height: auto;
+        background: var(--color-surface-2);
+        border-radius: 8px;
+        padding: 20px;
+        overflow: visible;
+
+        line,
+        ellipse,
+        circle {
+            vector-effect: non-scaling-stroke;
+        }
+
+        .orbit-plane {
+            fill: none;
+            stroke: var(--color-accent);
+            stroke-width: 2;
+        }
+
+        .distance-line {
+            stroke: var(--color-badge-cyan);
+            stroke-width: 1.5;
+            stroke-dasharray: 4 3;
+        }
+
+        .planet {
+            fill: var(--color-info);
+            stroke: var(--color-text-bright);
+            stroke-width: 1;
+        }
+
+        .marker {
+            fill: var(--color-warning);
+            stroke: var(--color-text-bright);
+            stroke-width: 1;
+        }
+
+        .marker-periapsis {
+            fill: var(--color-success);
+            stroke: var(--color-text-bright);
+            stroke-width: 0.75;
+        }
+
+        .marker-apoapsis {
+            fill: var(--color-badge-red);
+            stroke: var(--color-text-bright);
+            stroke-width: 0.75;
+        }
+
+        .label {
+            fill: var(--color-text-bright);
+            font-size: 7px;
+            font-weight: 600;
+            paint-order: stroke;
+            stroke: var(--color-surface-2);
+            stroke-width: 2.5px;
+            stroke-linejoin: round;
+        }
+
+        .value-label {
+            fill: var(--color-badge-cyan);
+            font-size: 6px;
+            font-weight: 600;
+            paint-order: stroke;
+            stroke: var(--color-surface-2);
+            stroke-width: 2.5px;
+            stroke-linejoin: round;
+        }
+    }
+
+    .legend {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 0.85em;
+        color: var(--color-text-muted);
+    }
+
+    .legend-entry {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+
+    .swatch {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+    }
+
+    .swatch-periapsis {
+        background: var(--color-success);
+    }
+
+    .swatch-apoapsis {
+        background: var(--color-badge-red);
+    }
+
+    .swatch-current {
+        background: var(--color-warning);
+    }
+
+    .explanation {
+        line-height: 1.6;
+
+        p {
+            margin-bottom: 8px;
+        }
+    }
+}

--- a/src/app/dialogs/parent-distance-dialog/parent-distance-dialog.component.spec.ts
+++ b/src/app/dialogs/parent-distance-dialog/parent-distance-dialog.component.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+import { ParentDistanceDialogComponent, ParentDistanceDialogData } from './parent-distance-dialog.component';
+import { OrbitalRelationsService } from '../../data/orbital-relations.service';
+
+function setup(data: ParentDistanceDialogData): ComponentFixture<ParentDistanceDialogComponent> {
+  TestBed.configureTestingModule({
+    imports: [ParentDistanceDialogComponent],
+    providers: [provideZonelessChangeDetection(), { provide: MAT_DIALOG_DATA, useValue: data }],
+  });
+  const fixture = TestBed.createComponent(ParentDistanceDialogComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('ParentDistanceDialogComponent', () => {
+  afterEach(() => TestBed.resetTestingModule());
+
+  const baseData: ParentDistanceDialogData = {
+    bodyName: 'Test Body b',
+    parentName: 'Test Star',
+    semiMajorAxisKm: 1_000_000,
+    eccentricity: 0.3,
+    apoapsisKm: 1_300_000,
+    periapsisKm: 700_000,
+    recordedMeanAnomaly: 45,
+    recordedTimestamp: new Date('2026-06-01T00:00:00Z'),
+    orbitalPeriodDays: 200,
+    argOfPeriapsisDeg: 0,
+  };
+
+  it('renders the values list and the diagram', () => {
+    const fixture = setup(baseData);
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('Test Body b');
+    expect(el.textContent).toContain('Test Star');
+    expect(el.querySelector('svg.parent-distance-diagram')).toBeTruthy();
+  });
+
+  it('derives the live mean/true anomaly and distance from the recorded elements', () => {
+    const fixture = setup(baseData);
+    const orbital = new OrbitalRelationsService();
+    const c = fixture.componentInstance;
+
+    // Computed independently against Date.now() (not the component's own captured value), so
+    // a loose tolerance absorbs the few milliseconds between the two calls — at a 200-day
+    // orbital period even a generous 1s drift is ~5e-5 degrees, far under this tolerance.
+    const expectedMean = orbital.meanAnomalyNow(45, 200, '2026-06-01T00:00:00.000Z', Date.now());
+    const expectedTrue = orbital.meanToTrueAnomaly(expectedMean, 0.3);
+    const expectedR = (baseData.semiMajorAxisKm * (1 - 0.3 * 0.3)) / (1 + 0.3 * Math.cos(expectedTrue * Math.PI / 180));
+
+    expect(c.meanAnomalyLive()).toBeCloseTo(expectedMean, 3);
+    expect(c.trueAnomalyLive()).toBeCloseTo(expectedTrue, 3);
+    expect(c.parentDistanceLiveKm()).toBeCloseTo(expectedR, 1);
+  });
+
+  it('places the diagram\'s body point at the same distance from the focus as the live value', () => {
+    const fixture = setup(baseData);
+    const c = fixture.componentInstance;
+    const d = c.diagram();
+    const distFromFocus = Math.hypot(d.bodyPoint.x - d.focus.x, d.bodyPoint.y - d.focus.y);
+    // The diagram is drawn to a fixed 46px "apoapsis" scale, not the real km value, so it
+    // won't equal parentDistanceLiveKm() directly — but it should stay strictly between the
+    // drawn periapsis and apoapsis distances from the focus, same as the live km value sits
+    // between data.periapsisKm and data.apoapsisKm.
+    const periDist = Math.hypot(d.periapsisPoint.x - d.focus.x, d.periapsisPoint.y - d.focus.y);
+    const apoDist = Math.hypot(d.apoapsisPoint.x - d.focus.x, d.apoapsisPoint.y - d.focus.y);
+    expect(distFromFocus).toBeGreaterThanOrEqual(Math.min(periDist, apoDist) - 0.01);
+    expect(distFromFocus).toBeLessThanOrEqual(Math.max(periDist, apoDist) + 0.01);
+  });
+
+  it('falls back to generic body/parent labels when names are absent', () => {
+    const fixture = setup({ ...baseData, bodyName: undefined, parentName: undefined });
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('This body');
+    expect(el.textContent).toContain('the parent body');
+  });
+});

--- a/src/app/dialogs/parent-distance-dialog/parent-distance-dialog.component.spec.ts
+++ b/src/app/dialogs/parent-distance-dialog/parent-distance-dialog.component.spec.ts
@@ -77,4 +77,22 @@ describe('ParentDistanceDialogComponent', () => {
     expect(el.textContent).toContain('This body');
     expect(el.textContent).toContain('the parent body');
   });
+
+  it('uses the provided now override instead of the live wall clock', () => {
+    const overrideData: ParentDistanceDialogData = {
+      ...baseData,
+      nowOverrideMs: new Date('2026-07-01T00:00:00Z').getTime(),
+    };
+    const fixture = setup(overrideData);
+    const orbital = new OrbitalRelationsService();
+    const c = fixture.componentInstance;
+
+    const expectedMean = orbital.meanAnomalyNow(45, 200, '2026-06-01T00:00:00.000Z', overrideData.nowOverrideMs!);
+    const expectedTrue = orbital.meanToTrueAnomaly(expectedMean, 0.3);
+    const expectedR = (baseData.semiMajorAxisKm * (1 - 0.3 * 0.3)) / (1 + 0.3 * Math.cos(expectedTrue * Math.PI / 180));
+
+    expect(c.meanAnomalyLive()).toBeCloseTo(expectedMean, 6);
+    expect(c.trueAnomalyLive()).toBeCloseTo(expectedTrue, 6);
+    expect(c.parentDistanceLiveKm()).toBeCloseTo(expectedR, 6);
+  });
 });

--- a/src/app/dialogs/parent-distance-dialog/parent-distance-dialog.component.ts
+++ b/src/app/dialogs/parent-distance-dialog/parent-distance-dialog.component.ts
@@ -1,0 +1,93 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, afterNextRender, computed, inject, signal } from '@angular/core';
+import { DatePipe, DecimalPipe } from '@angular/common';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { DialogShellComponent } from '../dialog-shell/dialog-shell.component';
+import { OrbitalRelationsService } from '../../data/orbital-relations.service';
+import { ParentDistanceDiagram, parentDistanceDiagram } from '../../data/orbital-diagrams';
+import { InlineLengthUnit, RADIANS_PER_DEGREE, formatLengthInUnit, pickInlineLengthUnit } from '../../data/unit-conversions';
+
+/** Data passed to the parent-distance dialog when it is opened. */
+export interface ParentDistanceDialogData {
+  bodyName?: string;
+  parentName?: string;
+  /** Semi-major axis (km) — stored in AU by Spansh, converted by the caller. */
+  semiMajorAxisKm: number;
+  eccentricity: number;
+  apoapsisKm: number;
+  periapsisKm: number;
+  /** The mean anomaly (degrees) as recorded by Spansh. */
+  recordedMeanAnomaly: number;
+  /** When the recorded mean anomaly was captured. */
+  recordedTimestamp: Date;
+  orbitalPeriodDays: number;
+  argOfPeriapsisDeg?: number;
+}
+
+/**
+ * Explains a body's current straight-line distance from its parent: the orbital elements
+ * behind it (semi-major axis, eccentricity, periapsis/apoapsis), a live value ticking to
+ * the current time via r = a(1 − e²) / (1 + e·cos ν), and a diagram showing where that puts
+ * the body on its orbit right now. Mirrors {@link AnomalyDialogComponent}'s live rAF-driven
+ * value/marker.
+ */
+@Component({
+  selector: 'app-parent-distance-dialog',
+  templateUrl: './parent-distance-dialog.component.html',
+  styleUrls: ['./parent-distance-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DialogShellComponent, DatePipe, DecimalPipe],
+})
+export class ParentDistanceDialogComponent {
+  public readonly data = inject<ParentDistanceDialogData>(MAT_DIALOG_DATA);
+  private readonly orbital = inject(OrbitalRelationsService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  /** Current wall-clock time, ticked by the animation loop to drive the live value/marker. */
+  private readonly now = signal(Date.now());
+
+  /** One shared length unit for a/periapsis/apoapsis/live-r, chosen from the semi-major axis. */
+  public readonly unit: InlineLengthUnit = pickInlineLengthUnit(this.data.semiMajorAxisKm);
+
+  public readonly meanAnomalyLive = computed(() =>
+    this.orbital.meanAnomalyNow(
+      this.data.recordedMeanAnomaly, this.data.orbitalPeriodDays, this.data.recordedTimestamp.toISOString(), this.now(),
+    ),
+  );
+
+  public readonly trueAnomalyLive = computed(() =>
+    this.orbital.meanToTrueAnomaly(this.meanAnomalyLive(), this.data.eccentricity),
+  );
+
+  public readonly parentDistanceLiveKm = computed(() => {
+    const e = this.data.eccentricity;
+    const nu = this.trueAnomalyLive() * RADIANS_PER_DEGREE;
+    return (this.data.semiMajorAxisKm * (1 - e * e)) / (1 + e * Math.cos(nu));
+  });
+
+  public readonly diagram = computed<ParentDistanceDiagram>(() =>
+    parentDistanceDiagram(this.trueAnomalyLive(), this.data.eccentricity, this.data.argOfPeriapsisDeg),
+  );
+
+  public formatKm(km: number): string {
+    return formatLengthInUnit(km, this.unit);
+  }
+
+  constructor() {
+    let rafId = 0;
+    // Register the cancel synchronously so the loop is always torn down, even if the
+    // dialog is destroyed before the first render runs (cancelAnimationFrame(0) is a no-op).
+    this.destroyRef.onDestroy(() => cancelAnimationFrame(rafId));
+    afterNextRender(() => {
+      let last = 0;
+      const tick = (t: number) => {
+        // ~10 fps is plenty for the slow drift of a real orbit and keeps it cheap.
+        if (t - last > 100) {
+          this.now.set(Date.now());
+          last = t;
+        }
+        rafId = requestAnimationFrame(tick);
+      };
+      rafId = requestAnimationFrame(tick);
+    });
+  }
+}

--- a/src/app/dialogs/parent-distance-dialog/parent-distance-dialog.component.ts
+++ b/src/app/dialogs/parent-distance-dialog/parent-distance-dialog.component.ts
@@ -21,6 +21,8 @@ export interface ParentDistanceDialogData {
   recordedTimestamp: Date;
   orbitalPeriodDays: number;
   argOfPeriapsisDeg?: number;
+  /** Fixed "now" override (ms since epoch), e.g. from the app's ?t= query param. */
+  nowOverrideMs?: number;
 }
 
 /**
@@ -44,13 +46,15 @@ export class ParentDistanceDialogComponent {
 
   /** Current wall-clock time, ticked by the animation loop to drive the live value/marker. */
   private readonly now = signal(Date.now());
+  /** Mirrors the body row's time basis: ?t= override when present, otherwise the live wall clock. */
+  private readonly effectiveNow = computed(() => this.data.nowOverrideMs ?? this.now());
 
   /** One shared length unit for a/periapsis/apoapsis/live-r, chosen from the semi-major axis. */
   public readonly unit: InlineLengthUnit = pickInlineLengthUnit(this.data.semiMajorAxisKm);
 
   public readonly meanAnomalyLive = computed(() =>
     this.orbital.meanAnomalyNow(
-      this.data.recordedMeanAnomaly, this.data.orbitalPeriodDays, this.data.recordedTimestamp.toISOString(), this.now(),
+      this.data.recordedMeanAnomaly, this.data.orbitalPeriodDays, this.data.recordedTimestamp.toISOString(), this.effectiveNow(),
     ),
   );
 

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -1301,6 +1301,17 @@ describe('SystemBodyComponent (extended coverage)', () => {
       await component.showParentDistanceDialog();
       expect(dialogOpenCalls).toBe(before);
     });
+
+    it('passes the app-level time override through to the dialog so it matches the row value', async () => {
+      const svc = TestBed.inject(AppService) as any;
+      svc.nowOverride.set(new Date('2026-03-01T00:00:00Z').getTime());
+      render(makeBody({
+        semiMajorAxis: 1, orbitalEccentricity: 0.3, meanAnomaly: 45, orbitalPeriod: 200,
+        timestamps: { distanceToArrival: '', meanAnomaly: '2026-01-01T00:00:00Z' },
+      }));
+      await component.showParentDistanceDialog();
+      expect(lastDialogData().nowOverrideMs).toBe(svc.nowOverride());
+    });
   });
 
   describe('collision dialog', () => {

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -1302,6 +1302,17 @@ describe('SystemBodyComponent (extended coverage)', () => {
       expect(dialogOpenCalls).toBe(before);
     });
 
+    it('does not show a parent distance or open the dialog for an invalid mean-anomaly timestamp', async () => {
+      render(makeBody({
+        semiMajorAxis: 1, orbitalEccentricity: 0.3, meanAnomaly: 45, orbitalPeriod: 200,
+        timestamps: { distanceToArrival: '', meanAnomaly: 'not-a-date' },
+      }));
+      expect(component.getParentDistanceKm()).toBeNull();
+      const before = dialogOpenCalls;
+      await component.showParentDistanceDialog();
+      expect(dialogOpenCalls).toBe(before);
+    });
+
     it('passes the app-level time override through to the dialog so it matches the row value', async () => {
       const svc = TestBed.inject(AppService) as any;
       svc.nowOverride.set(new Date('2026-03-01T00:00:00Z').getTime());

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -257,6 +257,72 @@ describe('SystemBodyComponent (extended coverage)', () => {
       expect(atMarch20).not.toBeNull();
       expect(atMarch20!.days).not.toBe(atMarch1!.days);
     });
+
+    it('computes parent distance right now, matching periapsis/apoapsis when M = 0/180', () => {
+      // Mean and true anomaly always coincide exactly at 0° and 180°, and with a timestamp
+      // matching the (faked) "now" there's no propagation drift, so parent distance should
+      // land on periapsis/apoapsis exactly.
+      render(makeBody({
+        semiMajorAxis: 1, orbitalEccentricity: 0.3, meanAnomaly: 0, orbitalPeriod: 100,
+        timestamps: { distanceToArrival: '', meanAnomaly: new Date().toISOString() },
+      }));
+      expect(component.getParentDistanceKm()).toBeCloseTo(component.getPeriapsis(), 0);
+
+      render(makeBody({
+        semiMajorAxis: 1, orbitalEccentricity: 0.3, meanAnomaly: 180, orbitalPeriod: 100,
+        timestamps: { distanceToArrival: '', meanAnomaly: new Date().toISOString() },
+      }));
+      expect(component.getParentDistanceKm()).toBeCloseTo(component.getApoapsis(), 0);
+    });
+
+    it('returns a constant parent distance for a circular orbit (e = 0)', () => {
+      render(makeBody({
+        semiMajorAxis: 1, orbitalEccentricity: 0, meanAnomaly: 45, orbitalPeriod: 100,
+        timestamps: { distanceToArrival: '', meanAnomaly: new Date().toISOString() },
+      }));
+      expect(component.getParentDistanceKm()).toBeCloseTo(KM_PER_AU, 0);
+    });
+
+    it('returns null parent distance when the recorded mean anomaly/timestamp are missing', () => {
+      render(makeBody({ semiMajorAxis: 1, orbitalEccentricity: 0.3 }));
+      expect(component.getParentDistanceKm()).toBeNull();
+    });
+
+    it('returns null parent distance for an unbound (e >= 1) or negative eccentricity', () => {
+      const base = {
+        semiMajorAxis: 1, meanAnomaly: 45, orbitalPeriod: 100,
+        timestamps: { distanceToArrival: '', meanAnomaly: new Date().toISOString() },
+      };
+      render(makeBody({ ...base, orbitalEccentricity: 1 }));
+      expect(component.getParentDistanceKm()).toBeNull();
+
+      render(makeBody({ ...base, orbitalEccentricity: 1.2 }));
+      expect(component.getParentDistanceKm()).toBeNull();
+
+      render(makeBody({ ...base, orbitalEccentricity: -0.1 }));
+      expect(component.getParentDistanceKm()).toBeNull();
+    });
+
+    it('honours the ?t= time override when computing parent distance', () => {
+      const svc = TestBed.inject(AppService) as any;
+      const body = makeBody({
+        semiMajorAxis: 1, orbitalEccentricity: 0.3, meanAnomaly: 90, orbitalPeriod: 100,
+        timestamps: { distanceToArrival: '', meanAnomaly: '2026-01-01T00:00:00Z' },
+      });
+
+      svc.nowOverride.set(new Date('2026-01-01T00:00:00Z').getTime());
+      render(body);
+      const at0Days = component.getParentDistanceKm();
+
+      // A quarter of the 100-day period later, moved well along the orbit.
+      svc.nowOverride.set(new Date('2026-01-26T00:00:00Z').getTime());
+      component.ngOnChanges();
+      const atQuarterPeriod = component.getParentDistanceKm();
+
+      expect(at0Days).not.toBeNull();
+      expect(atQuarterPeriod).not.toBeNull();
+      expect(atQuarterPeriod).not.toBeCloseTo(at0Days!, 0);
+    });
   });
 
   describe('rings', () => {
@@ -1195,6 +1261,45 @@ describe('SystemBodyComponent (extended coverage)', () => {
 
       render(newer);
       expect(component.getSystemAnomalyEpoch()?.toISOString()).toBe(new Date('2026-04-01T00:00:00Z').toISOString());
+    });
+  });
+
+  describe('parent distance dialog', () => {
+    it('opens with the body/parent names and the orbital elements needed to derive a live value', async () => {
+      const parent = makeBody({ name: 'Star A' });
+      const body = makeBody({
+        name: 'Star A 1', semiMajorAxis: 1, orbitalEccentricity: 0.3, meanAnomaly: 45, orbitalPeriod: 200,
+        timestamps: { distanceToArrival: '', meanAnomaly: '2026-01-01T00:00:00Z' },
+      }, parent);
+      parent.subBodies = [body];
+
+      render(body);
+      await component.showParentDistanceDialog();
+
+      expect(lastDialogData().bodyName).toBe('Star A 1!');
+      expect(lastDialogData().parentName).toBe('Star A!');
+      expect(lastDialogData().semiMajorAxisKm).toBe(component.getSemiMajorAxisKm());
+      expect(lastDialogData().eccentricity).toBe(0.3);
+      expect(lastDialogData().apoapsisKm).toBe(component.getApoapsis());
+      expect(lastDialogData().periapsisKm).toBe(component.getPeriapsis());
+      expect(lastDialogData().recordedMeanAnomaly).toBe(45);
+      expect(lastDialogData().orbitalPeriodDays).toBe(200);
+    });
+
+    it('leaves parentName undefined for a body with no parent', async () => {
+      render(makeBody({
+        semiMajorAxis: 1, orbitalEccentricity: 0.3, meanAnomaly: 45, orbitalPeriod: 200,
+        timestamps: { distanceToArrival: '', meanAnomaly: '2026-01-01T00:00:00Z' },
+      }));
+      await component.showParentDistanceDialog();
+      expect(lastDialogData().parentName).toBeUndefined();
+    });
+
+    it('does nothing when the orbital elements needed for parent distance are missing', async () => {
+      render(makeBody({ semiMajorAxis: 1, orbitalEccentricity: 0.3 }));
+      const before = dialogOpenCalls;
+      await component.showParentDistanceDialog();
+      expect(dialogOpenCalls).toBe(before);
     });
   });
 

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -206,7 +206,7 @@
           <!-- Orbit Section -->
           @if (body().bodyData.orbitalPeriod || body().bodyData.semiMajorAxis || body().bodyData.orbitalEccentricity !==
           undefined || body().bodyData.orbitalInclination || body().bodyData.argOfPeriapsis ||
-          body().bodyData.ascendingNode || getNextPeriapsis() || getNextApoapsis()) {
+          body().bodyData.ascendingNode) {
           <div class="body-data-section">
             <div class="body-data-section-header">Orbit</div>
             @if (body().bodyData.orbitalPeriod) {
@@ -251,16 +251,6 @@
               </div>
             </div>
             }
-            @if (getNextApoapsis()) {
-            <div class="body-data-entry clickable" (click)="showApoPeriDialog('apo')">
-              <div>
-                Next apoapsis<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
-              </div>
-              <div>
-                <span [matTooltip]="(getNextApoapsis()!.date | date:'yyyy-MM-dd HH:mm') || ''">{{ getNextApoapsis()!.days | number:'0.1-1' }} days</span><app-convert-icon [kind]="'duration'" [value]="getNextApoapsis()!.days" label="Next apoapsis" uiUnit="Days" />
-              </div>
-            </div>
-            }
             @if (body().bodyData.semiMajorAxis && body().bodyData.orbitalEccentricity !== undefined &&
             body().bodyData.orbitalEccentricity !== null && body().bodyData.orbitalEccentricity !== 0) {
             <div class="body-data-entry clickable" (click)="showApoPeriDialog('peri')">
@@ -269,16 +259,6 @@
               </div>
               <div>
                 <span [matTooltip]="getPeriapsis() + ' km'">{{ formatOrbitDistance(getPeriapsis()) }}</span><app-convert-icon [kind]="'length'" [value]="getPeriapsis()" label="Periapsis" [uiUnit]="orbitDistanceUnitLabel()" />
-              </div>
-            </div>
-            }
-            @if (getNextPeriapsis()) {
-            <div class="body-data-entry clickable" (click)="showApoPeriDialog('peri')">
-              <div>
-                Next periapsis<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
-              </div>
-              <div>
-                <span [matTooltip]="(getNextPeriapsis()!.date | date:'yyyy-MM-dd HH:mm') || ''">{{ getNextPeriapsis()!.days | number:'0.1-1' }} days</span><app-convert-icon [kind]="'duration'" [value]="getNextPeriapsis()!.days" label="Next periapsis" uiUnit="Days" />
               </div>
             </div>
             }
@@ -752,6 +732,36 @@
             </div>
             <div>
               <span [matTooltip]="'Calculated for ' + (getSystemAnomalyEpoch() | date:'yyyy-MM-dd HH:mm') + ' UTC - click for details'">{{ getTrueAnomaly() | number:'0.2-2' }}°</span><app-convert-icon [kind]="'angle'" [value]="getTrueAnomaly()" label="True anomaly" uiUnit="Degrees" />
+            </div>
+          </div>
+          }
+          @if (getParentDistanceKm(); as parentDistanceKm) {
+          <div class="body-data-entry clickable" (click)="showParentDistanceDialog()">
+            <div>
+              Parent distance<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
+            </div>
+            <div>
+              <span [matTooltip]="parentDistanceKm + ' km'">{{ formatOrbitDistance(parentDistanceKm) }}</span><app-convert-icon [kind]="'length'" [value]="parentDistanceKm" label="Parent distance" [uiUnit]="orbitDistanceUnitLabel()" />
+            </div>
+          </div>
+          }
+          @if (getNextApoapsis()) {
+          <div class="body-data-entry clickable" (click)="showApoPeriDialog('apo')">
+            <div>
+              Next apoapsis<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
+            </div>
+            <div>
+              <span [matTooltip]="(getNextApoapsis()!.date | date:'yyyy-MM-dd HH:mm') || ''">{{ getNextApoapsis()!.days | number:'0.1-1' }} days</span><app-convert-icon [kind]="'duration'" [value]="getNextApoapsis()!.days" label="Next apoapsis" uiUnit="Days" />
+            </div>
+          </div>
+          }
+          @if (getNextPeriapsis()) {
+          <div class="body-data-entry clickable" (click)="showApoPeriDialog('peri')">
+            <div>
+              Next periapsis<fa-icon class="info-icon" title="Click for more information" [icon]="faInfo"></fa-icon>
+            </div>
+            <div>
+              <span [matTooltip]="(getNextPeriapsis()!.date | date:'yyyy-MM-dd HH:mm') || ''">{{ getNextPeriapsis()!.days | number:'0.1-1' }} days</span><app-convert-icon [kind]="'duration'" [value]="getNextPeriapsis()!.days" label="Next periapsis" uiUnit="Days" />
             </div>
           </div>
           }

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -1328,6 +1328,8 @@ export class SystemBodyComponent implements OnChanges {
     const bd = body.bodyData;
     const aKm = this.getSemiMajorAxisKm();
     if (aKm == null || bd.orbitalEccentricity == null || bd.meanAnomaly == null || !bd.orbitalPeriod || !bd.timestamps?.meanAnomaly) return;
+    const recordedTimestampMs = Date.parse(bd.timestamps.meanAnomaly);
+    if (!Number.isFinite(recordedTimestampMs)) return;
 
     openLazyDialog(this.dialog, {
       loader: () => import('../dialogs/parent-distance-dialog/parent-distance-dialog.component').then(m => m.ParentDistanceDialogComponent),
@@ -1344,7 +1346,7 @@ export class SystemBodyComponent implements OnChanges {
         apoapsisKm: this.getApoapsis(),
         periapsisKm: this.getPeriapsis(),
         recordedMeanAnomaly: bd.meanAnomaly,
-        recordedTimestamp: new Date(bd.timestamps.meanAnomaly),
+        recordedTimestamp: new Date(recordedTimestampMs),
         orbitalPeriodDays: bd.orbitalPeriod,
         argOfPeriapsisDeg: bd.argOfPeriapsis ?? 0,
         nowOverrideMs: this.appService.nowOverride() ?? undefined,
@@ -2001,6 +2003,7 @@ export class SystemBodyComponent implements OnChanges {
     if (aKm == null || e == null || !(e >= 0) || e >= 1 || bd.meanAnomaly == null || !bd.orbitalPeriod || !bd.timestamps?.meanAnomaly) { return null; }
     const now = this.appService.nowOverride() ?? Date.now();
     const meanNow = this.orbitalRelations.meanAnomalyNow(bd.meanAnomaly, bd.orbitalPeriod, bd.timestamps.meanAnomaly, now);
+    if (!Number.isFinite(meanNow)) { return null; }
     const nu = this.orbitalRelations.meanToTrueAnomaly(meanNow, e) * RADIANS_PER_DEGREE;
     return (aKm * (1 - e * e)) / (1 + e * Math.cos(nu));
   }

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -1347,6 +1347,7 @@ export class SystemBodyComponent implements OnChanges {
         recordedTimestamp: new Date(bd.timestamps.meanAnomaly),
         orbitalPeriodDays: bd.orbitalPeriod,
         argOfPeriapsisDeg: bd.argOfPeriapsis ?? 0,
+        nowOverrideMs: this.appService.nowOverride() ?? undefined,
       } satisfies ParentDistanceDialogData,
     });
   }

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -28,6 +28,7 @@ import type { InvisibleRingDialogData } from '../dialogs/invisible-ring-dialog/i
 import type { RingClassificationDialogData, RingClassificationRingInfo } from '../dialogs/ring-classification-dialog/ring-classification-dialog.component';
 import type { ApoPeriDialogData } from '../dialogs/apo-peri-dialog/apo-peri-dialog.component';
 import type { AnomalyDialogData } from '../dialogs/anomaly-dialog/anomaly-dialog.component';
+import type { ParentDistanceDialogData } from '../dialogs/parent-distance-dialog/parent-distance-dialog.component';
 import type { CollisionBodyInfo, CollisionDialogData } from '../dialogs/collision-dialog/collision-dialog.component';
 import type { SynodicDiagramInput } from '../data/collision-diagram';
 import type { JsonDialogData } from '../dialogs/json-dialog/json-dialog.component';
@@ -57,6 +58,7 @@ import {
   KG_PER_EARTH_MASS,
   KG_PER_MEGATONNE,
   KG_PER_SOLAR_MASS,
+  RADIANS_PER_DEGREE,
 } from '../data/unit-conversions';
 
 /**
@@ -284,6 +286,7 @@ export class SystemBodyComponent implements OnChanges {
     }
     this.getNextPeriapsis.set(this.calculateNextPeriapsis());
     this.getNextApoapsis.set(this.calculateNextApoapsis());
+    this.getParentDistanceKm.set(this.calculateParentDistanceKm());
     this.getRocheExcess.set(this.calculateRocheExcess());
     this.getStellarAgeAssessment.set(this.computeStellarAgeAssessment());
 
@@ -1319,6 +1322,35 @@ export class SystemBodyComponent implements OnChanges {
     });
   }
 
+  /** Opens the Parent Distance dialog with this body's live distance and its orbital elements. */
+  public async showParentDistanceDialog(): Promise<void> {
+    const body = this.body();
+    const bd = body.bodyData;
+    const aKm = this.getSemiMajorAxisKm();
+    if (aKm == null || bd.orbitalEccentricity == null || bd.meanAnomaly == null || !bd.orbitalPeriod || !bd.timestamps?.meanAnomaly) return;
+
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/parent-distance-dialog/parent-distance-dialog.component').then(m => m.ParentDistanceDialogComponent),
+      skeleton: 'diagram',
+      width: '900px',
+      maxWidth: '95vw',
+      hasBackdrop: true,
+      backdropClass: 'cdk-overlay-dark-backdrop',
+      data: {
+        bodyName: this.getBodyDisplayName(bd.name),
+        parentName: body.parent ? this.getBodyDisplayName(body.parent.bodyData.name) : undefined,
+        semiMajorAxisKm: aKm,
+        eccentricity: bd.orbitalEccentricity,
+        apoapsisKm: this.getApoapsis(),
+        periapsisKm: this.getPeriapsis(),
+        recordedMeanAnomaly: bd.meanAnomaly,
+        recordedTimestamp: new Date(bd.timestamps.meanAnomaly),
+        orbitalPeriodDays: bd.orbitalPeriod,
+        argOfPeriapsisDeg: bd.argOfPeriapsis ?? 0,
+      } satisfies ParentDistanceDialogData,
+    });
+  }
+
   /** Opens the collision dialog with this body's collision-candidate details. */
   public async showCollisionDialog(): Promise<void> {
     const status = this.collisionStatus();
@@ -1922,6 +1954,7 @@ export class SystemBodyComponent implements OnChanges {
   public readonly getLandableTooltip = signal('');
   public readonly getNextPeriapsis = signal<{ date: Date, days: number } | null>(null);
   public readonly getNextApoapsis = signal<{ date: Date, days: number } | null>(null);
+  public readonly getParentDistanceKm = signal<number | null>(null);
   public readonly getChildrenExpandedState = signal<boolean>(false);
   public readonly getRocheExcess = signal<number | null>(null);
   public readonly getStellarAgeAssessment = signal<StellarAgeAssessment | null>(null);
@@ -1947,6 +1980,28 @@ export class SystemBodyComponent implements OnChanges {
 
   private calculateNextApoapsis(): { date: Date, days: number } | null {
     return this.orbitalRelations.nextOrbitalEvent(this.body().bodyData, 'apo', this.appService.nowOverride() ?? Date.now());
+  }
+
+  /**
+   * Current straight-line distance (km) from the parent body — the orbital radius at the
+   * body's true anomaly right now — via the polar orbit equation r = a(1 − e²) / (1 + e·cos ν).
+   * Propagates the recorded mean anomaly to the same wall-clock "now" (or `?t=` override) that
+   * Next Apoapsis/Periapsis use, rather than the shared system-epoch snapshot Mean/True Anomaly
+   * show, so it reads as a genuinely live value. Null when the semi-major axis, eccentricity,
+   * or recorded mean anomaly + timestamp needed to propagate it is unavailable. Also null for
+   * an eccentricity outside [0, 1) (parabolic/hyperbolic escape trajectory, or corrupt data) —
+   * there's no recurring, bound orbit to place a "current distance" on — matching the same
+   * bound {@link OrbitalRelationsCore.orbitalRadialRange} enforces before computing extents.
+   */
+  private calculateParentDistanceKm(): number | null {
+    const bd = this.body().bodyData;
+    const aKm = this.getSemiMajorAxisKm();
+    const e = bd.orbitalEccentricity;
+    if (aKm == null || e == null || !(e >= 0) || e >= 1 || bd.meanAnomaly == null || !bd.orbitalPeriod || !bd.timestamps?.meanAnomaly) { return null; }
+    const now = this.appService.nowOverride() ?? Date.now();
+    const meanNow = this.orbitalRelations.meanAnomalyNow(bd.meanAnomaly, bd.orbitalPeriod, bd.timestamps.meanAnomaly, now);
+    const nu = this.orbitalRelations.meanToTrueAnomaly(meanNow, e) * RADIANS_PER_DEGREE;
+    return (aKm * (1 - e * e)) / (1 + e * Math.cos(nu));
   }
 
   private computeMaterialBadges(): void {


### PR DESCRIPTION
Moves Next Apoapsis/Periapsis into the Dynamics section and adds a Parent Distance row showing the body's current straight-line distance from its parent (r = a(1 - e^2) / (1 + e*cos nu)), propagated to the same wall-clock "now" that Next Apoapsis/Periapsis already use. The row opens a new dialog (mirroring the Mean/True Anomaly dialog) with a live-ticking value and an orbit diagram showing periapsis, apoapsis, and the body's current position.

<img width="630" height="296" alt="image" src="https://github.com/user-attachments/assets/15421efc-d2dc-4478-914a-239b58227406" />


<img width="892" height="1095" alt="image" src="https://github.com/user-attachments/assets/a093c468-ec29-4292-b555-a5cf732e889e" />

