### PR TITLE
Add Open Graph and Twitter Card meta tags for social link previews

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -16,6 +16,24 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <meta name="description" content="Canonn Signals is an Elite Dangerous system analysis tool showing detailed astronomical data, signal predictions, and orbital mechanics for stellar systems.">
+
+  <!-- Open Graph / Twitter Card. Static — this is a client-rendered SPA with no
+       SSR, so crawlers (which don't run JS) only ever see these tags, not the
+       per-system background image the app swaps in at runtime. -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://signals.canonn.tech/">
+  <meta property="og:title" content="Canonn Signals">
+  <meta property="og:description" content="Elite Dangerous system analysis tool showing detailed astronomical data, signal predictions, and orbital mechanics for stellar systems.">
+  <meta property="og:image" content="https://signals.canonn.tech/assets/bg1.jpg">
+  <meta property="og:image:width" content="2560">
+  <meta property="og:image:height" content="1440">
+  <meta property="og:image:alt" content="Canonn Signals background artwork">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Canonn Signals">
+  <meta name="twitter:description" content="Elite Dangerous system analysis tool showing detailed astronomical data, signal predictions, and orbital mechanics for stellar systems.">
+  <meta name="twitter:image" content="https://signals.canonn.tech/assets/bg1.jpg">
+
   <style>
     /* The app's global styles only load after bootstrap, so give the document a height
        here — otherwise the height:100% splash wrapper collapses and the centred logo

--- a/src/index.html
+++ b/src/index.html
@@ -33,6 +33,7 @@
   <meta name="twitter:title" content="Canonn Signals">
   <meta name="twitter:description" content="Elite Dangerous system analysis tool showing detailed astronomical data, signal predictions, and orbital mechanics for stellar systems.">
   <meta name="twitter:image" content="https://signals.canonn.tech/assets/bg1.jpg">
+  <meta name="twitter:image:alt" content="Canonn Signals background artwork">
 
   <style>
     /* The app's global styles only load after bootstrap, so give the document a height


### PR DESCRIPTION
## Summary
- Adds static Open Graph and Twitter Card meta tags to `src/index.html` so links shared on social media/chat apps render a title, description, and image preview
- Tags point at the default background image (`assets/bg1.jpg`) since the app is a client-rendered SPA with no SSR — crawlers never execute the JS that swaps in per-system backgrounds

## Test plan
- [ ] Validate tags with a social preview debugger (e.g. Facebook Sharing Debugger, Twitter Card Validator) once deployed
- [ ] Confirm image renders correctly in a shared link preview