### PR TITLE
Add quick filter buttons for expanding relevant bodies

### DIFF
--- a/src/app/data/body-filters.spec.ts
+++ b/src/app/data/body-filters.spec.ts
@@ -1,0 +1,199 @@
+import { TestBed } from '@angular/core/testing';
+import { CanonnBiostatsBody, SystemBody } from '../home/home.component';
+import { BODY_TYPE } from './body-types';
+import { BodyPhysicsService } from './body-physics.service';
+import { OrbitalRelationsService } from './orbital-relations.service';
+import {
+  collectMatchingBodies, walkBodies, resolveBodySignalsMap, getBodyHotspotKeys, getBodyMaterialKeys,
+  hasBiologySignals, hasGeologySignals, hasGuardianSignals, hasThargoidSignals, hasHumanSignals, isLandable,
+  isTouristInteresting,
+} from './body-filters';
+
+function makeBody(overrides: Partial<CanonnBiostatsBody> & { bodyId: number }): CanonnBiostatsBody {
+  return {
+    id64: BigInt(overrides.bodyId), name: `Body ${overrides.bodyId}`, type: BODY_TYPE.Planet, subType: 'Rocky body',
+    ...overrides,
+  };
+}
+
+function node(bodyData: CanonnBiostatsBody, parent: SystemBody | null = null): SystemBody {
+  return { bodyData, subBodies: [], parent };
+}
+
+describe('body-filters', () => {
+  describe('signal predicates', () => {
+    it('detects biology/geology signals but never on a Star', () => {
+      const planet = node(makeBody({
+        bodyId: 1, type: BODY_TYPE.Planet,
+        signals: { biology: ['Bacterium'], geology: [], updateTime: '' },
+      }));
+      expect(hasBiologySignals(planet)).toBe(true);
+      expect(hasGeologySignals(planet)).toBe(false);
+
+      const star = node(makeBody({
+        bodyId: 2, type: BODY_TYPE.Star,
+        signals: { biology: ['Bacterium'], signals: { '$SAA_SignalType_Geological;': 3 }, updateTime: '' },
+      }));
+      expect(hasBiologySignals(star)).toBe(false);
+      expect(hasGeologySignals(star)).toBe(false);
+    });
+
+    it('detects guardian/thargoid/human from either the array or the SAA signal count', () => {
+      const guardianByArray = node(makeBody({ bodyId: 1, signals: { guardian: ['Structure'], updateTime: '' } }));
+      const thargoidByCount = node(makeBody({ bodyId: 2, signals: { signals: { '$SAA_SignalType_Thargoid;': 4 }, updateTime: '' } }));
+      const humanBody = node(makeBody({ bodyId: 3, signals: { signals: { '$SAA_SignalType_Human;': 1 }, updateTime: '' } }));
+      const plainBody = node(makeBody({ bodyId: 4 }));
+
+      expect(hasGuardianSignals(guardianByArray)).toBe(true);
+      expect(hasThargoidSignals(thargoidByCount)).toBe(true);
+      expect(hasHumanSignals(humanBody)).toBe(true);
+      expect(hasGuardianSignals(plainBody)).toBe(false);
+      expect(hasThargoidSignals(plainBody)).toBe(false);
+      expect(hasHumanSignals(plainBody)).toBe(false);
+    });
+  });
+
+  describe('isLandable', () => {
+    it('matches only bodies flagged landable', () => {
+      expect(isLandable(node(makeBody({ bodyId: 1, isLandable: true })))).toBe(true);
+      expect(isLandable(node(makeBody({ bodyId: 2, isLandable: false })))).toBe(false);
+      expect(isLandable(node(makeBody({ bodyId: 3 })))).toBe(false);
+    });
+  });
+
+  describe('resolveBodySignalsMap / getBodyHotspotKeys', () => {
+    it('reads a ring body\'s hotspot signals from the parent\'s rings array, not the ring\'s own bodyData', () => {
+      const parentData = makeBody({
+        bodyId: 1, type: BODY_TYPE.Planet,
+        rings: [{
+          name: 'Ring A', innerRadius: 1, outerRadius: 2, mass: 1, type: 'Metallic',
+          signals: { signals: { 'Painite': 2, 'Platinum': 1 }, updateTime: '' },
+        }],
+      });
+      const parent = node(parentData);
+      const ring = node(makeBody({ bodyId: 2, name: 'Ring A', type: BODY_TYPE.Ring }), parent);
+      parent.subBodies.push(ring);
+
+      expect(resolveBodySignalsMap(ring)).toEqual({ 'Painite': 2, 'Platinum': 1 });
+      expect(getBodyHotspotKeys(ring)).toEqual(['Painite', 'Platinum']);
+    });
+
+    it('excludes non-mining SAA signal-type keys from the hotspot list', () => {
+      const planet = node(makeBody({ bodyId: 1, signals: { signals: { '$SAA_SignalType_Geological;': 3 }, updateTime: '' } }));
+      expect(getBodyHotspotKeys(planet)).toEqual([]);
+    });
+
+    it('returns undefined when a ring has no matching parent ring entry', () => {
+      const parent = node(makeBody({ bodyId: 1 }));
+      const ring = node(makeBody({ bodyId: 2, name: 'Ring A', type: BODY_TYPE.Ring }), parent);
+      expect(resolveBodySignalsMap(ring)).toBeUndefined();
+    });
+  });
+
+  describe('getBodyMaterialKeys', () => {
+    it('only includes materials with a nonzero percentage', () => {
+      const planet = node(makeBody({
+        bodyId: 1,
+        materials: {
+          Carbon: 5, Chromium: 0, Germanium: 0, Iron: 20, Manganese: 0,
+          Mercury: 0, Nickel: 0, Phosphorus: 0, Ruthenium: 0, Sulphur: 0, Tin: 0,
+        },
+      }));
+      expect(getBodyMaterialKeys(planet).sort()).toEqual(['Carbon', 'Iron']);
+    });
+
+    it('returns an empty list when the body has no materials', () => {
+      expect(getBodyMaterialKeys(node(makeBody({ bodyId: 1 })))).toEqual([]);
+    });
+  });
+
+  describe('walkBodies / collectMatchingBodies', () => {
+    it('visits every descendant, not just direct children', () => {
+      const root = node(makeBody({ bodyId: 1 }));
+      const child = node(makeBody({ bodyId: 2 }), root);
+      const grandchild = node(makeBody({ bodyId: 3 }), child);
+      root.subBodies.push(child);
+      child.subBodies.push(grandchild);
+
+      const visited: number[] = [];
+      walkBodies([root], b => visited.push(b.bodyData.bodyId));
+      expect(visited).toEqual([1, 2, 3]);
+    });
+
+    it('collects only the bodies matching the predicate', () => {
+      const root = node(makeBody({ bodyId: 1 }));
+      const a = node(makeBody({ bodyId: 2, signals: { biology: ['X'], updateTime: '' } }), root);
+      const b = node(makeBody({ bodyId: 3 }), root);
+      root.subBodies.push(a, b);
+
+      expect(collectMatchingBodies([root], hasBiologySignals)).toEqual(new Set([a]));
+    });
+
+    it('distinguishes bodies that share the same placeholder bodyId (belts/rings all use -1)', () => {
+      const root = node(makeBody({ bodyId: 1 }));
+      const ringA = node(makeBody({ bodyId: -1, name: 'Ring A', type: BODY_TYPE.Ring, signals: { signals: { 'Painite': 2 }, updateTime: '' } }), root);
+      const ringB = node(makeBody({ bodyId: -1, name: 'Ring B', type: BODY_TYPE.Ring }), root);
+      root.subBodies.push(ringA, ringB);
+
+      const matches = collectMatchingBodies([root], body => getBodyHotspotKeys(body).includes('Painite'));
+      expect(matches.has(ringA)).toBe(true);
+      expect(matches.has(ringB)).toBe(false);
+    });
+  });
+
+  describe('isTouristInteresting', () => {
+    let physics: BodyPhysicsService;
+    let orbitalRelations: OrbitalRelationsService;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({});
+      physics = TestBed.inject(BodyPhysicsService);
+      orbitalRelations = TestBed.inject(OrbitalRelationsService);
+    });
+
+    it('matches an interesting subtype', () => {
+      const body = node(makeBody({ bodyId: 1, subType: 'Earth-like world' }));
+      expect(isTouristInteresting(body, physics, orbitalRelations)).toBe(true);
+    });
+
+    it('matches a landable body', () => {
+      const body = node(makeBody({ bodyId: 1, isLandable: true }));
+      expect(isTouristInteresting(body, physics, orbitalRelations)).toBe(true);
+    });
+
+    it('matches a terraformable body', () => {
+      const body = node(makeBody({ bodyId: 1, terraformingState: 'Terraformable' }));
+      expect(isTouristInteresting(body, physics, orbitalRelations)).toBe(true);
+    });
+
+    it('does not match a tidally-locked (synchronised) body on its own', () => {
+      const body = node(makeBody({ bodyId: 1, subType: 'Rocky body', rotationalPeriodTidallyLocked: true }));
+      expect(isTouristInteresting(body, physics, orbitalRelations)).toBe(false);
+    });
+
+    it('does not match an unremarkable body', () => {
+      const body = node(makeBody({ bodyId: 1, subType: 'Rocky body' }));
+      expect(isTouristInteresting(body, physics, orbitalRelations)).toBe(false);
+    });
+
+    it('matches a ring carrying a Taylor-ring badge', () => {
+      const parent = node(makeBody({ bodyId: 1, type: BODY_TYPE.Planet, radius: 1000 }));
+      const ring = node(makeBody({
+        bodyId: -1, name: 'Ring A', type: BODY_TYPE.Ring, innerRadius: 100, outerRadius: 150, mass: 1e10,
+      }), parent);
+      parent.subBodies.push(ring);
+
+      expect(isTouristInteresting(ring, physics, orbitalRelations)).toBe(true);
+    });
+
+    it('does not match an unremarkable ring', () => {
+      const parent = node(makeBody({ bodyId: 1, type: BODY_TYPE.Planet, radius: 1000 }));
+      const ring = node(makeBody({
+        bodyId: -1, name: 'Ring A', type: BODY_TYPE.Ring, innerRadius: 100, outerRadius: 400, mass: 1e10,
+      }), parent);
+      parent.subBodies.push(ring);
+
+      expect(isTouristInteresting(ring, physics, orbitalRelations)).toBe(false);
+    });
+  });
+});

--- a/src/app/data/body-filters.ts
+++ b/src/app/data/body-filters.ts
@@ -1,0 +1,163 @@
+import type { SystemBody } from '../home/home.component';
+import { BODY_TYPE } from './body-types';
+import { MINING_RESOURCES } from './mining-resources';
+import { BodyPhysicsService } from './body-physics.service';
+import { OrbitalRelationsService } from './orbital-relations.service';
+import { assessStellarAge, isPlottableStarClass } from './stellar-reference';
+
+/**
+ * Quick-filter categories for the system-page toolbar. Each expands the bodies
+ * matching the category and collapses every other body. `materials`/`mining`
+ * additionally need a set of selected keys (materials or hotspot resources).
+ */
+export type FilterCategory = 'biology' | 'geology' | 'guardian' | 'thargoid' | 'human' | 'materials' | 'mining' | 'landable' | 'tourist' | 'everything';
+
+/**
+ * A quick-filter "apply now" instruction, threaded down through every `SystemBodyComponent`
+ * (root and descendants alike) as an input. `token` increments on every click so a repeat
+ * click of the same button (recomputing the same `bodies`) still re-applies — a same-reference
+ * `Set` wouldn't otherwise be seen as a change. `bodies === 'all'` expands every body (the
+ * "Everything" filter); otherwise only the bodies in the set are expanded, and every other
+ * body is collapsed.
+ *
+ * Matched by `SystemBody` object identity, not `bodyData.bodyId`: belts and rings are
+ * synthesized in `HomeComponent.processBodies` with a shared placeholder `bodyId` of `-1`
+ * (the game data has no real id for them), so an id-keyed set would make one matching ring
+ * expand every ring and belt in the system.
+ */
+export interface FilterCommand {
+  token: number;
+  bodies: Set<SystemBody> | 'all';
+}
+
+/** Recursively visits every body in the tree, including all descendants. */
+export function walkBodies(roots: SystemBody[], visit: (body: SystemBody) => void): void {
+  for (const body of roots) {
+    visit(body);
+    if (body.subBodies.length) {
+      walkBodies(body.subBodies, visit);
+    }
+  }
+}
+
+/** Collects every body (anywhere in the tree) for which `predicate` is true. */
+export function collectMatchingBodies(roots: SystemBody[], predicate: (body: SystemBody) => boolean): Set<SystemBody> {
+  const matches = new Set<SystemBody>();
+  walkBodies(roots, body => {
+    if (predicate(body)) {
+      matches.add(body);
+    }
+  });
+  return matches;
+}
+
+export function hasBiologySignals(body: SystemBody): boolean {
+  if (body.bodyData.type === BODY_TYPE.Star) { return false; }
+  const signals = body.bodyData.signals;
+  return (signals?.biology?.length ?? 0) > 0 || (signals?.signals?.['$SAA_SignalType_Biological;'] ?? 0) > 0;
+}
+
+export function hasGeologySignals(body: SystemBody): boolean {
+  if (body.bodyData.type === BODY_TYPE.Star) { return false; }
+  const signals = body.bodyData.signals;
+  return (signals?.geology?.length ?? 0) > 0 || (signals?.signals?.['$SAA_SignalType_Geological;'] ?? 0) > 0;
+}
+
+export function hasGuardianSignals(body: SystemBody): boolean {
+  const signals = body.bodyData.signals;
+  return (signals?.guardian?.length ?? 0) > 0 || (signals?.signals?.['$SAA_SignalType_Guardian;'] ?? 0) > 0;
+}
+
+export function hasThargoidSignals(body: SystemBody): boolean {
+  const signals = body.bodyData.signals;
+  return (signals?.thargoid?.length ?? 0) > 0 || (signals?.signals?.['$SAA_SignalType_Thargoid;'] ?? 0) > 0;
+}
+
+export function hasHumanSignals(body: SystemBody): boolean {
+  return (body.bodyData.signals?.signals?.['$SAA_SignalType_Human;'] ?? 0) > 0;
+}
+
+export function isLandable(body: SystemBody): boolean {
+  return !!body.bodyData.isLandable;
+}
+
+/**
+ * Resolves the raw signal-count map (hotspot name -> count) that applies to `body`. Rings
+ * carry their own signals nested under the parent's `rings[]` entry rather than on the ring's
+ * own `bodyData.signals`, so those need a name-matched lookup against the parent.
+ */
+export function resolveBodySignalsMap(body: SystemBody): { [key: string]: number } | undefined {
+  if (body.bodyData.signals?.signals) {
+    return body.bodyData.signals.signals;
+  }
+  if (body.bodyData.type === BODY_TYPE.Ring && body.parent?.bodyData.rings) {
+    const ringData = body.parent.bodyData.rings.find(r => r.name === body.bodyData.name);
+    return ringData?.signals?.signals;
+  }
+  return undefined;
+}
+
+/** Mining-hotspot resource keys (as found in {@link MINING_RESOURCES}) present on `body`. */
+export function getBodyHotspotKeys(body: SystemBody): string[] {
+  const signals = resolveBodySignalsMap(body);
+  if (!signals) { return []; }
+  return Object.keys(signals).filter(key => key in MINING_RESOURCES);
+}
+
+/** Surface-material keys with a nonzero percentage on `body`. */
+export function getBodyMaterialKeys(body: SystemBody): string[] {
+  const materials = body.bodyData.materials;
+  if (!materials) { return []; }
+  return Object.entries(materials).filter(([, percentage]) => percentage > 0).map(([material]) => material);
+}
+
+const TOURIST_INTERESTING_SUBTYPES = new Set(['Earth-like world', 'Water world', 'Ammonia world']);
+
+/**
+ * "Tourist" quick filter: bodies carrying one of the special badges shown in the body title,
+ * excluding orbital-collision candidates (that badge resolves asynchronously per body via a
+ * background worker — see {@link BodyInterestRegistryService} for how it's folded back in once
+ * available). Rings carry their own set of badges (Invisible, Taylor/Pauper, Racing Rings) via
+ * {@link BodyPhysicsService}'s ring-classification methods.
+ */
+export function isTouristInteresting(body: SystemBody, physics: BodyPhysicsService, orbitalRelations: OrbitalRelationsService): boolean {
+  const bd = body.bodyData;
+
+  if (bd.type === BODY_TYPE.Ring) {
+    if (physics.isInvisibleRing(bd)) { return true; }
+    const ringClass = physics.classifyRingSystem(body);
+    if (ringClass?.isTaylor || ringClass?.isPauper) { return true; }
+    if (physics.isRacingRings(body)) { return true; }
+  }
+
+  if (TOURIST_INTERESTING_SUBTYPES.has(bd.subType)
+    || bd.subType?.includes('Black Hole')
+    || bd.subType === 'Neutron Star'
+    || bd.subType?.includes('White Dwarf')
+    || bd.subType?.includes('Wolf-Rayet')
+    || bd.subType?.includes('Herbig')) {
+    return true;
+  }
+  if (bd.isLandable) { return true; }
+  if (bd.terraformingState === 'Terraformable') { return true; }
+
+  const trojan = orbitalRelations.detectTrojanStatus(body);
+  if (trojan.lagrangePoint || trojan.isHost) { return true; }
+  if (orbitalRelations.detectRosetteStatus(body)) { return true; }
+
+  if (physics.isActualShepherd(body)) { return true; }
+  if (physics.rocheExcess(body) !== null) { return true; }
+
+  if (bd.type === BODY_TYPE.Star && bd.age != null && isPlottableStarClass(bd.spectralClass, bd.subType)) {
+    const assessment = assessStellarAge({
+      spectralClass: bd.spectralClass,
+      subType: bd.subType,
+      luminosity: bd.luminosity,
+      solarMasses: bd.solarMasses,
+      ageMyr: bd.age,
+    });
+    if (assessment.status === 'old' || assessment.status === 'young') { return true; }
+  }
+
+  return false;
+}

--- a/src/app/data/body-interest-registry.service.spec.ts
+++ b/src/app/data/body-interest-registry.service.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+import { CanonnBiostatsBody, SystemBody } from '../home/home.component';
+import { BODY_TYPE } from './body-types';
+import { BodyInterestRegistryService } from './body-interest-registry.service';
+
+function makeBody(bodyId: number): SystemBody {
+  const bodyData: CanonnBiostatsBody = {
+    bodyId, id64: BigInt(Math.max(bodyId, 0)), name: `Body ${bodyId}`, type: BODY_TYPE.Planet, subType: 'Rocky body',
+  };
+  return { bodyData, subBodies: [], parent: null };
+}
+
+describe('BodyInterestRegistryService', () => {
+  let service: BodyInterestRegistryService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BodyInterestRegistryService);
+  });
+
+  it('starts empty', () => {
+    expect(service.collisionCandidateBodies().size).toBe(0);
+  });
+
+  it('records a reported candidate for the current system', () => {
+    const body = makeBody(42);
+    service.resetForSystem(1n);
+    service.reportCollisionCandidate(1n, body, true);
+    expect(service.collisionCandidateBodies().has(body)).toBe(true);
+  });
+
+  it('removes a body once it is reported as no longer a candidate', () => {
+    const body = makeBody(42);
+    service.resetForSystem(1n);
+    service.reportCollisionCandidate(1n, body, true);
+    service.reportCollisionCandidate(1n, body, false);
+    expect(service.collisionCandidateBodies().has(body)).toBe(false);
+  });
+
+  it('ignores a report keyed to a system that is no longer current', () => {
+    const body = makeBody(42);
+    service.resetForSystem(1n);
+    service.reportCollisionCandidate(2n, body, true);
+    expect(service.collisionCandidateBodies().size).toBe(0);
+  });
+
+  it('clears prior results when a different system is loaded', () => {
+    const body = makeBody(42);
+    service.resetForSystem(1n);
+    service.reportCollisionCandidate(1n, body, true);
+    service.resetForSystem(2n);
+    expect(service.collisionCandidateBodies().size).toBe(0);
+  });
+
+  it('is a no-op when reset to the same system key it already has', () => {
+    const body = makeBody(42);
+    service.resetForSystem(1n);
+    service.reportCollisionCandidate(1n, body, true);
+    service.resetForSystem(1n);
+    expect(service.collisionCandidateBodies().has(body)).toBe(true);
+  });
+
+  it('distinguishes two different bodies that share the same placeholder bodyId', () => {
+    const ringA = makeBody(-1);
+    const ringB = makeBody(-1);
+    service.resetForSystem(1n);
+    service.reportCollisionCandidate(1n, ringA, true);
+    expect(service.collisionCandidateBodies().has(ringA)).toBe(true);
+    expect(service.collisionCandidateBodies().has(ringB)).toBe(false);
+  });
+});

--- a/src/app/data/body-interest-registry.service.ts
+++ b/src/app/data/body-interest-registry.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, signal } from '@angular/core';
+import type { SystemBody } from '../home/home.component';
+
+/**
+ * Tracks which bodies in the currently-loaded system have resolved as orbital-collision
+ * candidates. Collision status is computed off the main thread per body (see
+ * `SystemBodyComponent.requestCollisionStatus`) independently of whether that body's panel
+ * is expanded, so results trickle in asynchronously; this registry lets the "Tourist" quick
+ * filter (computed eagerly from synchronous body data in `HomeComponent`) pick up collision
+ * candidates as they resolve, without every body needing to re-run its own collision search.
+ *
+ * Keyed by `SystemBody` object identity rather than `bodyData.bodyId`: belts and rings are
+ * synthesized with a shared placeholder `bodyId` of `-1` (see `HomeComponent.processBodies`),
+ * so an id-keyed set would make one candidate ring/belt mark every ring and belt as one too.
+ */
+@Injectable({ providedIn: 'root' })
+export class BodyInterestRegistryService {
+  private systemKey: string | number | bigint | null = null;
+  private readonly collisionCandidates = signal<ReadonlySet<SystemBody>>(new Set());
+  readonly collisionCandidateBodies = this.collisionCandidates.asReadonly();
+
+  /** Clears prior results when a new system loads. `key` should uniquely identify the system (its id64). */
+  resetForSystem(key: string | number | bigint): void {
+    if (this.systemKey === key) { return; }
+    this.systemKey = key;
+    this.collisionCandidates.set(new Set());
+  }
+
+  /** Reports whether `body` is a collision candidate. Ignored if `systemKey` isn't the current system. */
+  reportCollisionCandidate(systemKey: string | number | bigint, body: SystemBody, isCandidate: boolean): void {
+    if (systemKey !== this.systemKey) { return; }
+    const current = this.collisionCandidates();
+    if (current.has(body) === isCandidate) { return; }
+    const next = new Set(current);
+    if (isCandidate) { next.add(body); } else { next.delete(body); }
+    this.collisionCandidates.set(next);
+  }
+}

--- a/src/app/data/body-physics.service.ts
+++ b/src/app/data/body-physics.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { CanonnBiostatsBody, SystemBody } from '../home/home.component';
 import { BODY_TYPE } from './body-types';
 import { KM_PER_AU, KM_PER_SOLAR_RADIUS, KG_PER_EARTH_MASS, KG_PER_SOLAR_MASS, KG_PER_MEGATONNE } from './unit-conversions';
+import type { RingClassificationRingInfo } from '../dialogs/ring-classification-dialog/ring-classification-dialog.component';
 
 /** Approximate Earth masses per solar mass, used for parent-mass conversions. */
 const EARTH_MASSES_PER_SOLAR_MASS = 332950;
@@ -14,6 +15,33 @@ export const SPEED_OF_LIGHT = 299792458;
 export const INVISIBLE_RING_MAX_DENSITY = 0.1;
 /** Rings wider than this (km) are considered invisible when density is also low. */
 export const INVISIBLE_RING_MIN_WIDTH = 1_000_000;
+
+/**
+ * Maximum gap between adjacent rings (km) for the Racing Rings badge.
+ * Set so that both ring edges are likely to be simultaneously visible when
+ * flying nearby. The value is intentionally generous and may be tightened
+ * once in-game observations are collected.
+ */
+export const RACING_RINGS_MAX_GAP_KM = 50;
+/**
+ * Minimum outer-to-inner velocity difference (km/s) for the Racing Rings badge.
+ * Chosen as a speed differential large enough to be noticeable in-game;
+ * may be adjusted after in-game observations.
+ */
+export const RACING_RINGS_MIN_SPEED_DIFF_KMS = 5;
+
+/**
+ * Body-radius multiple below which a ring system's total span counts as narrow. Used
+ * as the Taylor ring badge's upper threshold, and as the Pauper ring badge's lower
+ * bound (a span this narrow is a Taylor ring, not a Pauper ring).
+ */
+export const NARROW_RING_SPAN_RADII = 0.25;
+/** Body-radii the innermost visible ring edge must clear for the Pauper ring badge (unusually distant). */
+export const PAUPER_RING_MIN_INNER_EDGE_RADII = 14;
+/** Maximum span (body radii) for the Pauper ring badge — no wider than one body diameter. */
+export const PAUPER_RING_MAX_SPAN_RADII = 2;
+/** Fraction of the total span above which a gap between two adjacent visible rings is called out as potentially visible. */
+export const VISIBLE_GAP_SPAN_FRACTION = 0.02;
 
 /**
  * Degenerate-matter stability limits (solar masses). The Chandrasekhar limit caps a
@@ -96,6 +124,26 @@ export interface RingDynamics {
   maxVelocityKms: number;
 }
 
+/** Taylor/Pauper ring classification, shared by every visible ring belonging to the same parent. */
+export interface RingClassification {
+  isTaylor: boolean;
+  isPauper: boolean;
+  span: number;
+  innermostInner: number;
+  outermostOuter: number;
+  parentRadius: number;
+  rings: RingClassificationRingInfo[];
+  hasVisibleGap: boolean;
+}
+
+/** Gap and relative velocity to a ring's next-outward sibling, for the Racing Rings badge. */
+export interface RingNeighbourDistance {
+  distance: number | null;
+  label: string;
+  velocityDiff: number | null;
+  eitherRingInvisible: boolean;
+}
+
 /**
  * Pure astrophysics for a body and its parent: densities, Roche limits, Hill
  * spheres and ring-shepherding analysis. Extracted from SystemBodyComponent so
@@ -139,6 +187,111 @@ export class BodyPhysicsService {
    */
   isLowDensityWideRing(widthKm: number, densityKgPerKm2: number): boolean {
     return densityKgPerKm2 < INVISIBLE_RING_MAX_DENSITY && widthKm > INVISIBLE_RING_MIN_WIDTH;
+  }
+
+  /** Whether `bd` (a ring) is invisible in-game — see {@link isLowDensityWideRing}. */
+  isInvisibleRing(bd: CanonnBiostatsBody): boolean {
+    if (bd.type !== BODY_TYPE.Ring) { return false; }
+    const outer = bd.outerRadius ?? 0;
+    const inner = bd.innerRadius ?? 0;
+    const width = outer - inner;
+    const area = Math.PI * (outer * outer - inner * inner);
+    const density = area > 0 ? (bd.mass ?? 0) / area : 0;
+    return this.isLowDensityWideRing(width, density);
+  }
+
+  /** `parent`'s ring-type sub-bodies, sorted by inner radius ascending. Includes invisible rings — callers filter those out themselves when they don't want them. */
+  sortedRingSiblings(parent: SystemBody): SystemBody[] {
+    return parent.subBodies
+      .filter(s => s.bodyData.type === BODY_TYPE.Ring)
+      .sort((a, b) => (a.bodyData.innerRadius ?? 0) - (b.bodyData.innerRadius ?? 0));
+  }
+
+  /** Strips the " Ring" suffix from a ring body's name, leaving just its letter designation (e.g. "A"). */
+  private stripRingSuffix(name: string): string {
+    return name.replace('Ring', '').trim();
+  }
+
+  /**
+   * Classifies `body`'s ring system as Taylor (unusually narrow) and/or Pauper (unusually
+   * wide and distant), or null when `body` isn't a visible ring or the classification can't
+   * be computed. Both badges are derived from the same "span" of the body's *visible* rings
+   * (invisible rings — see {@link isInvisibleRing} — are stripped first), so the result is
+   * identical for every ring belonging to the same parent and the badge shows on all of them.
+   */
+  classifyRingSystem(body: SystemBody): RingClassification | null {
+    const bd = body.bodyData;
+    if (bd.type !== BODY_TYPE.Ring || !body.parent || this.isInvisibleRing(bd)) { return null; }
+
+    const parentRadius = this.getParentRadiusKm(body);
+    if (!parentRadius) { return null; }
+
+    const visibleRings = this.sortedRingSiblings(body.parent)
+      .filter(s => !this.isInvisibleRing(s.bodyData));
+    if (visibleRings.length === 0) { return null; }
+
+    // Already sorted by inner radius ascending, so the first entry is the innermost inner edge.
+    const innermostInner = visibleRings[0].bodyData.innerRadius ?? 0;
+    const outermostOuter = Math.max(...visibleRings.map(r => r.bodyData.outerRadius ?? 0));
+    const span = outermostOuter - innermostInner;
+
+    const isTaylor = span < NARROW_RING_SPAN_RADII * parentRadius;
+    // `span > NARROW_RING_SPAN_RADII * parentRadius` here is what keeps this mutually
+    // exclusive with isTaylor above (span < the same threshold).
+    const isPauper = innermostInner >= PAUPER_RING_MIN_INNER_EDGE_RADII * parentRadius
+      && span <= PAUPER_RING_MAX_SPAN_RADII * parentRadius
+      && span > NARROW_RING_SPAN_RADII * parentRadius;
+
+    const rings = visibleRings.map(r => ({
+      name: this.stripRingSuffix(r.bodyData.name),
+      innerRadius: r.bodyData.innerRadius ?? 0,
+      outerRadius: r.bodyData.outerRadius ?? 0,
+    }));
+
+    // Gap between each ring's outer edge and the next ring's inner edge — a gap wide enough
+    // relative to the total span may show up as a visible break in an otherwise "single ring".
+    const hasVisibleGap = span > 0 && rings.some((r, i) => {
+      const next = rings[i + 1];
+      if (!next) { return false; }
+      return (next.innerRadius - r.outerRadius) > VISIBLE_GAP_SPAN_FRACTION * span;
+    });
+
+    return { isTaylor, isPauper, span, innermostInner, outermostOuter, parentRadius, rings, hasVisibleGap };
+  }
+
+  /** Gap and relative velocity between `body` (a ring) and its next-outward sibling, for the Racing Rings badge. */
+  ringNeighbourDistance(body: SystemBody): RingNeighbourDistance {
+    const bd = body.bodyData;
+    if (bd.type !== BODY_TYPE.Ring || !body.parent) {
+      return { distance: null, label: '', velocityDiff: null, eitherRingInvisible: false };
+    }
+    const siblings = this.sortedRingSiblings(body.parent);
+    const idx = siblings.indexOf(body);
+    if (idx < 0 || idx === siblings.length - 1) {
+      return { distance: null, label: '', velocityDiff: null, eitherRingInvisible: false };
+    }
+    const next = siblings[idx + 1];
+    const distance = (next.bodyData.innerRadius ?? 0) - (bd.outerRadius ?? 0);
+    const thisLabel = this.stripRingSuffix(bd.name);
+    const nextLabel = this.stripRingSuffix(next.bodyData.name);
+    const currentDynamics = this.ringDynamics(body);
+    const nextDynamics = this.ringDynamics(next);
+    const velocityDiff = (currentDynamics !== null && nextDynamics !== null)
+      ? currentDynamics.maxVelocityKms - nextDynamics.minVelocityKms
+      : null;
+    const eitherRingInvisible = this.isInvisibleRing(bd) || this.isInvisibleRing(next.bodyData);
+    return { distance, label: `${thisLabel}-${nextLabel}`, velocityDiff, eitherRingInvisible };
+  }
+
+  /**
+   * Racing Rings badge: `body` (a ring) sits within {@link RACING_RINGS_MAX_GAP_KM} of its
+   * next-outward sibling with a velocity differential above {@link RACING_RINGS_MIN_SPEED_DIFF_KMS},
+   * and neither ring in the pair is invisible.
+   */
+  isRacingRings(body: SystemBody): boolean {
+    const { distance, velocityDiff, eitherRingInvisible } = this.ringNeighbourDistance(body);
+    return distance !== null && velocityDiff !== null
+      && distance < RACING_RINGS_MAX_GAP_KM && velocityDiff > RACING_RINGS_MIN_SPEED_DIFF_KMS && !eitherRingInvisible;
   }
 
   /** Parent radius in km, or null when the parent exposes no radius. */

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -365,7 +365,7 @@
     }
     @if (bodies().length) {
     <div class="quick-filters">
-      @if (biologyMatchIds().size) {
+      @if (biologyMatches().size) {
       <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'biology'"
         (click)="onBiologyFilterClick()" title="Expand only bodies with biological signals"
         aria-label="Expand only bodies with biological signals">
@@ -373,7 +373,7 @@
         <span>Biology</span>
       </button>
       }
-      @if (geologyMatchIds().size) {
+      @if (geologyMatches().size) {
       <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'geology'"
         (click)="onGeologyFilterClick()" title="Expand only bodies with geological signals"
         aria-label="Expand only bodies with geological signals">
@@ -381,7 +381,7 @@
         <span>Geology</span>
       </button>
       }
-      @if (guardianMatchIds().size) {
+      @if (guardianMatches().size) {
       <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'guardian'"
         (click)="onGuardianFilterClick()" title="Expand only bodies with Guardian sites"
         aria-label="Expand only bodies with Guardian sites">
@@ -389,7 +389,7 @@
         <span>Guardian</span>
       </button>
       }
-      @if (thargoidMatchIds().size) {
+      @if (thargoidMatches().size) {
       <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'thargoid'"
         (click)="onThargoidFilterClick()" title="Expand only bodies with Thargoid sites"
         aria-label="Expand only bodies with Thargoid sites">
@@ -397,7 +397,7 @@
         <span>Thargoid</span>
       </button>
       }
-      @if (humanMatchIds().size) {
+      @if (humanMatches().size) {
       <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'human'"
         (click)="onHumanFilterClick()" title="Expand only bodies with human sites"
         aria-label="Expand only bodies with human sites">
@@ -405,7 +405,7 @@
         <span>Human</span>
       </button>
       }
-      @if (landableMatchIds().size) {
+      @if (landableMatches().size) {
       <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'landable'"
         (click)="onLandableFilterClick()" title="Expand only landable bodies"
         aria-label="Expand only landable bodies">
@@ -455,7 +455,7 @@
         }
       </div>
       }
-      @if (touristMatchIds().size) {
+      @if (touristMatches().size) {
       <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'tourist'"
         (click)="onTouristFilterClick()" title="Expand only bodies with special badges"
         aria-label="Expand only bodies with special badges">

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -364,11 +364,114 @@
     </div>
     }
     @if (bodies().length) {
+    <div class="quick-filters">
+      @if (biologyMatchIds().size) {
+      <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'biology'"
+        (click)="onBiologyFilterClick()" title="Expand only bodies with biological signals"
+        aria-label="Expand only bodies with biological signals">
+        <img alt="" src="assets/icons/Biology.svg" />
+        <span>Biology</span>
+      </button>
+      }
+      @if (geologyMatchIds().size) {
+      <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'geology'"
+        (click)="onGeologyFilterClick()" title="Expand only bodies with geological signals"
+        aria-label="Expand only bodies with geological signals">
+        <img alt="" src="assets/icons/Geology.svg" />
+        <span>Geology</span>
+      </button>
+      }
+      @if (guardianMatchIds().size) {
+      <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'guardian'"
+        (click)="onGuardianFilterClick()" title="Expand only bodies with Guardian sites"
+        aria-label="Expand only bodies with Guardian sites">
+        <img alt="" src="assets/icons/Guardian.svg" />
+        <span>Guardian</span>
+      </button>
+      }
+      @if (thargoidMatchIds().size) {
+      <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'thargoid'"
+        (click)="onThargoidFilterClick()" title="Expand only bodies with Thargoid sites"
+        aria-label="Expand only bodies with Thargoid sites">
+        <img alt="" src="assets/icons/Thargoid.svg" />
+        <span>Thargoid</span>
+      </button>
+      }
+      @if (humanMatchIds().size) {
+      <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'human'"
+        (click)="onHumanFilterClick()" title="Expand only bodies with human sites"
+        aria-label="Expand only bodies with human sites">
+        <img alt="" src="assets/icons/Human.svg" />
+        <span>Human</span>
+      </button>
+      }
+      @if (landableMatchIds().size) {
+      <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'landable'"
+        (click)="onLandableFilterClick()" title="Expand only landable bodies"
+        aria-label="Expand only landable bodies">
+        <img alt="" src="assets/icons/footprint.svg" style="filter: brightness(0) invert(1);" />
+        <span>Landable</span>
+      </button>
+      }
+      @if (availableMaterialKeys().length) {
+      <div class="quick-filter-dropdown" (click)="$event.stopPropagation()">
+        <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'materials'"
+          (click)="toggleMaterialsMenu()" aria-haspopup="true" [attr.aria-expanded]="materialsMenuOpen()"
+          title="Expand only bodies containing selected materials">
+          <span>Materials{{ selectedMaterials().size ? ' (' + selectedMaterials().size + ')' : '' }}</span>
+          <fa-icon [icon]="faChevronDown" aria-hidden="true"></fa-icon>
+        </button>
+        @if (materialsMenuOpen()) {
+        <div class="quick-filter-menu">
+          @for (material of availableMaterialKeys(); track material) {
+          <label class="quick-filter-menu-item">
+            <input type="checkbox" [checked]="selectedMaterials().has(material)"
+              (change)="toggleMaterialSelection(material)" />
+            {{ material }}
+          </label>
+          }
+        </div>
+        }
+      </div>
+      }
+      @if (availableHotspotKeys().length) {
+      <div class="quick-filter-dropdown" (click)="$event.stopPropagation()">
+        <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'mining'"
+          (click)="toggleMiningMenu()" aria-haspopup="true" [attr.aria-expanded]="miningMenuOpen()"
+          title="Expand only bodies containing selected mining hotspots">
+          <span>Mining{{ selectedHotspots().size ? ' (' + selectedHotspots().size + ')' : '' }}</span>
+          <fa-icon [icon]="faChevronDown" aria-hidden="true"></fa-icon>
+        </button>
+        @if (miningMenuOpen()) {
+        <div class="quick-filter-menu">
+          @for (resource of availableHotspotKeys(); track resource) {
+          <label class="quick-filter-menu-item">
+            <input type="checkbox" [checked]="selectedHotspots().has(resource)"
+              (change)="toggleHotspotSelection(resource)" />
+            {{ hotspotDisplayName(resource) }}
+          </label>
+          }
+        </div>
+        }
+      </div>
+      }
+      @if (touristMatchIds().size) {
+      <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'tourist'"
+        (click)="onTouristFilterClick()" title="Expand only bodies with special badges"
+        aria-label="Expand only bodies with special badges">
+        <span>Tourist</span>
+      </button>
+      }
+      <button type="button" class="quick-filter-button" [class.active]="activeFilterCategory() === 'everything'"
+        (click)="onEverythingFilterClick()" title="Expand every body" aria-label="Expand every body">
+        <span>Everything</span>
+      </button>
+    </div>
     <div class="bodies">
       @for (body of bodies(); track trackByBody($index, body); let isLast = $last) {
       <app-system-body [body]="body" [isRoot]="true" [isLast]="isLast" [forceExpanded]="getTotalBodyCount() <= 3"
-        [anchorBodyId]="anchorBodyId()" [edGalaxyData]="edGalaxy"
-        [systemPopulation]="data.system.population"></app-system-body>
+        [anchorBodyId]="anchorBodyId()" [edGalaxyData]="edGalaxy" [filterCommand]="filterCommand()"
+        [systemKey]="systemKey()" [systemPopulation]="data.system.population"></app-system-body>
       }
     </div>
     }

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -169,6 +169,92 @@
     transition: width 0.4s ease, background-color 0.4s ease;
 }
 
+/* Quick-filter toolbar: collapses every body except those matching the pressed
+   category. Sits between System Completeness and the body list. Buttons for
+   categories with no matching body in the current system are omitted entirely
+   (see the @if guards in the template) rather than shown disabled. */
+.quick-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 8px;
+    background-color: rgba(150, 150, 150, 0.7);
+    backdrop-filter: blur(6px);
+    padding: 6px;
+    border-radius: 4px;
+    /* `.bodies` below also uses backdrop-filter, which forms its own stacking context;
+       being later in the DOM it would otherwise paint over this toolbar's dropdown menus
+       regardless of their own z-index. Promoting this container above it fixes that. */
+    position: relative;
+    z-index: 1;
+}
+
+.quick-filter-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 8px;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid transparent;
+    border-radius: 4px;
+    color: var(--color-white);
+    cursor: pointer;
+    font-size: 12px;
+    line-height: 1.2;
+    white-space: nowrap;
+}
+
+.quick-filter-button img {
+    width: 14px;
+    height: 14px;
+}
+
+.quick-filter-button:hover {
+    background: var(--color-surface-hover);
+}
+
+.quick-filter-button.active {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+}
+
+.quick-filter-dropdown {
+    position: relative;
+}
+
+.quick-filter-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 20;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 180px;
+    max-height: 260px;
+    overflow-y: auto;
+    background-color: var(--color-surface, #333);
+    border: 1px solid var(--color-border, #555);
+    border-radius: 4px;
+    padding: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.quick-filter-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 4px;
+    color: var(--color-white);
+    font-size: 12px;
+    cursor: pointer;
+    border-radius: 3px;
+}
+
+.quick-filter-menu-item:hover {
+    background: var(--color-surface-hover);
+}
+
 .bodies {
     background-color: rgba(150, 150, 150, 0.7);
     backdrop-filter: blur(6px);

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, inject, viewChild, signal, computed, effect } from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, HostListener, inject, viewChild, signal, computed, effect } from '@angular/core';
 import { AppService, EdastroData } from '../app.service';
 import { ActivatedRoute, Params, Router } from '@angular/router';
-import { faChartColumn, faDownload, faFileCode, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { faChartColumn, faChevronDown, faDownload, faFileCode, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import { MatDialog } from '@angular/material/dialog';
 import { openLazyDialog } from '../dialogs/lazy-dialog';
 import type { HistogramDialogData } from '../dialogs/histogram-dialog/histogram-dialog.component';
@@ -27,6 +27,15 @@ import { BodyEnrichmentService } from '../data/body-enrichment.service';
 import { buildSystemExport, downloadJson, serializeSystemExport, systemExportFilename } from '../data/system-export';
 import { buildMegashipIndex, megashipRoute, megashipsAtSystem, MegashipSystemEntry } from '../data/megaships';
 import type { MegashipRouteDialogData } from '../dialogs/megaship-route-dialog/megaship-route-dialog.component';
+import { BodyPhysicsService } from '../data/body-physics.service';
+import { OrbitalRelationsService } from '../data/orbital-relations.service';
+import { BodyInterestRegistryService } from '../data/body-interest-registry.service';
+import {
+  FilterCategory, FilterCommand, walkBodies, collectMatchingBodies,
+  hasBiologySignals, hasGeologySignals, hasGuardianSignals, hasThargoidSignals, hasHumanSignals, isLandable,
+  getBodyMaterialKeys, getBodyHotspotKeys, isTouristInteresting,
+} from '../data/body-filters';
+import { MINING_RESOURCES } from '../data/mining-resources';
 
 /** A Megaships-table row: the ship plus its resolved current-location display label. */
 interface MegashipRow {
@@ -47,6 +56,9 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly enrichment = inject(BodyEnrichmentService);
+  private readonly physics = inject(BodyPhysicsService);
+  private readonly orbitalRelations = inject(OrbitalRelationsService);
+  private readonly interestRegistry = inject(BodyInterestRegistryService);
 
   private lastSimbadSystemName: string | null = null;
   private lastSimbadId64: bigint | null = null;
@@ -602,6 +614,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   public readonly faDownload = faDownload;
   public readonly faMagnifyingGlass = faMagnifyingGlass;
   public readonly faChartColumn = faChartColumn;
+  public readonly faChevronDown = faChevronDown;
   private readonly dialog = inject(MatDialog);
 
   /** Opens the body-type histogram for the current system. */
@@ -695,6 +708,109 @@ export class HomeComponent implements OnInit, OnDestroy {
   public readonly data = signal<CanonnBiostats | null>(null);
   public readonly bodies = signal<SystemBody[]>([]);
   public readonly anchorBodyId = signal<number | null>(null);
+
+  /** id64 of the loaded system, threaded down to every SystemBodyComponent as a key for the async collision registry. */
+  public readonly systemKey = computed<bigint | null>(() => this.data()?.system?.id64 ?? null);
+
+  // --- Quick filters (see body-filters.ts) ---
+  public readonly activeFilterCategory = signal<FilterCategory | null>(null);
+  public readonly filterCommand = signal<FilterCommand | null>(null);
+  private filterTokenSeq = 0;
+  public readonly selectedMaterials = signal<Set<string>>(new Set());
+  public readonly selectedHotspots = signal<Set<string>>(new Set());
+  public readonly materialsMenuOpen = signal(false);
+  public readonly miningMenuOpen = signal(false);
+
+  public readonly biologyMatchIds = computed(() => collectMatchingBodies(this.bodies(), hasBiologySignals));
+  public readonly geologyMatchIds = computed(() => collectMatchingBodies(this.bodies(), hasGeologySignals));
+  public readonly guardianMatchIds = computed(() => collectMatchingBodies(this.bodies(), hasGuardianSignals));
+  public readonly thargoidMatchIds = computed(() => collectMatchingBodies(this.bodies(), hasThargoidSignals));
+  public readonly humanMatchIds = computed(() => collectMatchingBodies(this.bodies(), hasHumanSignals));
+  public readonly landableMatchIds = computed(() => collectMatchingBodies(this.bodies(), isLandable));
+
+  /**
+   * Synchronous "special badge" criteria only (see {@link isTouristInteresting}). Orbital
+   * collision candidates resolve later, off the main thread, and are folded in separately by
+   * {@link touristMatchIds} so the Tourist filter (and its visibility) can still catch up once
+   * those results land.
+   */
+  private readonly touristSyncMatchIds = computed(() =>
+    collectMatchingBodies(this.bodies(), body => isTouristInteresting(body, this.physics, this.orbitalRelations)));
+  public readonly touristMatchIds = computed(() => {
+    const collisionBodies = this.interestRegistry.collisionCandidateBodies();
+    if (collisionBodies.size === 0) { return this.touristSyncMatchIds(); }
+    const merged = new Set(this.touristSyncMatchIds());
+    for (const body of collisionBodies) { merged.add(body); }
+    return merged;
+  });
+
+  /** Material keys present anywhere in the system, for populating the Materials dropdown (and hiding it when empty). */
+  public readonly availableMaterialKeys = computed(() => {
+    const keys = new Set<string>();
+    walkBodies(this.bodies(), body => { for (const key of getBodyMaterialKeys(body)) { keys.add(key); } });
+    return Array.from(keys).sort((a, b) => a.localeCompare(b));
+  });
+  /** Mining-hotspot resource keys present anywhere in the system, for the Mining dropdown. */
+  public readonly availableHotspotKeys = computed(() => {
+    const keys = new Set<string>();
+    walkBodies(this.bodies(), body => { for (const key of getBodyHotspotKeys(body)) { keys.add(key); } });
+    return Array.from(keys).sort((a, b) => a.localeCompare(b));
+  });
+
+  /** Collapses every body except those in `bodies` (or every body, for `'all'`) and marks `category` as the active filter. */
+  private applyFilter(category: FilterCategory, bodies: Set<SystemBody> | 'all'): void {
+    this.activeFilterCategory.set(category);
+    this.filterCommand.set({ token: ++this.filterTokenSeq, bodies });
+  }
+
+  public onBiologyFilterClick(): void { this.applyFilter('biology', this.biologyMatchIds()); }
+  public onGeologyFilterClick(): void { this.applyFilter('geology', this.geologyMatchIds()); }
+  public onGuardianFilterClick(): void { this.applyFilter('guardian', this.guardianMatchIds()); }
+  public onThargoidFilterClick(): void { this.applyFilter('thargoid', this.thargoidMatchIds()); }
+  public onHumanFilterClick(): void { this.applyFilter('human', this.humanMatchIds()); }
+  public onLandableFilterClick(): void { this.applyFilter('landable', this.landableMatchIds()); }
+  public onTouristFilterClick(): void { this.applyFilter('tourist', this.touristMatchIds()); }
+  public onEverythingFilterClick(): void { this.applyFilter('everything', 'all'); }
+
+  public toggleMaterialsMenu(): void {
+    this.miningMenuOpen.set(false);
+    this.materialsMenuOpen.set(!this.materialsMenuOpen());
+  }
+
+  public toggleMiningMenu(): void {
+    this.materialsMenuOpen.set(false);
+    this.miningMenuOpen.set(!this.miningMenuOpen());
+  }
+
+  /** Closes the Materials/Mining dropdown menus on any click outside them (the menus themselves stop propagation). */
+  @HostListener('document:click')
+  public closeFilterMenus(): void {
+    this.materialsMenuOpen.set(false);
+    this.miningMenuOpen.set(false);
+  }
+
+  /** Toggles `material` in the selection and immediately re-applies the Materials filter. */
+  public toggleMaterialSelection(material: string): void {
+    const next = new Set(this.selectedMaterials());
+    if (next.has(material)) { next.delete(material); } else { next.add(material); }
+    this.selectedMaterials.set(next);
+    if (next.size === 0) { return; }
+    this.applyFilter('materials', collectMatchingBodies(this.bodies(), body => getBodyMaterialKeys(body).some(key => next.has(key))));
+  }
+
+  public hotspotDisplayName(resourceKey: string): string {
+    return MINING_RESOURCES[resourceKey]?.name ?? resourceKey;
+  }
+
+  /** Toggles `resource` in the selection and immediately re-applies the Mining filter. */
+  public toggleHotspotSelection(resource: string): void {
+    const next = new Set(this.selectedHotspots());
+    if (next.has(resource)) { next.delete(resource); } else { next.add(resource); }
+    this.selectedHotspots.set(next);
+    if (next.size === 0) { return; }
+    this.applyFilter('mining', collectMatchingBodies(this.bodies(), body => getBodyHotspotKeys(body).some(key => next.has(key))));
+  }
+
   public searchControl = new FormControl('');
   public readonly filteredSystems = signal<string[]>([]);
   private readonly autocompleteTrigger = viewChild(MatAutocompleteTrigger);
@@ -921,6 +1037,15 @@ export class HomeComponent implements OnInit, OnDestroy {
 
     // Check if we're loading a different system
     const isDifferentSystem = !previousData || previousData.system.id64 !== data.system.id64;
+
+    if (isDifferentSystem) {
+      this.interestRegistry.resetForSystem(data.system.id64);
+      this.activeFilterCategory.set(null);
+      this.filterCommand.set(null);
+      this.selectedMaterials.set(new Set());
+      this.selectedHotspots.set(new Set());
+      this.closeFilterMenus();
+    }
 
     this.data.set(data);
     this.bodies.set([]);

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -794,7 +794,13 @@ export class HomeComponent implements OnInit, OnDestroy {
     const next = new Set(this.selectedMaterials());
     if (next.has(material)) { next.delete(material); } else { next.add(material); }
     this.selectedMaterials.set(next);
-    if (next.size === 0) { return; }
+    if (next.size === 0) {
+      if (this.activeFilterCategory() === 'materials') {
+        this.activeFilterCategory.set(null);
+        this.filterCommand.set(null);
+      }
+      return;
+    }
     this.applyFilter('materials', collectMatchingBodies(this.bodies(), body => getBodyMaterialKeys(body).some(key => next.has(key))));
   }
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -721,25 +721,25 @@ export class HomeComponent implements OnInit, OnDestroy {
   public readonly materialsMenuOpen = signal(false);
   public readonly miningMenuOpen = signal(false);
 
-  public readonly biologyMatchIds = computed(() => collectMatchingBodies(this.bodies(), hasBiologySignals));
-  public readonly geologyMatchIds = computed(() => collectMatchingBodies(this.bodies(), hasGeologySignals));
-  public readonly guardianMatchIds = computed(() => collectMatchingBodies(this.bodies(), hasGuardianSignals));
-  public readonly thargoidMatchIds = computed(() => collectMatchingBodies(this.bodies(), hasThargoidSignals));
-  public readonly humanMatchIds = computed(() => collectMatchingBodies(this.bodies(), hasHumanSignals));
-  public readonly landableMatchIds = computed(() => collectMatchingBodies(this.bodies(), isLandable));
+  public readonly biologyMatches = computed(() => collectMatchingBodies(this.bodies(), hasBiologySignals));
+  public readonly geologyMatches = computed(() => collectMatchingBodies(this.bodies(), hasGeologySignals));
+  public readonly guardianMatches = computed(() => collectMatchingBodies(this.bodies(), hasGuardianSignals));
+  public readonly thargoidMatches = computed(() => collectMatchingBodies(this.bodies(), hasThargoidSignals));
+  public readonly humanMatches = computed(() => collectMatchingBodies(this.bodies(), hasHumanSignals));
+  public readonly landableMatches = computed(() => collectMatchingBodies(this.bodies(), isLandable));
 
   /**
    * Synchronous "special badge" criteria only (see {@link isTouristInteresting}). Orbital
    * collision candidates resolve later, off the main thread, and are folded in separately by
-   * {@link touristMatchIds} so the Tourist filter (and its visibility) can still catch up once
+   * {@link touristMatches} so the Tourist filter (and its visibility) can still catch up once
    * those results land.
    */
-  private readonly touristSyncMatchIds = computed(() =>
+  private readonly touristSyncMatches = computed(() =>
     collectMatchingBodies(this.bodies(), body => isTouristInteresting(body, this.physics, this.orbitalRelations)));
-  public readonly touristMatchIds = computed(() => {
+  public readonly touristMatches = computed(() => {
     const collisionBodies = this.interestRegistry.collisionCandidateBodies();
-    if (collisionBodies.size === 0) { return this.touristSyncMatchIds(); }
-    const merged = new Set(this.touristSyncMatchIds());
+    if (collisionBodies.size === 0) { return this.touristSyncMatches(); }
+    const merged = new Set(this.touristSyncMatches());
     for (const body of collisionBodies) { merged.add(body); }
     return merged;
   });
@@ -763,13 +763,13 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.filterCommand.set({ token: ++this.filterTokenSeq, bodies });
   }
 
-  public onBiologyFilterClick(): void { this.applyFilter('biology', this.biologyMatchIds()); }
-  public onGeologyFilterClick(): void { this.applyFilter('geology', this.geologyMatchIds()); }
-  public onGuardianFilterClick(): void { this.applyFilter('guardian', this.guardianMatchIds()); }
-  public onThargoidFilterClick(): void { this.applyFilter('thargoid', this.thargoidMatchIds()); }
-  public onHumanFilterClick(): void { this.applyFilter('human', this.humanMatchIds()); }
-  public onLandableFilterClick(): void { this.applyFilter('landable', this.landableMatchIds()); }
-  public onTouristFilterClick(): void { this.applyFilter('tourist', this.touristMatchIds()); }
+  public onBiologyFilterClick(): void { this.applyFilter('biology', this.biologyMatches()); }
+  public onGeologyFilterClick(): void { this.applyFilter('geology', this.geologyMatches()); }
+  public onGuardianFilterClick(): void { this.applyFilter('guardian', this.guardianMatches()); }
+  public onThargoidFilterClick(): void { this.applyFilter('thargoid', this.thargoidMatches()); }
+  public onHumanFilterClick(): void { this.applyFilter('human', this.humanMatches()); }
+  public onLandableFilterClick(): void { this.applyFilter('landable', this.landableMatches()); }
+  public onTouristFilterClick(): void { this.applyFilter('tourist', this.touristMatches()); }
   public onEverythingFilterClick(): void { this.applyFilter('everything', 'all'); }
 
   public toggleMaterialsMenu(): void {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -813,7 +813,13 @@ export class HomeComponent implements OnInit, OnDestroy {
     const next = new Set(this.selectedHotspots());
     if (next.has(resource)) { next.delete(resource); } else { next.add(resource); }
     this.selectedHotspots.set(next);
-    if (next.size === 0) { return; }
+    if (next.size === 0) {
+      if (this.activeFilterCategory() === 'mining') {
+        this.activeFilterCategory.set(null);
+        this.filterCommand.set(null);
+      }
+      return;
+    }
     this.applyFilter('mining', collectMatchingBodies(this.bodies(), body => getBodyHotspotKeys(body).some(key => next.has(key))));
   }
 

--- a/src/app/system-body/system-body.component.html
+++ b/src/app/system-body/system-body.component.html
@@ -1011,6 +1011,7 @@
   @for (body of body().subBodies; track $index; let isLast = $last) {
   <app-system-body [body]="body" [isLast]="isLast" [forceExpanded]="forceExpanded() || isAnchorBody"
     [anchorBodyId]="anchorBodyId()" [systemPopulation]="systemPopulation()"
+    [filterCommand]="filterCommand()" [systemKey]="systemKey()"
     [edGalaxyData]="edGalaxyData()"></app-system-body>
   }
 </div>

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -1,6 +1,6 @@
 import { estimateTempRange, isTempSafe, lookupTempDelta } from '../data/temperature-estimation';
 import { Component, OnChanges, ChangeDetectionStrategy, SimpleChanges, input, viewChildren, inject, afterNextRender, signal, effect, untracked, DestroyRef } from '@angular/core';
-import { SystemBody, EdGalaxyData, CanonnBiostatsBody } from '../home/home.component';
+import { SystemBody, EdGalaxyData } from '../home/home.component';
 import { faCircleChevronRight, faCircleQuestion, faInfo, faSquareCaretDown, faSquareCaretUp, faUpRightFromSquare, faCode, faLock, faLink } from '@fortawesome/free-solid-svg-icons';
 import { AppService, CanonnCodexEntry } from '../app.service';
 import { BodyImage } from '../data/body-images';
@@ -10,7 +10,10 @@ import { MatDialog } from '@angular/material/dialog';
 import { DecimalPipe, DatePipe } from '@angular/common';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ClickableDirective } from '../clickable.directive';
-import { BodyPhysicsService, RingDynamics, ShepherdingHillLimit, BodyRocheLimits, PlanetaryDensity, MassStabilityAlert, SPEED_OF_LIGHT } from '../data/body-physics.service';
+import {
+  BodyPhysicsService, RingDynamics, ShepherdingHillLimit, BodyRocheLimits, PlanetaryDensity, MassStabilityAlert, SPEED_OF_LIGHT,
+  NARROW_RING_SPAN_RADII, PAUPER_RING_MIN_INNER_EDGE_RADII, PAUPER_RING_MAX_SPAN_RADII,
+} from '../data/body-physics.service';
 import { StellarPhysicsService } from '../data/stellar-physics.service';
 import { OrbitalRelationsService, CollisionStatus, LagrangeConfiguration, LagrangeOccupant } from '../data/orbital-relations.service';
 import { OrbitalWorkerService } from '../data/orbital-worker.service';
@@ -25,7 +28,7 @@ import { GENUS_NAMES } from '../data/genus';
 import type { OrbitalDiagramType, OrbitElements } from '../dialogs/orbital-diagram-dialog/orbital-diagram-dialog.component';
 import type { TidalLockDialogData } from '../dialogs/tidal-lock-dialog/tidal-lock-dialog.component';
 import type { InvisibleRingDialogData } from '../dialogs/invisible-ring-dialog/invisible-ring-dialog.component';
-import type { RingClassificationDialogData, RingClassificationRingInfo } from '../dialogs/ring-classification-dialog/ring-classification-dialog.component';
+import type { RingClassificationDialogData } from '../dialogs/ring-classification-dialog/ring-classification-dialog.component';
 import type { ApoPeriDialogData } from '../dialogs/apo-peri-dialog/apo-peri-dialog.component';
 import type { AnomalyDialogData } from '../dialogs/anomaly-dialog/anomaly-dialog.component';
 import type { ParentDistanceDialogData } from '../dialogs/parent-distance-dialog/parent-distance-dialog.component';
@@ -37,6 +40,8 @@ import { BodyEnrichmentService } from '../data/body-enrichment.service';
 import type { LagrangeDialogData } from '../dialogs/lagrange-dialog/lagrange-dialog.component';
 import type { OnFootSafetyDialogData } from '../dialogs/on-foot-safety-dialog/on-foot-safety-dialog.component';
 import { StellarAgeAssessment, assessStellarAge, isPlottableStarClass } from '../data/stellar-reference';
+import { resolveBodySignalsMap, FilterCommand } from '../data/body-filters';
+import { BodyInterestRegistryService } from '../data/body-interest-registry.service';
 import { ConvertIconComponent } from '../dialogs/unit-conversion-dialog/convert-icon.component';
 import {
   dynamicArealDensityUnitLabel,
@@ -80,33 +85,6 @@ const COLLISION_DIAGRAM_SYNODIC_PERIODS = 10;
  */
 const COLLISION_DIAGRAM_SAMPLES = 1000;
 
-/**
- * Maximum gap between adjacent rings (km) for the Racing Rings badge.
- * Set so that both ring edges are likely to be simultaneously visible when
- * flying nearby. The value is intentionally generous and may be tightened
- * once in-game observations are collected.
- */
-const RACING_RINGS_MAX_GAP_KM = 50;
-/**
- * Minimum outer-to-inner velocity difference (km/s) for the Racing Rings badge.
- * Chosen as a speed differential large enough to be noticeable in-game;
- * may be adjusted after in-game observations.
- */
-const RACING_RINGS_MIN_SPEED_DIFF_KMS = 5;
-
-/**
- * Body-radius multiple below which a ring system's total span counts as narrow. Used
- * as the Taylor ring badge's upper threshold, and as the Pauper ring badge's lower
- * bound (a span this narrow is a Taylor ring, not a Pauper ring).
- */
-const NARROW_RING_SPAN_RADII = 0.25;
-/** Body-radii the innermost visible ring edge must clear for the Pauper ring badge (unusually distant). */
-const PAUPER_RING_MIN_INNER_EDGE_RADII = 14;
-/** Maximum span (body radii) for the Pauper ring badge — no wider than one body diameter. */
-const PAUPER_RING_MAX_SPAN_RADII = 2;
-/** Fraction of the total span above which a gap between two adjacent visible rings is called out as potentially visible. */
-const VISIBLE_GAP_SPAN_FRACTION = 0.02;
-
 @Component({
   selector: 'app-system-body',
   templateUrl: './system-body.component.html',
@@ -123,6 +101,7 @@ export class SystemBodyComponent implements OnChanges {
   private readonly orbitalWorker = inject(OrbitalWorkerService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly enrichment = inject(BodyEnrichmentService);
+  private readonly interestRegistry = inject(BodyInterestRegistryService);
 
   // Expose Math.abs for template use
   abs(value: number): number {
@@ -144,6 +123,8 @@ export class SystemBodyComponent implements OnChanges {
   readonly forceExpanded = input<boolean>(false);
   readonly anchorBodyId = input<number | null>(null);
   readonly systemPopulation = input<number>(0);
+  readonly filterCommand = input<FilterCommand | null>(null);
+  readonly systemKey = input<string | number | bigint | null>(null);
   readonly childComponents = viewChildren(SystemBodyComponent);
   public styleClass = "child-container-default";
   private codex: CanonnCodexEntry[] | null = null;
@@ -175,6 +156,8 @@ export class SystemBodyComponent implements OnChanges {
   // user has since collapsed. See the auto-expand block in ngOnChanges.
   private autoExpandBody: SystemBody | null = null;
   private autoExpandAnchor: number | null = null;
+  /** Last-applied quick-filter token (see {@link FilterCommand}), so a repeat ngOnChanges from an unrelated input doesn't reapply it. */
+  private lastAppliedFilterToken: number | null = null;
   private autoExpandForce = false;
 
   public hoveredIndex: number = -1;
@@ -409,6 +392,14 @@ export class SystemBodyComponent implements OnChanges {
       }
     }
 
+    // Quick-filter command (see FilterCommand): applies unconditionally, overriding whatever
+    // expanded() currently holds, so a click both expands matching bodies and collapses the rest.
+    const filterCommand = this.filterCommand();
+    if (filterCommand && filterCommand.token !== this.lastAppliedFilterToken) {
+      this.lastAppliedFilterToken = filterCommand.token;
+      this.expanded.set(filterCommand.bodies === 'all' || filterCommand.bodies.has(body));
+    }
+
     if (this.isRoot()) {
       this.styleClass = "";
     }
@@ -486,7 +477,7 @@ export class SystemBodyComponent implements OnChanges {
     this.applyRingDynamics(this.physics.ringDynamics(body));
 
     // Distance to the next ring/belt sibling (by innerRadius order).
-    const { distance: neighbourDist, label: neighbourLabel, velocityDiff, eitherRingInvisible } = this.computeRingNeighbourDistance(body);
+    const { distance: neighbourDist, label: neighbourLabel, velocityDiff, eitherRingInvisible } = this.physics.ringNeighbourDistance(body);
     // Suppress gap/velocity display when either ring in the pair is invisible — the values
     // are physically real but the invisible ring cannot be observed in-game.
     const displayDist = eitherRingInvisible ? null : neighbourDist;
@@ -499,8 +490,7 @@ export class SystemBodyComponent implements OnChanges {
 
     // Racing Rings badge: gap between adjacent rings below threshold AND speed
     // differential above threshold, and neither ring in the pair is invisible.
-    const racingRings = neighbourDist !== null && velocityDiff !== null
-      && neighbourDist < RACING_RINGS_MAX_GAP_KM && velocityDiff > RACING_RINGS_MIN_SPEED_DIFF_KMS && !eitherRingInvisible;
+    const racingRings = this.physics.isRacingRings(body);
     this.isRacingRings.set(racingRings);
     if (racingRings) {
       const dashIdx = neighbourLabel.indexOf('-');
@@ -514,7 +504,7 @@ export class SystemBodyComponent implements OnChanges {
     }
 
     // Taylor (unusually narrow) / Pauper (unusually wide and distant) ring badges.
-    const ringClass = this.classifyRingSystem(body);
+    const ringClass = this.physics.classifyRingSystem(body);
     this.isTaylorRing.set(ringClass?.isTaylor ?? false);
     this.isPauperRing.set(ringClass?.isPauper ?? false);
     this.taylorRingTooltip.set(ringClass?.isTaylor
@@ -876,20 +866,11 @@ export class SystemBodyComponent implements OnChanges {
 
   /**
    * The hotspot/signal map for this body: its own `signals.signals`, or — for a ring
-   * body — the matching entry in the parent's `rings` array. Single source of truth for
-   * the signal-count, hotspot-list and signal-tooltip lookups, which previously each
-   * reimplemented this resolution.
+   * body — the matching entry in the parent's `rings` array. Delegates to the shared
+   * {@link resolveBodySignalsMap}, also used by the home page's Mining quick filter.
    */
   private resolveSignalsMap(): { [key: string]: number } | undefined {
-    const body = this.body();
-    if (body.bodyData.signals?.signals) {
-      return body.bodyData.signals.signals;
-    }
-    if (body.bodyData.type === BODY_TYPE.Ring && body.parent?.bodyData.rings) {
-      const ringData = body.parent.bodyData.rings.find(r => r.name === body.bodyData.name);
-      return ringData?.signals?.signals;
-    }
-    return undefined;
+    return resolveBodySignalsMap(this.body());
   }
 
   private computeSignalsCount(): number {
@@ -1115,7 +1096,7 @@ export class SystemBodyComponent implements OnChanges {
   /** Opens the explanation dialog for the Taylor (narrow) or Pauper (wide, distant) ring badge. */
   public async showRingClassificationDialog(kind: 'taylor' | 'pauper'): Promise<void> {
     const body = this.body();
-    const ringClass = this.classifyRingSystem(body);
+    const ringClass = this.physics.classifyRingSystem(body);
     if (!ringClass) { return; }
 
     openLazyDialog(this.dialog, {
@@ -1622,104 +1603,9 @@ export class SystemBodyComponent implements OnChanges {
     return this.stellarPhysics.radiusKm(bd.radius, bd.solarRadius);
   }
 
-  private isInvisibleRing(bd: CanonnBiostatsBody): boolean {
-    if (bd.type !== BODY_TYPE.Ring) { return false; }
-    const outer = bd.outerRadius ?? 0;
-    const inner = bd.innerRadius ?? 0;
-    const width = outer - inner;
-    const area = Math.PI * (outer * outer - inner * inner);
-    const density = area > 0 ? (bd.mass ?? 0) / area : 0;
-    return this.isLowDensityWideRing(width, density);
-  }
-
   /** Shared invisibility heuristic used for ring stats, badges, and dialog explanations. */
   private isLowDensityWideRing(widthKm: number, densityKgPerKm2: number): boolean {
     return this.physics.isLowDensityWideRing(widthKm, densityKgPerKm2);
-  }
-
-  /** `parent`'s ring-type sub-bodies, sorted by inner radius ascending. Includes invisible rings — callers filter those out themselves when they don't want them. */
-  private sortedRingSiblings(parent: SystemBody): SystemBody[] {
-    return parent.subBodies
-      .filter(s => s.bodyData.type === BODY_TYPE.Ring)
-      .sort((a, b) => (a.bodyData.innerRadius ?? 0) - (b.bodyData.innerRadius ?? 0));
-  }
-
-  /** Strips the " Ring" suffix from a ring body's name, leaving just its letter designation (e.g. "A"). */
-  private stripRingSuffix(name: string): string {
-    return name.replace('Ring', '').trim();
-  }
-
-  /**
-   * Classifies `body`'s ring system as Taylor (unusually narrow) and/or Pauper (unusually
-   * wide and distant), or null when `body` isn't a visible ring or the classification can't
-   * be computed. Both badges are derived from the same "span" of the body's *visible* rings
-   * (invisible rings — see {@link isInvisibleRing} — are stripped first), so the result is
-   * identical for every ring belonging to the same parent and the badge shows on all of them.
-   */
-  private classifyRingSystem(body: SystemBody): {
-    isTaylor: boolean; isPauper: boolean; span: number; innermostInner: number; outermostOuter: number;
-    parentRadius: number; rings: RingClassificationRingInfo[]; hasVisibleGap: boolean;
-  } | null {
-    const bd = body.bodyData;
-    if (bd.type !== BODY_TYPE.Ring || !body.parent || this.isInvisibleRing(bd)) { return null; }
-
-    const parentRadius = this.physics.getParentRadiusKm(body);
-    if (!parentRadius) { return null; }
-
-    const visibleRings = this.sortedRingSiblings(body.parent)
-      .filter(s => !this.isInvisibleRing(s.bodyData));
-    if (visibleRings.length === 0) { return null; }
-
-    // Already sorted by inner radius ascending, so the first entry is the innermost inner edge.
-    const innermostInner = visibleRings[0].bodyData.innerRadius ?? 0;
-    const outermostOuter = Math.max(...visibleRings.map(r => r.bodyData.outerRadius ?? 0));
-    const span = outermostOuter - innermostInner;
-
-    const isTaylor = span < NARROW_RING_SPAN_RADII * parentRadius;
-    // `span > NARROW_RING_SPAN_RADII * parentRadius` here is what keeps this mutually
-    // exclusive with isTaylor above (span < the same threshold).
-    const isPauper = innermostInner >= PAUPER_RING_MIN_INNER_EDGE_RADII * parentRadius
-      && span <= PAUPER_RING_MAX_SPAN_RADII * parentRadius
-      && span > NARROW_RING_SPAN_RADII * parentRadius;
-
-    const rings = visibleRings.map(r => ({
-      name: this.stripRingSuffix(r.bodyData.name),
-      innerRadius: r.bodyData.innerRadius ?? 0,
-      outerRadius: r.bodyData.outerRadius ?? 0,
-    }));
-
-    // Gap between each ring's outer edge and the next ring's inner edge — a gap wide enough
-    // relative to the total span may show up as a visible break in an otherwise "single ring".
-    const hasVisibleGap = span > 0 && rings.some((r, i) => {
-      const next = rings[i + 1];
-      if (!next) { return false; }
-      return (next.innerRadius - r.outerRadius) > VISIBLE_GAP_SPAN_FRACTION * span;
-    });
-
-    return { isTaylor, isPauper, span, innermostInner, outermostOuter, parentRadius, rings, hasVisibleGap };
-  }
-
-  private computeRingNeighbourDistance(body: SystemBody): { distance: number | null; label: string; velocityDiff: number | null; eitherRingInvisible: boolean } {
-    const bd = body.bodyData;
-    if (bd.type !== BODY_TYPE.Ring || !body.parent) {
-      return { distance: null, label: '', velocityDiff: null, eitherRingInvisible: false };
-    }
-    const siblings = this.sortedRingSiblings(body.parent);
-    const idx = siblings.indexOf(body);
-    if (idx < 0 || idx === siblings.length - 1) {
-      return { distance: null, label: '', velocityDiff: null, eitherRingInvisible: false };
-    }
-    const next = siblings[idx + 1];
-    const distance = (next.bodyData.innerRadius ?? 0) - (bd.outerRadius ?? 0);
-    const thisLabel = this.stripRingSuffix(bd.name);
-    const nextLabel = this.stripRingSuffix(next.bodyData.name);
-    const currentDynamics = this.physics.ringDynamics(body);
-    const nextDynamics = this.physics.ringDynamics(next);
-    const velocityDiff = (currentDynamics !== null && nextDynamics !== null)
-      ? currentDynamics.maxVelocityKms - nextDynamics.minVelocityKms
-      : null;
-    const eitherRingInvisible = this.isInvisibleRing(bd) || this.isInvisibleRing(next.bodyData);
-    return { distance, label: `${thisLabel}-${nextLabel}`, velocityDiff, eitherRingInvisible };
   }
 
   private applyRingDynamics(dynamics: RingDynamics | null): void {
@@ -1905,6 +1791,7 @@ export class SystemBodyComponent implements OnChanges {
         clearTimeout(this.collisionPendingTimer);
         this.collisionStatus.set(status);
         this.collisionPending.set(false);
+        this.reportCollisionCandidate(body, status.isCandidate);
       })
       .catch((err: unknown) => {
         // A worker/engine failure leaves the badge simply absent (collisionStatus stays null) rather
@@ -1914,7 +1801,19 @@ export class SystemBodyComponent implements OnChanges {
         if (requestId !== this.collisionRequestId) { return; }
         clearTimeout(this.collisionPendingTimer);
         this.collisionPending.set(false);
+        this.reportCollisionCandidate(body, false);
       });
+  }
+
+  /**
+   * Surfaces this body's resolved collision-candidate status to the shared registry so the
+   * "Tourist" quick filter (computed eagerly in HomeComponent from synchronous body data) can
+   * pick it up once the off-thread search finishes, without re-running collision detection itself.
+   */
+  private reportCollisionCandidate(body: SystemBody, isCandidate: boolean): void {
+    const key = this.systemKey();
+    if (key === null) { return; }
+    this.interestRegistry.reportCollisionCandidate(key, body, isCandidate);
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #109.

- Adds a quick-filter toolbar between **System Completeness** and the body list: **Biology**, **Geology**, **Guardian**, **Thargoid**, **Human**, **Landable**, **Materials** (multi-select dropdown), **Mining** (multi-select dropdown), **Tourist**, and **Everything**.
- Each button first collapses every body panel, then expands only the bodies matching that category.
- A button (or dropdown entry) is only rendered when it would actually match at least one body in the loaded system — no disabled/dead buttons.
- **Tourist** expands bodies carrying a "special badge" (interesting subtypes, landable, terraformable, Trojan/Rosette, shepherd, Roche-limit exceeded, stellar age, and ring badges — Invisible/Taylor/Pauper/Racing Rings). Orbital-collision candidates are folded in as they resolve asynchronously off the main thread, via a new `BodyInterestRegistryService`, so the filter can catch up once those checks land without re-running the search itself.
- Filter matching is keyed by `SystemBody` object identity rather than `bodyData.bodyId`, since belts and rings are synthesized with a shared placeholder `bodyId` of `-1` — an id-keyed set would make one matching ring/belt expand every ring/belt in the system.
- Extracted ring-badge classification (`classifyRingSystem`, `isRacingRings`, `isInvisibleRing`, etc.) out of `SystemBodyComponent`'s private methods and into `BodyPhysicsService`, so both the existing per-body badges and the new Tourist filter share one implementation.
- Left the "Cloud" category out of scope: system.signals.cloud/anomaly is only recorded at the system level with no per-body link in the current data model, so it could never match a body. Filed #117 to track investigating that gap upstream.

## Test plan
- [ ] `ng test` — new specs in `body-filters.spec.ts` and `body-interest-registry.service.spec.ts`, plus existing `system-body.component` specs (ring badges now delegate to `BodyPhysicsService` but should behave identically)
- [ ] `ng build`
- [ ] `ng serve` — load a system with biology/geology/rings/materials, click through each filter button and the Materials/Mining dropdowns, confirm collapse/expand behavior and that buttons with no matches are hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)