### PR TITLE
Add bug-report and feature-request links to Credits and Feedback panel

### DIFF
--- a/src/app/home/home.component.extra.spec.ts
+++ b/src/app/home/home.component.extra.spec.ts
@@ -166,6 +166,47 @@ describe('HomeComponent (extended coverage)', () => {
     });
   });
 
+  describe('credits and feedback panel', () => {
+    async function loadTestSystem(): Promise<void> {
+      httpResponses.set('assets/test-system.json', {
+        system: { name: 'Test System', id64: 42, coords: { x: 1, y: 2, z: 3 }, bodies: [] },
+      });
+      httpResponses.set('/simbad?', { system_address: 42, name: 'Test System' });
+      component.searchControl.setValue('test');
+      component.search();
+      await flushPromises();
+      fixture.detectChanges();
+    }
+
+    it('stays hidden on the landing page (no system loaded)', () => {
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('.credits-panel')).toBeNull();
+    });
+
+    it('titles the panel "Credits and Feedback" once a system is loaded', async () => {
+      await loadTestSystem();
+      expect(fixture.nativeElement.querySelector('.credits-title-text')?.textContent?.trim())
+        .toBe('Credits and Feedback');
+    });
+
+    it('renders bug-report and feature-request links beside the donate button', async () => {
+      await loadTestSystem();
+      const actions = fixture.nativeElement.querySelector('.credits-title .credits-title-actions');
+      expect(actions).not.toBeNull();
+      // Feedback buttons sit alongside the PayPal donate link in the same actions group.
+      expect(actions.querySelector('.paypal-donate-link')).not.toBeNull();
+      const links = actions.querySelectorAll('.feedback-button');
+      const hrefs = Array.from(links).map((a: any) => a.getAttribute('href'));
+      expect(hrefs).toContain('https://github.com/canonn-science/canonn-signals/issues/new?template=bug_report.md');
+      expect(hrefs).toContain('https://github.com/canonn-science/canonn-signals/issues/new?template=feature_request.md');
+      // Open in a new tab without leaking the opener.
+      links.forEach((a: any) => {
+        expect(a.getAttribute('target')).toBe('_blank');
+        expect(a.getAttribute('rel')).toContain('noopener');
+      });
+    });
+  });
+
   describe('ngOnInit wiring', () => {
     it('reacts to the outpost feed', () => {
       component.ngOnInit();

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -512,11 +512,23 @@
     }
     <div class="credits-panel">
       <div class="credits-title">
-        <span class="credits-title-text">Credits</span>
-        <a class="paypal-donate-link" href="https://canonn.science/donate/" target="_blank" rel="noopener noreferrer"
-          aria-label="Donate via PayPal (fallback)">
-          <img src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" alt="Donate via PayPal" />
-        </a>
+        <span class="credits-title-text">Credits and Feedback</span>
+        <div class="credits-title-actions">
+          <a class="feedback-button feedback-button--bug" [href]="bugReportUrl" target="_blank"
+            rel="noopener noreferrer" aria-label="Report a bug on GitHub">
+            <fa-icon [icon]="faBug" aria-hidden="true"></fa-icon>
+            <span>Report a bug</span>
+          </a>
+          <a class="feedback-button feedback-button--feature" [href]="featureRequestUrl" target="_blank"
+            rel="noopener noreferrer" aria-label="Request a feature on GitHub">
+            <fa-icon [icon]="faLightbulb" aria-hidden="true"></fa-icon>
+            <span>Request a feature</span>
+          </a>
+          <a class="paypal-donate-link" href="https://canonn.science/donate/" target="_blank" rel="noopener noreferrer"
+            aria-label="Donate via PayPal (fallback)">
+            <img src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" alt="Donate via PayPal" />
+          </a>
+        </div>
       </div>
       <div class="credits-detail">
         <div [innerHTML]="creditsHtml"></div>
@@ -595,3 +607,4 @@
   </div>
 </div>
 }
+

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -364,11 +364,15 @@
     width: auto;
 }
 
+.paypal-donate-link {
+    display: flex;
+    align-items: center;
+}
+
 .paypal-donate-link img {
     height: 28px;
     width: auto;
-    display: inline-block;
-    margin-left: 6px;
+    display: block;
 }
 
 .credits-detail {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, HostListener, inject, viewChild, signal, computed, effect } from '@angular/core';
 import { AppService, EdastroData } from '../app.service';
 import { ActivatedRoute, Params, Router } from '@angular/router';
-import { faChartColumn, faChevronDown, faDownload, faFileCode, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { faBug, faChartColumn, faChevronDown, faDownload, faFileCode, faLightbulb, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import { MatDialog } from '@angular/material/dialog';
 import { openLazyDialog } from '../dialogs/lazy-dialog';
 import type { HistogramDialogData } from '../dialogs/histogram-dialog/histogram-dialog.component';
@@ -733,6 +733,11 @@ export class HomeComponent implements OnInit, OnDestroy {
   public readonly faMagnifyingGlass = faMagnifyingGlass;
   public readonly faChartColumn = faChartColumn;
   public readonly faChevronDown = faChevronDown;
+  public readonly faBug = faBug;
+  public readonly faLightbulb = faLightbulb;
+  /** GitHub "new issue" links pre-selecting the repo's bug / feature templates. */
+  public readonly bugReportUrl = 'https://github.com/canonn-science/canonn-signals/issues/new?template=bug_report.md';
+  public readonly featureRequestUrl = 'https://github.com/canonn-science/canonn-signals/issues/new?template=feature_request.md';
   private readonly dialog = inject(MatDialog);
 
   /** Opens the body-type histogram for the current system. */

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -490,3 +490,48 @@ hr {
   width: 120px;
   max-width: 100%;
 }
+
+/* Bug-report / feature-request links, shown next to the donate button in the "Credits and
+   Feedback" title bar (rendered in home.component). Kept global to keep home.component.scss
+   under its per-component style budget. */
+.credits-title-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.feedback-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background-color: var(--color-surface-2);
+  color: var(--color-text-bright);
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.feedback-button:hover,
+.feedback-button:focus-visible {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-accent);
+  color: var(--color-white);
+}
+
+.feedback-button fa-icon {
+  font-size: 14px;
+}
+
+.feedback-button--bug fa-icon {
+  color: #ff6b6b;
+}
+
+.feedback-button--feature fa-icon {
+  color: var(--color-accent);
+}


### PR DESCRIPTION
Closes #129

## What

Adds **Report a bug** and **Request a feature** buttons so users can file issues without leaving the app.

- Renames the credits panel title from **Credits** to **Credits and Feedback**.
- Places the two buttons in the title bar, next to the PayPal donate button.
- Each button deep-links to GitHub's new-issue form with the repo's existing template preselected (`?template=bug_report.md` / `?template=feature_request.md`) and opens in a new tab (`rel="noopener noreferrer"`).
- Vertically centers the PayPal donate image within the actions row.

The buttons appear only once a system is loaded, since they live in the credits panel.

<img width="1700" height="564" alt="image" src="https://github.com/user-attachments/assets/798c3f64-3d08-4a28-b148-fb2fa18dcd98" />

## Where

- `home.component.html` — title text + `.credits-title-actions` group (bug / feature buttons + donate link).
- `home.component.ts` — exposes `faBug`, `faLightbulb`, and the two template URLs.
- `styles.scss` — button and actions-row styling; donate-image centering. Kept in the global stylesheet to stay under `home.component.scss`'s per-component style budget.
- `home.component.extra.spec.ts` — tests: hidden on landing, title reads "Credits and Feedback", both links render beside the donate button with correct URLs and safe `target`/`rel`.

## Verification

- `ng test` — 984 tests pass.
- `ng build` — clean (only the two pre-existing size warnings, unchanged by this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)