### PR TITLE
Add Gnosis Megaship Science Tour route card

### DIFF
--- a/src/app/app.service.extra.spec.ts
+++ b/src/app/app.service.extra.spec.ts
@@ -226,6 +226,76 @@ describe('AppService (HTTP-driven coverage)', () => {
     expect(scheduleCalls).toBeGreaterThanOrEqual(1);
   });
 
+  it('lazily loads the Gnosis position and memoises the fetch within the cache window', async () => {
+    await init();
+    let gnosisCalls = 0;
+    route = (url: string) => {
+      if (url.includes('/gnosis')) {
+        gnosisCalls++;
+        return ok({ arrival: '2026-07-10', coords: [1, 2, 3], departure: '2026-07-17', desc: 'x', system: 'Varati' });
+      }
+      return ok({});
+    };
+    expect(service.gnosisData()).toBeNull();
+    service.ensureGnosis();
+    service.ensureGnosis(); // second call before the first resolves must not fire a second fetch
+    await flush();
+    expect(gnosisCalls).toBe(1);
+    expect(service.gnosisData()?.system).toBe('Varati');
+
+    // Still within the cache window: a further call doesn't refetch.
+    service.ensureGnosis();
+    await flush();
+    expect(gnosisCalls).toBe(1);
+  });
+
+  it('refetches the Gnosis position once the cache window has elapsed', async () => {
+    vi.useFakeTimers();
+    try {
+      await init();
+      let gnosisCalls = 0;
+      route = (url: string) => {
+        if (url.includes('/gnosis')) {
+          gnosisCalls++;
+          return ok({ arrival: 'x', coords: [0, 0, 0], departure: 'x', desc: '', system: gnosisCalls === 1 ? 'Varati' : 'HIP 17862' });
+        }
+        return ok({});
+      };
+      service.ensureGnosis();
+      await flush();
+      expect(service.gnosisData()?.system).toBe('Varati');
+
+      await vi.advanceTimersByTimeAsync(3600001); // just past the 1-hour cache window
+      service.ensureGnosis();
+      await flush();
+      expect(gnosisCalls).toBe(2);
+      expect(service.gnosisData()?.system).toBe('HIP 17862');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('leaves the Gnosis position unchanged and retryable when the fetch fails', async () => {
+    await init();
+    let gnosisCalls = 0;
+    route = (url: string) => {
+      if (url.includes('/gnosis')) {
+        gnosisCalls++;
+        return fail(404, 'nope'); // a 4xx isn't retried internally, keeping this test fast
+      }
+      return ok({});
+    };
+    service.ensureGnosis();
+    await flush();
+    expect(service.gnosisData()).toBeNull();
+    expect(gnosisCalls).toBe(1);
+
+    // The failed fetch cleared the memo, so an immediate retry (within the cache window) fires again.
+    service.ensureGnosis();
+    await flush();
+    expect(gnosisCalls).toBe(2);
+  });
+
   it('resolves a system name via biostats and caches it in systemNames', async () => {
     await init();
     let biostatsCalls = 0;

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -12,6 +12,9 @@ const HTTP_TIMEOUT_MS = 20000;
 const HTTP_RETRY_COUNT = 2;
 /** Base URL for the Canonn cloud-function query API. */
 const CANONN_QUERY_BASE = 'https://us-central1-canonn-api-236217.cloudfunctions.net/query';
+/** How long a fetched Gnosis position is considered fresh before {@link AppService.ensureGnosis}
+ *  refetches it. Matches the cache window the region map previously kept locally for the same data. */
+const GNOSIS_CACHE_DURATION_MS = 3600000; // 1 hour
 
 /**
  * Error thrown by {@link AppService} HTTP helpers for non-2xx responses. Mirrors the
@@ -129,6 +132,13 @@ export class AppService {
   /** In-flight name lookups, keyed by id64 string, so concurrent callers share one fetch. */
   private readonly systemNameLookups = new Map<string, Promise<string>>();
 
+  private readonly _gnosisData = signal<GnosisData | null>(null);
+  /** The Gnosis megaship's live-tracked current stop; null until {@link ensureGnosis} resolves
+   *  (or on failure). Shared by the Galaxy Region Map marker and the Gnosis route card. */
+  public readonly gnosisData: Signal<GnosisData | null> = this._gnosisData.asReadonly();
+  private gnosisLoad?: Promise<void>;
+  private gnosisFetchedAt = 0;
+
   constructor() {
     void this.loadCodexEntries();
     void this.loadEdastroSystems();
@@ -207,6 +217,25 @@ export class AppService {
         this._megashipSchedule.set(null);
         // Clear the memo so a later call can retry the load.
         this.megashipScheduleLoad = undefined;
+      });
+  }
+
+  /**
+   * Lazily (re)loads the Gnosis's current position, at most once per {@link GNOSIS_CACHE_DURATION_MS}.
+   * A failed fetch leaves the previous value in place (stale data beats none) and is retried on the
+   * next call rather than waiting out the cache window.
+   */
+  public ensureGnosis(): void {
+    const now = Date.now();
+    if (this.gnosisLoad && now - this.gnosisFetchedAt < GNOSIS_CACHE_DURATION_MS) {
+      return;
+    }
+    this.gnosisFetchedAt = now;
+    this.gnosisLoad = this.getGnosis()
+      .then(data => { this._gnosisData.set(data); })
+      .catch(() => {
+        // Clear the memo so the next call retries immediately instead of waiting out the cache window.
+        this.gnosisLoad = undefined;
       });
   }
 

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -223,12 +223,14 @@ export class AppService {
   /**
    * Lazily (re)loads the Gnosis's current position, at most once per {@link GNOSIS_CACHE_DURATION_MS}.
    * A failed fetch leaves the previous value in place (stale data beats none) and is retried on the
-   * next call rather than waiting out the cache window.
+   * next call rather than waiting out the cache window. Returns the in-flight/cached load promise
+   * so callers that need the resolved value (e.g. {@link RegionMapComponent}) can await it instead
+   * of keeping their own parallel cache.
    */
-  public ensureGnosis(): void {
+  public ensureGnosis(): Promise<void> {
     const now = Date.now();
     if (this.gnosisLoad && now - this.gnosisFetchedAt < GNOSIS_CACHE_DURATION_MS) {
-      return;
+      return this.gnosisLoad;
     }
     this.gnosisFetchedAt = now;
     this.gnosisLoad = this.getGnosis()
@@ -237,6 +239,7 @@ export class AppService {
         // Clear the memo so the next call retries immediately instead of waiting out the cache window.
         this.gnosisLoad = undefined;
       });
+    return this.gnosisLoad;
   }
 
   /**

--- a/src/app/data/gnosis-route.spec.ts
+++ b/src/app/data/gnosis-route.spec.ts
@@ -1,0 +1,90 @@
+import { GNOSIS_ROUTE_STOPS, gnosisRouteDueDates, gnosisRouteIndex, isGnosisRouteSystem, normalizeSystemName } from './gnosis-route';
+
+describe('gnosis-route', () => {
+  it('lists all 8 stops in visit order, starting and ending as specified by the issue', () => {
+    expect(GNOSIS_ROUTE_STOPS.length).toBe(8);
+    expect(GNOSIS_ROUTE_STOPS[0]).toBe('Varati');
+    expect(GNOSIS_ROUTE_STOPS[GNOSIS_ROUTE_STOPS.length - 1]).toBe('Epsilon Indi');
+    expect(GNOSIS_ROUTE_STOPS).toEqual([
+      'Varati',
+      'HIP 17862',
+      'Pleiades Sector PN-T b3-0',
+      'Synuefe PR-L b40-1',
+      'HIP 18120',
+      'IC 2391 Sector CQ-Y c16',
+      'Kappa-1 Volantis',
+      'Epsilon Indi',
+    ]);
+  });
+
+  describe('normalizeSystemName', () => {
+    it('trims whitespace and lowercases', () => {
+      expect(normalizeSystemName('  Varati  ')).toBe('varati');
+      expect(normalizeSystemName('EPSILON INDI')).toBe('epsilon indi');
+    });
+  });
+
+  describe('isGnosisRouteSystem', () => {
+    it('matches a route stop regardless of case or surrounding whitespace', () => {
+      expect(isGnosisRouteSystem('Varati')).toBe(true);
+      expect(isGnosisRouteSystem('varati')).toBe(true);
+      expect(isGnosisRouteSystem('  Epsilon Indi  ')).toBe(true);
+      expect(isGnosisRouteSystem('KAPPA-1 VOLANTIS')).toBe(true);
+    });
+
+    it('returns false for a system not on the route', () => {
+      expect(isGnosisRouteSystem('Sol')).toBe(false);
+      expect(isGnosisRouteSystem('')).toBe(false);
+    });
+  });
+
+  describe('gnosisRouteIndex', () => {
+    it('returns the 0-based visit-order index for each stop', () => {
+      expect(gnosisRouteIndex('Varati')).toBe(0);
+      expect(gnosisRouteIndex('hip 17862')).toBe(1);
+      expect(gnosisRouteIndex('Epsilon Indi')).toBe(7);
+    });
+
+    it('returns -1 for a system not on the route', () => {
+      expect(gnosisRouteIndex('Sol')).toBe(-1);
+    });
+  });
+
+  describe('gnosisRouteDueDates', () => {
+    it('infers every stop\'s date as a whole number of weeks from the current slot start', () => {
+      // "Now" is exactly a Thursday-07:00-UTC jump instant, so it IS the current slot's start.
+      // Currently at HIP 17862 (index 1).
+      const dates = gnosisRouteDueDates('HIP 17862', new Date('2026-07-09T07:00:00Z'));
+      expect(dates.map(d => d.name)).toEqual([...GNOSIS_ROUTE_STOPS]);
+
+      // The current stop keeps its own slot-start date; every other stop is a multiple of 7
+      // days later, wrapping around the 8-stop loop.
+      expect(dates).toEqual([
+        { name: 'Varati', dueDate: '2026-08-27', presentNow: false }, // 7 weeks ahead — wraps around the loop
+        { name: 'HIP 17862', dueDate: '2026-07-09', presentNow: true }, // index 1: itself
+        { name: 'Pleiades Sector PN-T b3-0', dueDate: '2026-07-16', presentNow: false },
+        { name: 'Synuefe PR-L b40-1', dueDate: '2026-07-23', presentNow: false },
+        { name: 'HIP 18120', dueDate: '2026-07-30', presentNow: false },
+        { name: 'IC 2391 Sector CQ-Y c16', dueDate: '2026-08-06', presentNow: false },
+        { name: 'Kappa-1 Volantis', dueDate: '2026-08-13', presentNow: false },
+        { name: 'Epsilon Indi', dueDate: '2026-08-20', presentNow: false },
+      ]);
+    });
+
+    it('marks exactly one stop present, at the current position', () => {
+      const dates = gnosisRouteDueDates('Epsilon Indi', new Date('2026-07-09T07:00:00Z'));
+      expect(dates.filter(d => d.presentNow)).toEqual([{ name: 'Epsilon Indi', dueDate: '2026-07-09', presentNow: true }]);
+    });
+
+    it('treats any instant within the week as the same slot (not just the exact jump moment)', () => {
+      // A few days after the Thursday jump — still the same weekly slot.
+      const dates = gnosisRouteDueDates('HIP 17862', new Date('2026-07-12T18:30:00Z'));
+      expect(dates.find(d => d.presentNow)).toEqual({ name: 'HIP 17862', dueDate: '2026-07-09', presentNow: true });
+    });
+
+    it('returns null dates when the live position is not a recognised route stop', () => {
+      const dates = gnosisRouteDueDates('Some Unrelated System', new Date('2026-07-09T07:00:00Z'));
+      expect(dates.every(d => d.dueDate === null && !d.presentNow)).toBe(true);
+    });
+  });
+});

--- a/src/app/data/gnosis-route.ts
+++ b/src/app/data/gnosis-route.ts
@@ -1,0 +1,83 @@
+/**
+ * The Gnosis megaship's permanent 8-system retirement loop (issue canonn-science/canonn-signals#121).
+ * Unlike the community-sighted megaship schedule in `data/megaships.ts`, this route is fixed and
+ * confirmed, not derived from sightings — the ship's current position is live-tracked via
+ * `AppService.getGnosis()`, the same source used to place its marker on the Galaxy Region Map
+ * (see `region-map.component.ts`).
+ */
+export const GNOSIS_ROUTE_STOPS: readonly string[] = [
+  'Varati',
+  'HIP 17862',
+  'Pleiades Sector PN-T b3-0',
+  'Synuefe PR-L b40-1',
+  'HIP 18120',
+  'IC 2391 Sector CQ-Y c16',
+  'Kappa-1 Volantis',
+  'Epsilon Indi',
+];
+
+/** Case/whitespace-insensitive comparison key for a system name. */
+export function normalizeSystemName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+/** True if `systemName` is one of the Gnosis's 8 permanent stops. */
+export function isGnosisRouteSystem(systemName: string): boolean {
+  return gnosisRouteIndex(systemName) !== -1;
+}
+
+/** The stop's index (0-based, in visit order starting at Varati), or -1 if not a route stop. */
+export function gnosisRouteIndex(systemName: string): number {
+  const target = normalizeSystemName(systemName);
+  return GNOSIS_ROUTE_STOPS.findIndex(stop => normalizeSystemName(stop) === target);
+}
+
+/** A route stop with its next-due date inferred from the Gnosis's current position. */
+export interface GnosisRouteDueStop {
+  name: string;
+  /** ISO date (YYYY-MM-DD) this stop is next due, or null if the current position couldn't be
+   *  placed on the route (e.g. stale/unrecognised live-tracking data). */
+  dueDate: string | null;
+  presentNow: boolean;
+}
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+/** Any Thursday 07:00 UTC works as the weekly-cadence reference point — this one matches the
+ *  community megaship schedule's own anchor in `data/megaships.ts`. */
+const CADENCE_ANCHOR_MS = Date.parse('2023-12-28T07:00:00+00:00');
+
+/** The UTC instant of the most recent Thursday ~07:00 UTC at or before `now` — the start of
+ *  the Gnosis's current weekly "slot". Computed from the wall clock rather than a live-fetched
+ *  timestamp: the Gnosis API reports only the current system, not a jump date. */
+function currentSlotStartMs(now: Date): number {
+  const slot = Math.floor((now.getTime() - CADENCE_ANCHOR_MS) / WEEK_MS);
+  return CADENCE_ANCHOR_MS + slot * WEEK_MS;
+}
+
+/** ISO date (YYYY-MM-DD) of the given UTC instant. */
+function isoDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/**
+ * Every stop's next-due date, inferred from the Gnosis's current position and the current time.
+ * The Gnosis jumps to the next stop on a fixed weekly cadence (Thursdays, ~07:00 UTC — the same
+ * cadence `data/megaships.ts` assumes for the community-tracked fleet), so once the current stop
+ * is known, every other stop's date is just the start of the current weekly slot plus a whole
+ * number of weeks around the 8-stop loop.
+ */
+export function gnosisRouteDueDates(currentSystemName: string, now: Date): GnosisRouteDueStop[] {
+  const currentIndex = gnosisRouteIndex(currentSystemName);
+  if (currentIndex === -1) {
+    return GNOSIS_ROUTE_STOPS.map(name => ({ name, dueDate: null, presentNow: false }));
+  }
+  const slotStartMs = currentSlotStartMs(now);
+  return GNOSIS_ROUTE_STOPS.map((name, index) => {
+    const offset = (index - currentIndex + GNOSIS_ROUTE_STOPS.length) % GNOSIS_ROUTE_STOPS.length;
+    return {
+      name,
+      dueDate: isoDate(slotStartMs + offset * WEEK_MS),
+      presentNow: offset === 0,
+    };
+  });
+}

--- a/src/app/dialogs/megaship-route-dialog/megaship-route-dialog.component.html
+++ b/src/app/dialogs/megaship-route-dialog/megaship-route-dialog.component.html
@@ -4,10 +4,15 @@
       <ul>
         <li><strong>Signal name:</strong> {{ data.signalName }}</li>
         @if (data.type === 'cycle') {
-        <li><strong>Route:</strong> {{ data.routeLen }} weekly stop{{ data.routeLen === 1 ? '' : 's' }}
+        <li><strong>Route:</strong>
+          @if (data.routeDescription) {
+          {{ data.routeDescription }}
+          } @else {
+          {{ data.routeLen }} weekly stop{{ data.routeLen === 1 ? '' : 's' }}
           — <span [class.confirmed]="data.confirmed" [class.unconfirmed]="!data.confirmed">
             {{ data.confirmed ? 'confirmed' : 'unconfirmed' }}
           </span>
+          }
         </li>
         } @else {
         <li><strong>Route:</strong> static — always at the same system</li>
@@ -38,7 +43,7 @@
           <tr [class.present]="stop.presentNow">
             <td class="num">{{ stop.position + 1 }}</td>
             <td>{{ stop.systemName }}</td>
-            <td class="date">{{ stop.dueDate }}</td>
+            <td class="date">{{ stop.dueDate ?? '—' }}</td>
             <td>{{ stop.presentNow ? 'Present' : 'Due' }}</td>
           </tr>
           }
@@ -47,10 +52,15 @@
     </div>
 
     <p class="disclaimer">
-      <strong>Disclaimer:</strong> This route is derived from community sightings collected since 2022 —
+      <strong>Disclaimer:</strong>
+      @if (data.disclaimer) {
+      {{ data.disclaimer }}
+      } @else {
+      This route is derived from community sightings collected since 2022 —
       it is not an official schedule and has not been confirmed against the ship's actual shipboard
       itinerary. Positions with no recorded sighting are omitted, and unconfirmed routes are a
       best guess from limited data.
+      }
     </p>
   </div>
 </app-dialog-shell>

--- a/src/app/dialogs/megaship-route-dialog/megaship-route-dialog.component.spec.ts
+++ b/src/app/dialogs/megaship-route-dialog/megaship-route-dialog.component.spec.ts
@@ -118,4 +118,70 @@ describe('MegashipRouteDialogComponent', () => {
     const el: HTMLElement = fixture.nativeElement;
     expect(el.textContent).toContain('unconfirmed');
   });
+
+  describe('statically-named stops (issue #121, e.g. the Gnosis)', () => {
+    it('shows a stop\'s systemName immediately, without an id64 lookup', async () => {
+      const fixture = await setup({
+        signalName: 'The Gnosis', shipName: 'The Gnosis', type: 'cycle', confirmed: true,
+        lastSeen: '2026-07-10', routeLen: 2,
+        stops: [
+          { position: 0, systemName: 'Varati', dueDate: '2026-07-17', presentNow: true },
+          { position: 1, systemName: 'HIP 17862', dueDate: null, presentNow: false },
+        ],
+      });
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.textContent).toContain('Varati');
+      expect(el.textContent).toContain('HIP 17862');
+      expect(el.textContent).not.toContain('…');
+    });
+
+    it('renders a null dueDate as an em dash and does not request a name lookup', async () => {
+      const requestSystemName = vi.fn();
+      vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(ok({}))));
+      TestBed.configureTestingModule({
+        imports: [MegashipRouteDialogComponent],
+        providers: [
+          provideZonelessChangeDetection(),
+          {
+            provide: MAT_DIALOG_DATA, useValue: {
+              signalName: 'The Gnosis', shipName: 'The Gnosis', type: 'cycle', confirmed: true,
+              lastSeen: '2026-07-10', routeLen: 1,
+              stops: [{ position: 0, systemName: 'Varati', dueDate: null, presentNow: true }],
+            } satisfies MegashipRouteDialogData,
+          },
+          { provide: AppService, useValue: { systemNames: () => new Map(), requestSystemName } },
+        ],
+      });
+      const fixture = TestBed.createComponent(MegashipRouteDialogComponent);
+      fixture.detectChanges();
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelector('.date')?.textContent?.trim()).toBe('—');
+      expect(requestSystemName).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('overridable route description and disclaimer (issue #121)', () => {
+    it('uses routeDescription in place of the default "N weekly stops" summary', async () => {
+      const fixture = await setup({
+        signalName: 'The Gnosis', shipName: 'The Gnosis', type: 'cycle', confirmed: true,
+        lastSeen: '2026-07-10', routeLen: 8, routeDescription: '8-system retirement loop — confirmed',
+        stops: [{ position: 0, systemName: 'Varati', dueDate: null, presentNow: true }],
+      });
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.textContent).toContain('8-system retirement loop — confirmed');
+      expect(el.textContent).not.toContain('weekly stop');
+    });
+
+    it('uses a custom disclaimer in place of the default community-sightings text', async () => {
+      const fixture = await setup({
+        signalName: 'The Gnosis', shipName: 'The Gnosis', type: 'cycle', confirmed: true,
+        lastSeen: '2026-07-10', routeLen: 8,
+        disclaimer: 'Live-tracked from the Gnosis API, not community sightings.',
+        stops: [{ position: 0, systemName: 'Varati', dueDate: null, presentNow: true }],
+      });
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.textContent).toContain('Live-tracked from the Gnosis API, not community sightings.');
+      expect(el.textContent).not.toContain('community sightings collected since 2022');
+    });
+  });
 });

--- a/src/app/dialogs/megaship-route-dialog/megaship-route-dialog.component.ts
+++ b/src/app/dialogs/megaship-route-dialog/megaship-route-dialog.component.ts
@@ -6,9 +6,14 @@ import { AppService } from '../../app.service';
 /** One stop on a megaship's route, before its system name has been resolved. */
 export interface MegashipRouteStopData {
   position: number;
-  systemId64: number;
-  /** ISO date (YYYY-MM-DD) this stop is next due. */
-  dueDate: string;
+  /** Resolved reactively via `AppService.systemNames()` (there's no reverse id64->name endpoint). */
+  systemId64?: number;
+  /** Set instead of `systemId64` for routes whose stop names are already known statically (e.g.
+   *  the Gnosis's fixed 8-system loop — see `data/gnosis-route.ts`), skipping the id64 lookup entirely. */
+  systemName?: string;
+  /** ISO date (YYYY-MM-DD) this stop is next due, or null when no date applies (e.g. a Gnosis
+   *  stop other than its current one — the loop is live-tracked, not scheduled). */
+  dueDate: string | null;
   presentNow: boolean;
 }
 
@@ -27,25 +32,35 @@ export interface MegashipRouteDialogData {
   routeLen?: number;
   /** Every observed stop, in route order (a single always-present entry for a static ship). */
   stops: MegashipRouteStopData[];
+  /** Overrides the default "N weekly stops" summary line for a cycle route that isn't weekly
+   *  (e.g. the Gnosis's retirement loop). */
+  routeDescription?: string;
+  /** Overrides the default community-sightings disclaimer (e.g. for the Gnosis's confirmed,
+   *  live-tracked route, where that disclaimer would be misleading). */
+  disclaimer?: string;
 }
 
 /** A route stop with its system name resolved for display (falls back to the raw id64 while resolving). */
 export interface MegashipRouteStopDisplay {
   position: number;
   systemName: string;
-  dueDate: string;
+  dueDate: string | null;
   presentNow: boolean;
 }
 
 /**
  * Shows a tracked megaship's full route: every system it visits and the date it's next due
- * there. Per issue canonn-science/canonn-signals#114, this data is derived from community
- * sightings, not an official schedule, so the dialog carries a disclaimer to that effect.
+ * there. Per issue canonn-science/canonn-signals#114, most tracked megaships' routes are derived
+ * from community sightings rather than an official schedule, so the dialog carries a disclaimer
+ * to that effect by default — overridable via `MegashipRouteDialogData.disclaimer` for routes that
+ * aren't (e.g. the Gnosis's confirmed, live-tracked loop — issue #121).
  *
- * The route arrives as raw system addresses (`MegashipRouteDialogData.stops`) so the dialog
- * opens instantly; names are resolved reactively via `AppService.systemNames()` (there's no
- * reverse id64->name endpoint, so each stop piggybacks on a biostats lookup) and fill in as
- * they arrive, the same pattern the Megaships table row uses for its "current location" cell.
+ * Most callers pass stops as raw system addresses (`MegashipRouteStopData.systemId64`) so the
+ * dialog opens instantly; names are resolved reactively via `AppService.systemNames()` (there's no
+ * reverse id64->name endpoint, so each stop piggybacks on a biostats lookup) and fill in as they
+ * arrive, the same pattern the Megaships table row uses for its "current location" cell. A route
+ * whose stop names are already known statically (again, the Gnosis) can set `systemName` directly
+ * per stop instead, skipping that lookup.
  */
 @Component({
   selector: 'app-megaship-route-dialog',
@@ -62,7 +77,7 @@ export class MegashipRouteDialogComponent {
     const names = this.appService.systemNames();
     return this.data.stops.map(stop => ({
       position: stop.position,
-      systemName: names.get(String(stop.systemId64)) ?? '…',
+      systemName: stop.systemName ?? names.get(String(stop.systemId64)) ?? '…',
       dueDate: stop.dueDate,
       presentNow: stop.presentNow,
     }));
@@ -71,7 +86,9 @@ export class MegashipRouteDialogComponent {
   constructor() {
     effect(() => {
       for (const stop of this.data.stops) {
-        this.appService.requestSystemName(stop.systemId64);
+        if (stop.systemId64 !== undefined) {
+          this.appService.requestSystemName(stop.systemId64);
+        }
       }
     });
   }

--- a/src/app/gnosis-route/gnosis-route.component.html
+++ b/src/app/gnosis-route/gnosis-route.component.html
@@ -1,0 +1,27 @@
+<div class="gnosis-route" role="region" aria-label="Gnosis Megaship Science Tour route">
+  <div class="gnosis-route-header">
+    <span class="gnosis-route-label">Gnosis Route</span>
+    <span class="gnosis-route-title">Gnosis Megaship Science Tour</span>
+  </div>
+  <div class="gnosis-route-track">
+    @for (stop of stops(); track stop.name; let last = $last) {
+    <div class="gnosis-stop" [class.gnosis-stop--current]="stop.current" role="button" tabindex="0"
+      [attr.aria-current]="stop.current ? 'location' : null"
+      [title]="'Open the signals page for ' + stop.name" (click)="select(stop.name)"
+      (keydown.enter)="select(stop.name)" (keydown.space)="$event.preventDefault(); select(stop.name)">
+      <span class="gnosis-stop-node" aria-hidden="true"></span>
+      <span class="gnosis-stop-label">{{ stop.name }}</span>
+      @if (stop.current) {
+      <span class="gnosis-stop-tag">Current position</span>
+      }
+    </div>
+    @if (!last) {
+    <span class="gnosis-connector" aria-hidden="true"></span>
+    }
+    }
+  </div>
+  <div class="gnosis-loop-note">
+    <span class="gnosis-loop-icon" aria-hidden="true">&#8635;</span>
+    Loops back to Varati
+  </div>
+</div>

--- a/src/app/gnosis-route/gnosis-route.component.scss
+++ b/src/app/gnosis-route/gnosis-route.component.scss
@@ -1,0 +1,200 @@
+:host {
+    display: block;
+}
+
+/* Same solid dark-charcoal panel as each body's header bar (.body-title in
+   system-body.component.scss), rather than the translucent grey used elsewhere. */
+.gnosis-route {
+    margin-top: 32px;
+    background-color: var(--color-surface);
+    padding: 10px 12px;
+    border-radius: 4px;
+}
+
+.gnosis-route-header {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.gnosis-route-label {
+    font-size: 14px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-accent);
+}
+
+.gnosis-route-title {
+    font-size: 12px;
+    color: var(--color-white);
+    opacity: 0.85;
+}
+
+.gnosis-route-track {
+    display: flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    row-gap: 16px;
+}
+
+.gnosis-stop {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.gnosis-stop:hover,
+.gnosis-stop:focus-visible {
+    background: var(--color-surface-hover);
+}
+
+.gnosis-stop:focus-visible {
+    outline: 2px solid var(--color-link-hover);
+    outline-offset: 2px;
+}
+
+.gnosis-stop-node {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--color-surface);
+    border: 2px solid var(--color-accent);
+    box-sizing: border-box;
+    flex-shrink: 0;
+}
+
+.gnosis-stop-label {
+    font-size: 12px;
+    color: var(--color-text-2);
+    text-align: center;
+    line-height: 1.25;
+    max-width: 100px;
+}
+
+.gnosis-stop-tag {
+    font-size: 9px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-accent);
+    background: color-mix(in srgb, var(--color-accent) 20%, transparent);
+    border-radius: 999px;
+    padding: 1px 6px;
+    white-space: nowrap;
+}
+
+/* The current stop reads as a distinct filled red node (var(--color-danger)) with its label/tag
+   in the site's orange accent — flat, no glow, so it stays legible rather than garish. */
+.gnosis-stop--current .gnosis-stop-node {
+    background: var(--color-danger);
+    border-color: var(--color-danger);
+}
+
+.gnosis-stop--current .gnosis-stop-label {
+    color: var(--color-accent);
+    font-weight: bold;
+}
+
+/* A thin track segment between adjacent stops, with an arrowhead showing travel direction.
+   `align-self: flex-start` (inherited from the track's own `align-items: flex-start`) plus this
+   margin centers it on the 14px node regardless of how many lines a neighboring stop's label
+   wraps to. */
+.gnosis-connector {
+    position: relative;
+    flex: 1 1 20px;
+    min-width: 10px;
+    height: 3px;
+    margin-top: 6px;
+    background: var(--color-accent);
+}
+
+/* Right-pointing arrowhead (a CSS border-triangle) at the connector's leading edge. */
+.gnosis-connector::after {
+    content: '';
+    position: absolute;
+    right: -1px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 5px 0 5px 7px;
+    border-color: transparent transparent transparent var(--color-accent);
+}
+
+.gnosis-loop-note {
+    margin-top: 10px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+    color: var(--color-text-2);
+    opacity: 0.85;
+}
+
+.gnosis-loop-icon {
+    color: var(--color-accent);
+    font-size: 13px;
+    line-height: 1;
+}
+
+/* Progressively shrink node spacing and label size before the track would otherwise overflow. */
+@media (max-width: 900px) {
+    .gnosis-stop-label {
+        font-size: 11px;
+        max-width: 76px;
+    }
+
+    .gnosis-connector {
+        flex-basis: 10px;
+    }
+}
+
+/* Collapse to a vertical tube map, consistent with how the System Panel's own two-column
+   layout reflows to a single column at the same breakpoint (home.component.scss). */
+@media (max-width: 600px) {
+    .gnosis-route-track {
+        flex-direction: column;
+        align-items: flex-start;
+        row-gap: 8px;
+    }
+
+    .gnosis-stop {
+        flex-direction: row;
+        width: 100%;
+        justify-content: flex-start;
+        gap: 8px;
+    }
+
+    .gnosis-stop-label {
+        max-width: none;
+        text-align: left;
+    }
+
+    .gnosis-connector {
+        width: 3px;
+        height: 16px;
+        min-width: 0;
+        flex: 0 0 auto;
+        margin-top: 0;
+        margin-left: 6px;
+    }
+
+    /* Down-pointing arrowhead, matching the vertical track direction. */
+    .gnosis-connector::after {
+        right: auto;
+        top: auto;
+        left: 50%;
+        bottom: -1px;
+        transform: translateX(-50%);
+        border-width: 7px 5px 0 5px;
+        border-color: var(--color-accent) transparent transparent transparent;
+    }
+}

--- a/src/app/gnosis-route/gnosis-route.component.spec.ts
+++ b/src/app/gnosis-route/gnosis-route.component.spec.ts
@@ -1,0 +1,75 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal, WritableSignal } from '@angular/core';
+
+import { GnosisRouteComponent } from './gnosis-route.component';
+import { AppService } from '../app.service';
+import { GNOSIS_ROUTE_STOPS } from '../data/gnosis-route';
+
+describe('GnosisRouteComponent', () => {
+  let component: GnosisRouteComponent;
+  let fixture: ComponentFixture<GnosisRouteComponent>;
+  let gnosisData$: WritableSignal<{ system: string } | null>;
+
+  beforeEach(() => {
+    gnosisData$ = signal<{ system: string } | null>(null);
+    TestBed.configureTestingModule({
+      imports: [GnosisRouteComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: AppService, useValue: { gnosisData: gnosisData$ } },
+      ],
+    });
+    fixture = TestBed.createComponent(GnosisRouteComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('lists all 8 stops in visit order with none highlighted before Gnosis data arrives', () => {
+    const stops = component.stops();
+    expect(stops.map(s => s.name)).toEqual([...GNOSIS_ROUTE_STOPS]);
+    expect(stops.every(s => !s.current)).toBe(true);
+  });
+
+  it('highlights the stop matching the live-tracked Gnosis position', () => {
+    gnosisData$.set({ system: 'HIP 17862' });
+    const stops = component.stops();
+    expect(stops.find(s => s.current)?.name).toBe('HIP 17862');
+    expect(stops.filter(s => s.current).length).toBe(1);
+  });
+
+  it('matches the current stop case/whitespace-insensitively', () => {
+    gnosisData$.set({ system: '  epsilon indi  ' });
+    expect(component.stops().find(s => s.current)?.name).toBe('Epsilon Indi');
+  });
+
+  it('highlights nothing when the live position is not one of the 8 stops', () => {
+    gnosisData$.set({ system: 'Some Unrelated System' });
+    expect(component.stops().every(s => !s.current)).toBe(true);
+  });
+
+  it('emits the stop name on select', () => {
+    const emitted: string[] = [];
+    component.stopSelected.subscribe(name => emitted.push(name));
+    component.select('Varati');
+    expect(emitted).toEqual(['Varati']);
+  });
+
+  it('renders a clickable node for every stop, with the current one tagged', () => {
+    gnosisData$.set({ system: 'Kappa-1 Volantis' });
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+    const stopEls = el.querySelectorAll('.gnosis-stop');
+    expect(stopEls.length).toBe(8);
+    expect(el.textContent).toContain('Kappa-1 Volantis');
+    expect(el.querySelector('.gnosis-stop--current')?.textContent).toContain('Current position');
+    expect(el.textContent).toContain('Loops back to Varati');
+  });
+
+  it('navigates when a stop is clicked', () => {
+    fixture.detectChanges();
+    const emitted: string[] = [];
+    component.stopSelected.subscribe(name => emitted.push(name));
+    const el: HTMLElement = fixture.nativeElement;
+    (el.querySelector('.gnosis-stop') as HTMLElement).click();
+    expect(emitted).toEqual(['Varati']);
+  });
+});

--- a/src/app/gnosis-route/gnosis-route.component.ts
+++ b/src/app/gnosis-route/gnosis-route.component.ts
@@ -1,0 +1,39 @@
+import { ChangeDetectionStrategy, Component, computed, inject, output } from '@angular/core';
+import { AppService } from '../app.service';
+import { GNOSIS_ROUTE_STOPS, gnosisRouteIndex } from '../data/gnosis-route';
+
+/** One stop on the Gnosis tube map, positioned in visit order. */
+export interface GnosisRouteStopView {
+  name: string;
+  current: boolean;
+}
+
+/**
+ * The Gnosis megaship's permanent 8-system retirement-loop "tube map" (issue
+ * canonn-science/canonn-signals#121). The caller (`home.component.html`) only mounts this when
+ * the currently viewed system is itself one of the 8 stops (`isGnosisRouteSystem`); the current
+ * stop is highlighted from `AppService.gnosisData()` — the same live-tracked source used to place
+ * the Gnosis marker on the Galaxy Region Map.
+ */
+@Component({
+  selector: 'app-gnosis-route',
+  templateUrl: './gnosis-route.component.html',
+  styleUrl: './gnosis-route.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class GnosisRouteComponent {
+  private readonly appService = inject(AppService);
+
+  /** Emits the stop's system name when it's clicked/activated. */
+  readonly stopSelected = output<string>();
+
+  readonly stops = computed<GnosisRouteStopView[]>(() => {
+    const gnosis = this.appService.gnosisData();
+    const currentIndex = gnosis ? gnosisRouteIndex(gnosis.system) : -1;
+    return GNOSIS_ROUTE_STOPS.map((name, index) => ({ name, current: index === currentIndex }));
+  });
+
+  public select(name: string): void {
+    this.stopSelected.emit(name);
+  }
+}

--- a/src/app/home/home.component.extra.spec.ts
+++ b/src/app/home/home.component.extra.spec.ts
@@ -93,6 +93,8 @@ describe('HomeComponent (extended coverage)', () => {
             requestSystemName: vi.fn(),
             resolveSystemName: vi.fn(() => Promise.resolve('')),
             nowOverride: signal<number | null>(null),
+            gnosisData: signal(null),
+            ensureGnosis: vi.fn(),
           },
         },
         { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => null } } } },

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -349,6 +349,9 @@
         </div>
       </div>
     </div>
+    @if (showGnosisRoute()) {
+    <app-gnosis-route (stopSelected)="openSignalsPage($event)"></app-gnosis-route>
+    }
     @if (systemCompleteness(); as completeness) {
     <div class="system-completeness" role="img"
       [attr.aria-label]="completeness.percent === null

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -42,7 +42,7 @@ describe('HomeComponent', () => {
             resolveSystemName: () => Promise.resolve(''),
             nowOverride: signal(null),
             gnosisData: signal(null),
-            ensureGnosis: () => {},
+            ensureGnosis: vi.fn(),
           },
         },
         { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => null } } } },
@@ -513,6 +513,7 @@ describe('HomeComponent', () => {
       return TestBed.inject(AppService) as unknown as {
         gnosisData: { set(v: unknown): void };
         nowOverride: { set(v: number | null): void };
+        ensureGnosis: ReturnType<typeof vi.fn>;
       };
     }
 
@@ -594,6 +595,29 @@ describe('HomeComponent', () => {
 
       expect(() => component.openMegashipRouteDialog('The Gnosis')).not.toThrow();
       expect(open).toHaveBeenCalledTimes(1);
+    });
+
+    describe('ensureGnosis gating on system load', () => {
+      function systemWith(name: string) {
+        return {
+          system: {
+            name, id64: 1, coords: { x: 0, y: 0, z: 0 },
+            region: { name: 'Inner Orion Spur', region: 18 },
+            population: 0,
+            bodies: [],
+          },
+        };
+      }
+
+      it('kicks off the Gnosis fetch when the loaded system is one of its 8 route stops', () => {
+        (component as any).processBodies(systemWith('Varati'));
+        expect(appService().ensureGnosis).toHaveBeenCalled();
+      });
+
+      it('does not fetch Gnosis data for a system it never visits (the region map fetches it independently if needed)', () => {
+        (component as any).processBodies(systemWith('Sol'));
+        expect(appService().ensureGnosis).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -41,6 +41,8 @@ describe('HomeComponent', () => {
             requestSystemName: vi.fn(),
             resolveSystemName: () => Promise.resolve(''),
             nowOverride: signal(null),
+            gnosisData: signal(null),
+            ensureGnosis: () => {},
           },
         },
         { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => null } } } },
@@ -435,6 +437,7 @@ describe('HomeComponent', () => {
         systemNames: { set(v: ReadonlyMap<string, string>): void };
         nowOverride: { set(v: number | null): void };
         requestSystemName: ReturnType<typeof vi.fn>;
+        gnosisData: { set(v: unknown): void };
       };
     }
 
@@ -502,6 +505,95 @@ describe('HomeComponent', () => {
       component.openMegashipRouteDialog('NO SUCH SHIP');
 
       expect(open).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Gnosis route (issue #121)', () => {
+    function appService() {
+      return TestBed.inject(AppService) as unknown as {
+        gnosisData: { set(v: unknown): void };
+        nowOverride: { set(v: number | null): void };
+      };
+    }
+
+    it('shows the tube-map card only on one of the Gnosis\'s 8 route stops', () => {
+      component.data.set({ system: { id64: 1, name: 'Varati', coords: { x: 0, y: 0, z: 0 }, bodies: [] } } as never);
+      expect(component.showGnosisRoute()).toBe(true);
+
+      component.data.set({ system: { id64: 2, name: 'Sol', coords: { x: 0, y: 0, z: 0 }, bodies: [] } } as never);
+      expect(component.showGnosisRoute()).toBe(false);
+    });
+
+    it('adds a Gnosis row to the Megaships table on a route stop, "…" before position data arrives', () => {
+      component.data.set({ system: { id64: 1, name: 'HIP 17862', coords: { x: 0, y: 0, z: 0 }, bodies: [] } } as never);
+      expect(component.megashipRows()).toEqual([
+        { signalName: 'The Gnosis', shipName: 'The Gnosis', locationLabel: '…' },
+      ]);
+    });
+
+    it('shows "Present" when the live Gnosis position matches the loaded system', () => {
+      component.data.set({ system: { id64: 1, name: 'HIP 17862', coords: { x: 0, y: 0, z: 0 }, bodies: [] } } as never);
+      // The live API returns only { system, coords, desc } — no arrival/departure timestamp.
+      appService().gnosisData.set({ system: 'hip 17862', coords: [0, 0, 0], desc: '' });
+      expect(component.megashipRows()[0].locationLabel).toBe('Present');
+    });
+
+    it('shows the Gnosis\'s actual current stop when it differs from the loaded system', () => {
+      component.data.set({ system: { id64: 1, name: 'HIP 17862', coords: { x: 0, y: 0, z: 0 }, bodies: [] } } as never);
+      appService().gnosisData.set({ system: 'Varati', coords: [0, 0, 0], desc: '' });
+      expect(component.megashipRows()[0].locationLabel).toBe('Varati');
+    });
+
+    it('does not add a Gnosis row for a system it never visits', () => {
+      component.data.set({ system: { id64: 1, name: 'Sol', coords: { x: 0, y: 0, z: 0 }, bodies: [] } } as never);
+      expect(component.megashipRows()).toEqual([]);
+    });
+
+    it('opens the route dialog with all 8 stops, highlighting the live-tracked position', () => {
+      component.data.set({ system: { id64: 1, name: 'Varati', coords: { x: 0, y: 0, z: 0 }, bodies: [] } } as never);
+      // The live API returns only { system, coords, desc } — no jump timestamp (issue: clicking
+      // "The Gnosis" threw when the dialog tried to read a nonexistent `.arrival` field). The
+      // current weekly slot is instead derived from "now", pinned here to a Thursday 07:00 UTC.
+      appService().gnosisData.set({ system: 'Kappa-1 Volantis', coords: [0, 0, 0], desc: '' });
+      appService().nowOverride.set(Date.parse('2026-07-09T07:00:00Z'));
+
+      const dialog = TestBed.inject(MatDialog);
+      const open = vi.spyOn(dialog, 'open').mockReturnValue({} as never);
+
+      component.openMegashipRouteDialog('The Gnosis');
+
+      expect(open).toHaveBeenCalledTimes(1);
+      const [, config] = open.mock.calls[0];
+      const data = (config?.data as { data: unknown }).data as {
+        signalName: string; shipName: string; type: string; routeLen: number; disclaimer: string; lastSeen: string;
+        stops: { position: number; systemName: string; dueDate: string | null; presentNow: boolean }[];
+      };
+      expect(data.signalName).toBe('The Gnosis');
+      expect(data.routeLen).toBe(8);
+      expect(data.stops.length).toBe(8);
+      expect(data.stops[0].systemName).toBe('Varati');
+      expect(data.stops[data.stops.length - 1].systemName).toBe('Epsilon Indi');
+      const current = data.stops.find(s => s.presentNow);
+      expect(current?.systemName).toBe('Kappa-1 Volantis');
+      expect(current?.dueDate).toBe('2026-07-09'); // the current weekly slot's start
+      expect(data.lastSeen).toBe('2026-07-09');
+      expect(data.stops.filter(s => s.presentNow).length).toBe(1);
+      // Every other stop's date is inferred from the current one, a whole number of weeks out —
+      // Epsilon Indi is the very next stop after Kappa-1 Volantis, one week later.
+      expect(data.stops.find(s => s.systemName === 'Epsilon Indi')?.dueDate).toBe('2026-07-16');
+      expect(data.stops.every(s => s.dueDate !== null)).toBe(true);
+      expect(data.disclaimer).toContain('live-tracked');
+    });
+
+    it('does not throw when the live Gnosis fetch has not resolved yet (no timestamp to rely on)', () => {
+      component.data.set({ system: { id64: 1, name: 'Varati', coords: { x: 0, y: 0, z: 0 }, bodies: [] } } as never);
+      // gnosisData is still null — regression guard for the crash this triggered when the dialog
+      // builder assumed a `gnosis.arrival` field the live API doesn't actually return.
+      const dialog = TestBed.inject(MatDialog);
+      const open = vi.spyOn(dialog, 'open').mockReturnValue({} as never);
+
+      expect(() => component.openMegashipRouteDialog('The Gnosis')).not.toThrow();
+      expect(open).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1182,7 +1182,11 @@ export class HomeComponent implements OnInit, OnDestroy {
     // Kick off the lazy megaship-schedule load so the "Megaships" panel can populate.
     this.appService.ensureMegaships();
     // Kick off the Gnosis position fetch so the route card/Megaships row can highlight its stop.
-    this.appService.ensureGnosis();
+    // Only relevant on the Gnosis's 8 route stops — the region map fetches independently (via
+    // its own ensureGnosis() call) when it needs the marker, so this doesn't gate that.
+    if (this.showGnosisRoute()) {
+      this.appService.ensureGnosis();
+    }
 
     // Only reset edastroData if loading a different system
     if (isDifferentSystem) {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -27,7 +27,9 @@ import { applySpeculativeBodies, getSpeculativeSystemCompleteness, getSpeculativ
 import { BodyEnrichmentService } from '../data/body-enrichment.service';
 import { buildSystemExport, downloadJson, serializeSystemExport, systemExportFilename } from '../data/system-export';
 import { buildMegashipIndex, megashipRoute, megashipsAtSystem, MegashipSystemEntry } from '../data/megaships';
-import type { MegashipRouteDialogData } from '../dialogs/megaship-route-dialog/megaship-route-dialog.component';
+import type { MegashipRouteDialogData, MegashipRouteStopData } from '../dialogs/megaship-route-dialog/megaship-route-dialog.component';
+import { GNOSIS_ROUTE_STOPS, gnosisRouteDueDates, isGnosisRouteSystem, normalizeSystemName } from '../data/gnosis-route';
+import { GnosisRouteComponent } from '../gnosis-route/gnosis-route.component';
 import { BodyPhysicsService } from '../data/body-physics.service';
 import { OrbitalRelationsService } from '../data/orbital-relations.service';
 import { BodyInterestRegistryService } from '../data/body-interest-registry.service';
@@ -45,12 +47,17 @@ interface MegashipRow {
   locationLabel: string;
 }
 
+/** Synthetic `signalName` for the Gnosis's row in the Megaships table (issue #121) — it isn't
+ *  part of the community-sighted schedule in `assets/megaship-schedule.json`, so it's not looked
+ *  up there; `openMegashipRouteDialog` special-cases this value instead. */
+const GNOSIS_SIGNAL_NAME = 'The Gnosis';
+
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatFormField, MatLabel, MatInput, ReactiveFormsModule, MatAutocompleteTrigger, MatAutocomplete, MatOption, MatError, MatButton, FaIconComponent, SystemBodyComponent, RegionMapComponent, CanonnLogoComponent, DecimalPipe, MatTooltip]
+  imports: [MatFormField, MatLabel, MatInput, ReactiveFormsModule, MatAutocompleteTrigger, MatAutocomplete, MatOption, MatError, MatButton, FaIconComponent, SystemBodyComponent, RegionMapComponent, CanonnLogoComponent, DecimalPipe, MatTooltip, GnosisRouteComponent]
 })
 export class HomeComponent implements OnInit, OnDestroy {
   readonly appService = inject(AppService);
@@ -404,11 +411,13 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   readonly megashipRows = computed<MegashipRow[]>(() => {
     const names = this.appService.systemNames();
-    return this.megashipEntries().map(entry => ({
+    const rows = this.megashipEntries().map(entry => ({
       signalName: entry.signalName,
       shipName: entry.shipName,
       locationLabel: this.megashipLocationLabel(entry, names),
     }));
+    const gnosisRow = this.gnosisMegashipRow();
+    return gnosisRow ? [gnosisRow, ...rows] : rows;
   });
 
   private megashipLocationLabel(entry: MegashipSystemEntry, names: ReadonlyMap<string, string>): string {
@@ -421,6 +430,30 @@ export class HomeComponent implements OnInit, OnDestroy {
     return names.get(String(entry.currentSystemId64)) ?? '…';
   }
 
+  // --- Gnosis route (issue #121) -----------------------------------------------------------
+  // True whenever the loaded system is one of the Gnosis's 8 permanent stops; gates both the
+  // tube-map card and its synthetic row in the Megaships table below.
+  readonly showGnosisRoute = computed<boolean>(() => {
+    const name = this.data()?.system?.name;
+    return !!name && isGnosisRouteSystem(name);
+  });
+
+  /** A synthetic Megaships-table row for the Gnosis, shown only on its 8 route stops (the
+   *  generic megaship schedule in `assets/megaship-schedule.json` doesn't cover it). */
+  private readonly gnosisMegashipRow = computed<MegashipRow | null>(() => {
+    const systemName = this.data()?.system?.name;
+    if (!systemName || !isGnosisRouteSystem(systemName)) {
+      return null;
+    }
+    const gnosis = this.appService.gnosisData();
+    const locationLabel = !gnosis
+      ? '…'
+      : normalizeSystemName(gnosis.system) === normalizeSystemName(systemName)
+        ? 'Present'
+        : gnosis.system;
+    return { signalName: GNOSIS_SIGNAL_NAME, shipName: 'The Gnosis', locationLabel };
+  });
+
   /** Best-effort name lookup for every megaship's current location not already shown as "Present". */
   private readonly requestMegashipLocationNames = effect(() => {
     for (const entry of this.megashipEntries()) {
@@ -432,6 +465,10 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   /** Opens the route-detail dialog for a Megaships table row, showing every stop and its due date. */
   public openMegashipRouteDialog(signalName: string): void {
+    if (signalName === GNOSIS_SIGNAL_NAME) {
+      this.openGnosisRouteDialog();
+      return;
+    }
     const schedule = this.appService.megashipSchedule();
     const ship = schedule?.ships.find(s => s.signal_name === signalName);
     if (!schedule || !ship) {
@@ -456,6 +493,49 @@ export class HomeComponent implements OnInit, OnDestroy {
         firstSeen: ship.type === 'static' ? ship.first_seen : undefined,
         weeksConfirmed: ship.type === 'static' ? ship.weeks_confirmed : undefined,
         routeLen: ship.type === 'cycle' ? ship.route_len : undefined,
+        stops,
+      } satisfies MegashipRouteDialogData,
+    });
+  }
+
+  /** Opens the route-detail dialog for the Gnosis's fixed 8-system retirement loop. Every stop's
+   *  date is inferred from the live-tracked current one: the Gnosis jumps on a fixed weekly
+   *  cadence, so the rest of the loop is just that date plus whole weeks (`gnosisRouteDueDates`). */
+  private openGnosisRouteDialog(): void {
+    const gnosis = this.appService.gnosisData();
+    const asOf = new Date(this.appService.nowOverride() ?? Date.now());
+    const dueDates = gnosis ? gnosisRouteDueDates(gnosis.system, asOf) : [];
+    const stops: MegashipRouteStopData[] = GNOSIS_ROUTE_STOPS.map((name, index) => {
+      const due = dueDates[index];
+      return {
+        position: index,
+        systemName: name,
+        dueDate: due?.dueDate ?? null,
+        presentNow: due?.presentNow ?? false,
+      };
+    });
+    // The current stop's own inferred date doubles as "since when" it's been there — the Gnosis
+    // API reports only the current system, not a jump timestamp (see `gnosisRouteDueDates`).
+    const lastSeen = dueDates.find(d => d.presentNow)?.dueDate ?? 'Unknown';
+
+    openLazyDialog(this.dialog, {
+      loader: () => import('../dialogs/megaship-route-dialog/megaship-route-dialog.component').then(m => m.MegashipRouteDialogComponent),
+      skeleton: 'text',
+      width: '700px',
+      maxWidth: '95vw',
+      hasBackdrop: true,
+      backdropClass: 'cdk-overlay-dark-backdrop',
+      data: {
+        signalName: GNOSIS_SIGNAL_NAME,
+        shipName: 'The Gnosis',
+        type: 'cycle',
+        confirmed: true,
+        lastSeen,
+        routeLen: GNOSIS_ROUTE_STOPS.length,
+        routeDescription: `${GNOSIS_ROUTE_STOPS.length}-system retirement loop — confirmed`,
+        disclaimer: "The Gnosis follows a permanent, confirmed retirement loop, jumping to the next stop " +
+          "on a fixed weekly cadence. Its current position is live-tracked from Canonn's Gnosis API; every " +
+          "other stop's date is inferred from that position, not individually confirmed.",
         stops,
       } satisfies MegashipRouteDialogData,
     });
@@ -1101,6 +1181,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.appService.ensureNebulae();
     // Kick off the lazy megaship-schedule load so the "Megaships" panel can populate.
     this.appService.ensureMegaships();
+    // Kick off the Gnosis position fetch so the route card/Megaships row can highlight its stop.
+    this.appService.ensureGnosis();
 
     // Only reset edastroData if loading a different system
     if (isDifferentSystem) {

--- a/src/app/region-map/region-map.component.spec.ts
+++ b/src/app/region-map/region-map.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideZonelessChangeDetection } from '@angular/core';
+import { provideZonelessChangeDetection, signal, WritableSignal } from '@angular/core';
 
-import { RegionMapComponent } from './region-map.component';
+import { GnosisData, RegionMapComponent } from './region-map.component';
 import { AppService } from '../app.service';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -10,19 +10,23 @@ describe('RegionMapComponent', () => {
   let component: RegionMapComponent;
   let fixture: ComponentFixture<RegionMapComponent>;
   let fetchMock: ReturnType<typeof vi.fn>;
-  let getGnosis: ReturnType<typeof vi.fn>;
+  let ensureGnosis: ReturnType<typeof vi.fn>;
+  let gnosisData$: WritableSignal<GnosisData | null>;
 
   beforeEach(() => {
     // The SVG is loaded via the global fetch; return an empty SVG so loadRegionMap has
     // something to parse.
     fetchMock = vi.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve('<svg></svg>') }));
     vi.stubGlobal('fetch', fetchMock);
-    getGnosis = vi.fn(() => Promise.resolve(null));
+    gnosisData$ = signal<GnosisData | null>(null);
+    // ensureGnosis resolves once gnosisData$ has been set, mirroring AppService's real
+    // "fetch, then set the signal" sequencing.
+    ensureGnosis = vi.fn(() => Promise.resolve());
     TestBed.configureTestingModule({
       imports: [RegionMapComponent],
       providers: [
         provideZonelessChangeDetection(),
-        { provide: AppService, useValue: { getGnosis } },
+        { provide: AppService, useValue: { ensureGnosis, gnosisData: gnosisData$ } },
       ],
     });
     fixture = TestBed.createComponent(RegionMapComponent);
@@ -229,23 +233,27 @@ describe('RegionMapComponent', () => {
     it('fetches Gnosis data only for Inner Orion Spur (region 18)', () => {
       const svg = buildSvg();
       (component as any).zoomToRegion(svg.querySelector('#Region_07') as any, svg);
-      expect(getGnosis).not.toHaveBeenCalled();
+      expect(ensureGnosis).not.toHaveBeenCalled();
       (component as any).zoomToRegion(svg.querySelector('#Region_18') as any, svg);
-      expect(getGnosis).toHaveBeenCalledTimes(1);
+      expect(ensureGnosis).toHaveBeenCalledTimes(1);
     });
 
-    it('caches Gnosis data within the cache window', async () => {
-      getGnosis.mockReturnValue(Promise.resolve({ system: 'Sol', coords: [0, 0, 0], arrival: '', departure: '', desc: '' }));
-      await (component as any).fetchGnosisData();
-      await (component as any).fetchGnosisData();
-      expect(getGnosis).toHaveBeenCalledTimes(1); // second call served from cache
+    it('reads the shared AppService.gnosisData cache instead of keeping its own', async () => {
+      // Region-map no longer has a private cache; caching lives solely in AppService (see
+      // app.service.extra.spec.ts), so a second zoom into region 18 just re-reads the signal
+      // rather than re-fetching — ensureGnosis is still called (it's a cheap cache check).
+      gnosisData$.set({ system: 'Sol', coords: [0, 0, 0], desc: '' });
+      const svg = buildSvg();
+      (component as any).zoomToRegion(svg.querySelector('#Region_18') as any, svg);
+      (component as any).zoomToRegion(svg.querySelector('#Region_18') as any, svg);
+      expect(ensureGnosis).toHaveBeenCalledTimes(2);
     });
   });
 
   describe('addGnosisMarker', () => {
     it('adds a clickable Gnosis marker when within the region bounds', () => {
       const svg = buildSvg();
-      (component as any).gnosisData = { system: 'Varati', coords: [-178.65625, 0, -87.125], arrival: '', departure: '', desc: '' };
+      gnosisData$.set({ system: 'Varati', coords: [-178.65625, 0, -87.125], desc: '' });
       const tx = (component as any).mapX(-178.65625);
       const ty = (component as any).mapY(-87.125);
       const bbox = { x: tx - 50, y: ty - 50, width: 100, height: 100 } as DOMRect;
@@ -262,8 +270,15 @@ describe('RegionMapComponent', () => {
 
     it('does not add the marker when Gnosis is outside the region bounds', () => {
       const svg = buildSvg();
-      (component as any).gnosisData = { system: 'Far', coords: [0, 0, 0], arrival: '', departure: '', desc: '' };
+      gnosisData$.set({ system: 'Far', coords: [0, 0, 0], desc: '' });
       const bbox = { x: 9000, y: 9000, width: 10, height: 10 } as DOMRect;
+      (component as any).addGnosisMarker(svg, bbox);
+      expect(svg.querySelector('#gnosis-marker')).toBeNull();
+    });
+
+    it('does nothing when the shared Gnosis data has not resolved yet', () => {
+      const svg = buildSvg();
+      const bbox = { x: 0, y: 0, width: 100, height: 100 } as DOMRect;
       (component as any).addGnosisMarker(svg, bbox);
       expect(svg.querySelector('#gnosis-marker')).toBeNull();
     });

--- a/src/app/region-map/region-map.component.ts
+++ b/src/app/region-map/region-map.component.ts
@@ -62,9 +62,6 @@ export class RegionMapComponent implements OnChanges {
 
   readonly regionMapContainer = viewChild.required<ElementRef<HTMLDivElement>>('regionMapContainer');
 
-  private gnosisData: GnosisData | null = null;
-  private gnosisLastFetched = 0;
-  private readonly GNOSIS_CACHE_DURATION = 3600000; // 1 hour in milliseconds
   /** Guards against issuing a second SVG fetch while the first is still in flight. */
   private svgLoading = false;
   /** False until the map SVG is injected (or the load fails); drives the reserved-space skeleton. */
@@ -267,11 +264,13 @@ export class RegionMapComponent implements OnChanges {
     // Calculate scale factor for markers
     const scaleFactor = MAP_SIZE / size;
 
-    // Fetch Gnosis data and add marker only if region is Inner Orion Spur (region 18)
+    // Fetch Gnosis data and add marker only if region is Inner Orion Spur (region 18). Shares
+    // AppService's cache/fetch (also used by the Gnosis route card) rather than keeping a
+    // second one here.
     if (regionNumber === 18) {
-      this.fetchGnosisData()
-        .then(gnosisData => {
-          if (gnosisData) {
+      this.appService.ensureGnosis()
+        .then(() => {
+          if (this.appService.gnosisData()) {
             this.addGnosisMarker(svgElement, bbox);
             // Scale the Gnosis marker after it's added
             setTimeout(() => {
@@ -511,23 +510,9 @@ export class RegionMapComponent implements OnChanges {
     });
   }
 
-  private async fetchGnosisData(): Promise<GnosisData | null> {
-    // Check if we have cached data and if it's still fresh
-    const now = Date.now();
-
-    if (this.gnosisData && (now - this.gnosisLastFetched) < this.GNOSIS_CACHE_DURATION) {
-      return this.gnosisData;
-    }
-
-    // Fetch fresh data
-    const data = await this.appService.getGnosis();
-    this.gnosisData = data;
-    this.gnosisLastFetched = now;
-    return data;
-  }
-
   private addGnosisMarker(svgElement: SVGSVGElement, regionBbox: DOMRect): void {
-    if (!this.gnosisData) {
+    const gnosisData = this.appService.gnosisData();
+    if (!gnosisData) {
       return;
     }
 
@@ -543,7 +528,7 @@ export class RegionMapComponent implements OnChanges {
     const viewBoxSize = Math.max(viewBoxValues[2], viewBoxValues[3]);
     const currentScaleFactor = MAP_SIZE / viewBoxSize;
 
-    const [x, , z] = this.gnosisData.coords;
+    const [x, , z] = gnosisData.coords;
     const tx = this.mapX(x);
     const finalY = this.mapY(z);
 
@@ -574,7 +559,7 @@ export class RegionMapComponent implements OnChanges {
     circle.style.cursor = 'pointer';
 
     // Add click handler to navigate to system
-    circle.addEventListener('click', () => this.selectSystem(this.gnosisData!.system));
+    circle.addEventListener('click', () => this.selectSystem(gnosisData.system));
 
     // Position tooltip - use more conservative positioning for long text
     // Check if we're in the right 60% of the map (not just right half)
@@ -591,7 +576,7 @@ export class RegionMapComponent implements OnChanges {
     text.setAttribute('pointer-events', 'none');
     text.setAttribute('text-anchor', isRightSide ? 'end' : 'start');
     text.style.display = 'none';
-    text.textContent = `The Gnosis (${this.gnosisData.system})`;
+    text.textContent = `The Gnosis (${gnosisData.system})`;
 
     // Create background rect for text
     const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');

--- a/src/app/region-map/region-map.component.ts
+++ b/src/app/region-map/region-map.component.ts
@@ -14,9 +14,11 @@ export interface RegionMapSystem {
 }
 
 export interface GnosisData {
-  arrival: string;
+  // The live endpoint (query/gnosis) currently returns only `coords`, `desc` and `system` — no
+  // jump/arrival timestamp — so these are optional rather than assumed present.
+  arrival?: string;
   coords: [number, number, number];
-  departure: string;
+  departure?: string;
   desc: string;
   system: string;
 }


### PR DESCRIPTION
## Summary
- Adds a "Gnosis Megaship Science Tour" tube-map card between the System Panel and System Completeness bar, shown only on the Gnosis's 8 permanent retirement-loop stops (Varati, HIP 17862, Pleiades Sector PN-T b3-0, Synuefe PR-L b40-1, HIP 18120, IC 2391 Sector CQ-Y c16, Kappa-1 Volantis, Epsilon Indi). The current stop is highlighted from the same live-tracked source (`AppService.getGnosis()`) used to place the Gnosis marker on the Galaxy Region Map. Track connectors show direction of travel with arrowheads; the layout reflows to a wrapped/vertical tube map on narrow viewports. Clicking a stop opens its signals page in a new tab.
- Adds a synthetic "The Gnosis" row to the Megaships table on those same 8 systems, whose route dialog reuses the existing Megaships route-dialog component (extended to support statically-known stop names and an overridable disclaimer/route description, since the Gnosis's route is a confirmed live-tracked loop, not a community-sighted schedule).
- Every stop's "due date" in that dialog is inferred from the Gnosis's fixed weekly (Thursday ~07:00 UTC) jump cadence and its current live position — the live API reports only the current system, not a jump timestamp, so this is computed from wall-clock time via the same cadence anchor `data/megaships.ts` uses for the rest of the tracked fleet.
- Fixes a bug (caught during review) where the dialog assumed the live Gnosis API returns `arrival`/`departure` fields it doesn't actually send, which threw and silently aborted the "open dialog" click.

## Test plan
- [x] Load one of the 8 Gnosis route-stop systems (e.g. Varati) and confirm the tube-map card appears between the System Panel and System Completeness bar, with the current stop highlighted (red node, orange label/tag) and directional arrows along the track.
- [x] Confirm the card does **not** appear on a system the Gnosis doesn't visit.
- [x] Resize to a narrow/mobile viewport and confirm the track reflows without horizontal overflow.
- [x] Click a stop and confirm it opens that system's signals page in a new tab.
- [x] On a route-stop system, confirm a "The Gnosis" row appears in the Megaships section and clicking it opens the route dialog with all 8 stops and inferred due dates (no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)