### PR TITLE
Link GEC image to its Galactic Exploration Catalog page

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -326,10 +326,11 @@
             <div class="system-data-section-header">Galactic Exploration Catalog</div>
             <div class="gec-image-panel">
               @if (edastro.poiUrl) {
-              <a [href]="edastro.poiUrl" target="_blank" rel="noopener noreferrer" class="gec-image-link"
-                title="View on the Galactic Exploration Catalog">
-                <img [src]="edastro.mainImage" alt="GEC Image" class="gec-main-image" (error)="onGecImageError($event)" />
-              </a>
+<a [href]="edastro.poiUrl" target="_blank" rel="noopener noreferrer" class="gec-image-link"
+  title="View on the Galactic Exploration Catalog"
+  aria-label="View on the Galactic Exploration Catalog (opens in a new tab)">
+  <img [src]="edastro.mainImage" alt="" class="gec-main-image" (error)="onGecImageError($event)" />
+</a>
               } @else {
               <img [src]="edastro.mainImage" alt="GEC Image" class="gec-main-image" (error)="onGecImageError($event)" />
               }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -325,7 +325,14 @@
           <div class="system-data-section">
             <div class="system-data-section-header">Galactic Exploration Catalog</div>
             <div class="gec-image-panel">
+              @if (edastro.poiUrl) {
+              <a [href]="edastro.poiUrl" target="_blank" rel="noopener noreferrer" class="gec-image-link"
+                title="View on the Galactic Exploration Catalog">
+                <img [src]="edastro.mainImage" alt="GEC Image" class="gec-main-image" (error)="onGecImageError($event)" />
+              </a>
+              } @else {
               <img [src]="edastro.mainImage" alt="GEC Image" class="gec-main-image" (error)="onGecImageError($event)" />
+              }
               @if (edastro.description) {
               <div class="gec-description">{{
                 edastro.description }}

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -544,6 +544,21 @@
     object-fit: contain;
 }
 
+.system-container .system-container-data .system-data .gec-image-link {
+    display: block;
+    border-radius: 8px;
+    transition: opacity 0.15s ease;
+}
+
+.system-container .system-container-data .system-data .gec-image-link:hover {
+    opacity: 0.85;
+}
+
+.system-container .system-container-data .system-data .gec-image-link:focus-visible {
+    outline: 2px solid var(--color-link-hover);
+    outline-offset: 2px;
+}
+
 /* ---------------------------------------------------------------------------
  * Responsive — small screens (phones).
  * Reclaim the horizontal space the desktop layout spends on side-by-side


### PR DESCRIPTION
## Summary
- Wraps the large GEC image in an `<a>` linking to `edastro.poiUrl`, opened in a new tab, so clicking it navigates to the entry's GEC page (falls back to a plain image if no `poiUrl` is available).
- Matches the existing link pattern already used for the small GEC marker icon next to the system title.
- Adds hover/focus-visible affordance styling for the new link.

Fixes #123

## Test plan
- [x] Search a system that has GEC data with a `poiUrl` and confirm clicking the large GEC image opens the correct GEC page in a new tab.
- [x] Confirm keyboard focus (Tab) shows a visible outline on the image link.
- [x] Confirm systems with GEC image but no `poiUrl` still render the image (non-clickable) without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)