### PR TITLE
Fix body deep-links scrolling to the wrong spot

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -827,6 +827,11 @@ export class HomeComponent implements OnInit, OnDestroy {
   public readonly bodies = signal<SystemBody[]>([]);
   public readonly anchorBodyId = signal<number | null>(null);
 
+  // --- Anchor-link scroll correction (see scrollToAnchor) ---
+  private anchorScrollInitialTimer: ReturnType<typeof setTimeout> | null = null;
+  private anchorScrollObserver: ResizeObserver | null = null;
+  private anchorScrollCleanup: (() => void) | null = null;
+
   /** id64 of the loaded system, threaded down to every SystemBodyComponent as a key for the async collision registry. */
   public readonly systemKey = computed<bigint | null>(() => this.data()?.system?.id64 ?? null);
 
@@ -977,6 +982,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   public ngOnDestroy(): void {
     window.removeEventListener('popstate', this.onPopState);
+    this.stopAnchorScrollCorrection();
     if (this.suggestionDebounceTimer !== null) {
       clearTimeout(this.suggestionDebounceTimer);
     }
@@ -1407,18 +1413,65 @@ export class HomeComponent implements OnInit, OnDestroy {
       if (match) {
         this.anchorBodyId.set(parseInt(match[1], 10));
       }
-      // Wait for Angular to render the body elements, then scroll
-      setTimeout(() => {
-        const el = document.querySelector(hash);
-        if (el) {
-          el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-      }, 300);
+      this.scrollToAnchor(hash);
     } else {
+      this.stopAnchorScrollCorrection();
       this.anchorBodyId.set(null);
     }
     // Zoneless: the data/bodies/anchorBodyId signal writes above schedule the CD
     // pass that re-reads this method's bound state, even from async HTTP callbacks.
+  }
+
+  /**
+   * Scrolls a `#body-N` deep link into view once Angular has rendered it, then keeps
+   * correcting the scroll position for a few seconds afterwards. The initial scroll alone
+   * (issue #133) lands correctly for an instant, but content that streams in above the body
+   * list — the EdAstro summary/region map/society panel, all fetched async in processBodies —
+   * grows the page and pushes the anchor back out of the viewport. Correction stops as soon
+   * as the user scrolls/touches/presses a key, or after a bounded window, so it never fights
+   * someone who has started reading elsewhere.
+   */
+  private scrollToAnchor(hash: string): void {
+    this.stopAnchorScrollCorrection();
+
+    const scrollIfPresent = () => {
+      document.querySelector(hash)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    };
+
+    // Wait for Angular to render the body elements, then scroll.
+    this.anchorScrollInitialTimer = setTimeout(() => {
+      this.anchorScrollInitialTimer = null;
+      scrollIfPresent();
+
+      const stop = () => this.stopAnchorScrollCorrection();
+      const interactionEvents: (keyof WindowEventMap)[] = ['wheel', 'touchstart', 'keydown'];
+      for (const type of interactionEvents) {
+        window.addEventListener(type, stop, { once: true, passive: true });
+      }
+
+      const observer = new ResizeObserver(scrollIfPresent);
+      observer.observe(document.body);
+      this.anchorScrollObserver = observer;
+
+      const stopTimer = setTimeout(stop, 3000);
+      this.anchorScrollCleanup = () => {
+        for (const type of interactionEvents) {
+          window.removeEventListener(type, stop);
+        }
+        clearTimeout(stopTimer);
+      };
+    }, 300);
+  }
+
+  private stopAnchorScrollCorrection(): void {
+    if (this.anchorScrollInitialTimer !== null) {
+      clearTimeout(this.anchorScrollInitialTimer);
+      this.anchorScrollInitialTimer = null;
+    }
+    this.anchorScrollObserver?.disconnect();
+    this.anchorScrollObserver = null;
+    this.anchorScrollCleanup?.();
+    this.anchorScrollCleanup = null;
   }
 
   private isNumeric(value: string) {


### PR DESCRIPTION
## Summary
- Copying a body link (e.g. `#body-43`) and opening it could land the page in the wrong spot: the one-shot scroll fired 300ms after the body tree rendered, but async content above the body list (EdAstro summary, region map, society/location panel) keeps growing the page afterwards and pushes the anchored body back out of the viewport.
- `scrollToAnchor` now re-corrects the scroll position via a `ResizeObserver` on `document.body` for a few seconds after the initial scroll, stopping as soon as the user scrolls/touches/presses a key so it never fights manual navigation.

Fixes #133

## Test plan
- [ ] Open a system link with a `#body-N` fragment for a body far down the list and confirm the page settles on that body even as the EdAstro summary/region map load in.
- [ ] Confirm scrolling manually shortly after landing stops the auto-correction (doesn't fight the user).
- [ ] Confirm searching a new system without a fragment still works normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)