### PR TITLE
Fix Glowing Green label for the Water giant subtype

### DIFF
--- a/src/app/data/green-gas-giant-images.spec.ts
+++ b/src/app/data/green-gas-giant-images.spec.ts
@@ -1,5 +1,4 @@
-import { getGreenGasGiantImagePath, isGreenGasGiant, findGreenGasGiant } from './green-gas-giant-images';
-import { GREEN_GAS_GIANTS } from './green-gas-giants.generated';
+import { getGreenGasGiantImagePath, isGreenGasGiant, findGreenGasGiant, RESOLVED_GREEN_GAS_GIANTS } from './green-gas-giant-images';
 
 describe('getGreenGasGiantImagePath', () => {
   it('resolves the square-crop path for a catalogued body', () => {
@@ -17,9 +16,9 @@ describe('getGreenGasGiantImagePath', () => {
   });
 
   it('resolves every catalogued body to a distinct path', () => {
-    const paths = GREEN_GAS_GIANTS.map(g => getGreenGasGiantImagePath(findGreenGasGiant(g.body)?.body ?? g.body));
+    const paths = RESOLVED_GREEN_GAS_GIANTS.map(g => getGreenGasGiantImagePath(g.body));
     expect(paths.every(p => p !== null)).toBe(true);
-    expect(new Set(paths).size).toBe(GREEN_GAS_GIANTS.length);
+    expect(new Set(paths).size).toBe(RESOLVED_GREEN_GAS_GIANTS.length);
   });
 
   describe('CSV rows recording only the system name (no body suffix)', () => {

--- a/src/app/data/green-gas-giant-images.ts
+++ b/src/app/data/green-gas-giant-images.ts
@@ -42,7 +42,7 @@ export interface ResolvedGreenGasGiant {
     slug: string;
 }
 
-const RESOLVED_GREEN_GAS_GIANTS: readonly ResolvedGreenGasGiant[] = GREEN_GAS_GIANTS.map(g => ({
+export const RESOLVED_GREEN_GAS_GIANTS: readonly ResolvedGreenGasGiant[] = GREEN_GAS_GIANTS.map(g => ({
     system: g.system,
     body: g.body.toLowerCase() === g.system.toLowerCase()
         ? (AMBIGUOUS_BODY_OVERRIDES[g.system.toLowerCase()] ?? g.body)

--- a/src/app/system-body/system-body.component.extra.spec.ts
+++ b/src/app/system-body/system-body.component.extra.spec.ts
@@ -200,6 +200,11 @@ describe('SystemBodyComponent (extended coverage)', () => {
       expect(component.getDisplaySubType()).toBe('Glowing green gas giant with water-based life');
     });
 
+    it('handles the "Water giant" subtype (no "gas" qualifier)', () => {
+      render(makeBody({ name: 'Eimbaith LW-W e1-290 7', subType: 'Water giant' }));
+      expect(component.getDisplaySubType()).toBe('Glowing green water giant');
+    });
+
     it('leaves an uncatalogued body\'s subType unchanged', () => {
       render(makeBody({ name: 'Sol 1', subType: 'Class I gas giant' }));
       expect(component.getDisplaySubType()).toBe('Class I gas giant');

--- a/src/app/system-body/system-body.component.ts
+++ b/src/app/system-body/system-body.component.ts
@@ -647,19 +647,21 @@ export class SystemBodyComponent implements OnChanges {
 
   /**
    * The classification text shown in the body header. A catalogued Green Gas Giant gets
-   * "glowing green" inserted ahead of "gas giant" (e.g. "Class I gas giant" -> "Class I
-   * glowing green gas giant"); every other body shows its subType unchanged. When "gas
-   * giant" opens the string (e.g. "Gas giant with ammonia-based life"), the sentence-case
-   * capital carries over to "Glowing" rather than being lowercased away.
+   * "glowing green" inserted ahead of its "gas giant"/"water giant" qualifier (e.g. "Class I
+   * gas giant" -> "Class I glowing green gas giant", "Water giant" -> "Glowing green water
+   * giant"); every other body shows its subType unchanged. When the qualifier opens the
+   * string (e.g. "Gas giant with ammonia-based life"), the sentence-case capital carries
+   * over to "Glowing" rather than being lowercased away.
    */
   public getDisplaySubType(): string {
     const bd = this.body().bodyData;
     if (bd.subType && isGreenGasGiant(bd.name)) {
-      return bd.subType.replace(/gas giant/i, (match, offset: number) => {
+      return bd.subType.replace(/(gas|water) giant/i, (match, qualifier: string, offset: number) => {
+        const lower = `glowing green ${qualifier.toLowerCase()} giant`;
         if (offset === 0 && /^[A-Z]/.test(match)) {
-          return 'Glowing green gas giant';
+          return lower.charAt(0).toUpperCase() + lower.slice(1);
         }
-        return 'glowing green gas giant';
+        return lower;
       });
     }
     return bd.subType;


### PR DESCRIPTION
## Summary
Follow-up to #130, which merged before this fix landed.

- `getDisplaySubType` only matched the literal "gas giant" substring, so the "Water giant" subtype (e.g. `Eimbaith LW-W e1-290 7`, a catalogued Green Gas Giant with no "gas" in its subType) rendered unchanged instead of "Glowing green water giant". Now matches either "gas giant" or "water giant".
- Fixes a test bug in `green-gas-giant-images.spec.ts`: the "distinct path" spec fed the raw, unresolved CSV name back into `findGreenGasGiant` for the 23 ambiguous-CSV-row entries, which correctly returns `null` for that input — exported `RESOLVED_GREEN_GAS_GIANTS` so the test asserts against the already-corrected body names instead.

## Test plan
- [x] `system-body.component.extra.spec.ts` — "Water giant" now renders "Glowing green water giant"
- [x] `green-gas-giant-images.spec.ts` — corrected distinct-path test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)