### PR TITLE
Use codex/dump instead of codex/biostats

### DIFF
--- a/e2e/body-anchor-deeplink.spec.ts
+++ b/e2e/body-anchor-deeplink.spec.ts
@@ -15,7 +15,7 @@ const FIXTURES_DIR = path.join(__dirname, 'fixtures');
 
 async function stubSystem(page: Page, systemName: string, id64: number, fixture: string): Promise<void> {
   const fixturePath = path.join(FIXTURES_DIR, fixture);
-  await page.route('**/query/codex/biostats*', (route) => route.fulfill({ path: fixturePath }));
+  await page.route('**/query/codex/dump*', (route) => route.fulfill({ path: fixturePath }));
   await page.route('**/query/typeahead*', (route) =>
     route.fulfill({ json: { min_max: [{ name: systemName, id64 }] } }),
   );

--- a/e2e/support/system-fixture.ts
+++ b/e2e/support/system-fixture.ts
@@ -85,7 +85,7 @@ export interface FixtureOptions {
 export async function loadFixtureSystem(page: Page, opts: FixtureOptions): Promise<void> {
   const fixturePath = path.join(FIXTURES_DIR, opts.fixture);
 
-  await page.route('**/query/codex/biostats*', (route) => route.fulfill({ path: fixturePath }));
+  await page.route('**/query/codex/dump*', (route) => route.fulfill({ path: fixturePath }));
   await page.route('**/query/typeahead*', (route) =>
     route.fulfill({ json: { min_max: [{ name: opts.systemName, id64: opts.id64 }] } }),
   );

--- a/src/app/app.service.extra.spec.ts
+++ b/src/app/app.service.extra.spec.ts
@@ -105,7 +105,7 @@ describe('AppService (HTTP-driven coverage)', () => {
 
   it('loads per-system biostats', async () => {
     await init();
-    route = (url: string) => url.includes('/codex/biostats?id=999') ? ok({ system: { name: 'Sys', id64: 999 } }) : ok({});
+    route = (url: string) => url.includes('/codex/dump?id=999') ? ok({ system: { name: 'Sys', id64: 999 } }) : ok({});
     const result = await service.getBiostats(999);
     expect(result.system.name).toBe('Sys');
   });
@@ -300,7 +300,7 @@ describe('AppService (HTTP-driven coverage)', () => {
     await init();
     let biostatsCalls = 0;
     route = (url: string) => {
-      if (url.includes('/codex/biostats?id=555')) {
+      if (url.includes('/codex/dump?id=555')) {
         biostatsCalls++;
         return ok({ system: { name: 'Croatigae' } });
       }
@@ -318,7 +318,7 @@ describe('AppService (HTTP-driven coverage)', () => {
     await init();
     let biostatsCalls = 0;
     route = (url: string) => {
-      if (url.includes('/codex/biostats?id=777')) {
+      if (url.includes('/codex/dump?id=777')) {
         biostatsCalls++;
         return fail(404, 'not found');
       }
@@ -336,7 +336,7 @@ describe('AppService (HTTP-driven coverage)', () => {
     await init();
     let biostatsCalls = 0;
     route = (url: string) => {
-      if (url.includes('/codex/biostats?id=888')) {
+      if (url.includes('/codex/dump?id=888')) {
         biostatsCalls++;
         return ok({ system: { name: 'Varati' } });
       }

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -298,10 +298,13 @@ export class AppService {
     return this.resilientGet<TypeaheadResponse>(`${CANONN_QUERY_BASE}/typeahead?q=${encodeURIComponent(query)}`);
   }
 
-  /** Loads the per-system biostats payload (bodies, signals, coordinates). Accepts the
-   *  address as a string to preserve 64-bit precision for very large system addresses. */
+  /** Loads the per-system biostats payload (bodies, signals, coordinates) from the `codex/dump`
+   *  endpoint — a superset of the old `codex/biostats` shape (adds system-level `factions`/
+   *  `stations`) served gzip-compressed; `fetch()` decodes `Content-Encoding: gzip` transparently,
+   *  so no extra handling is needed here. Accepts the address as a string to preserve 64-bit
+   *  precision for very large system addresses. */
   public getBiostats(systemAddress: number | string | bigint): Promise<CanonnBiostats> {
-    return this.resilientGet<CanonnBiostats>(`${CANONN_QUERY_BASE}/codex/biostats?id=${systemAddress}&caller=Signals`);
+    return this.resilientGet<CanonnBiostats>(`${CANONN_QUERY_BASE}/codex/dump?id=${systemAddress}&caller=Signals`);
   }
 
   /** Looks up Simbad cross-identification / coordinates for a hand-authored system. */

--- a/src/app/home/home.component.extra.spec.ts
+++ b/src/app/home/home.component.extra.spec.ts
@@ -85,7 +85,7 @@ describe('HomeComponent (extended coverage)', () => {
             setBackgroundImage,
             galMapSearch: vi.fn((q: string) => httpGet(`/typeahead?q=${q}`)),
             typeahead: vi.fn((q: string) => httpGet(`/typeahead?q=${q}`)),
-            getBiostats: vi.fn((id: number) => httpGet(`/codex/biostats?id=${id}&caller=Signals`)),
+            getBiostats: vi.fn((id: number) => httpGet(`/codex/dump?id=${id}&caller=Signals`)),
             getSimbad: vi.fn((id: number, name: string) => httpGet(`/simbad?system_address=${id}&name=${name}`)),
             megashipSchedule: megashipSchedule$,
             ensureMegaships: vi.fn(),
@@ -258,7 +258,7 @@ describe('HomeComponent (extended coverage)', () => {
     });
 
     it('searches by numeric system address', async () => {
-      httpResponses.set('/biostats?id=999', {
+      httpResponses.set('/dump?id=999', {
         system: { name: 'Numeric Sys', id64: 999, coords: { x: 0, y: 0, z: 0 }, bodies: [] },
       });
       component.searchControl.setValue('999');
@@ -270,7 +270,7 @@ describe('HomeComponent (extended coverage)', () => {
     it('passes a 64-bit system address through as a string (no parseInt precision loss)', async () => {
       // 18 digits — beyond Number.MAX_SAFE_INTEGER, where parseInt would round.
       const big = '123456789012345678';
-      httpResponses.set(`/biostats?id=${big}`, {
+      httpResponses.set(`/dump?id=${big}`, {
         system: { name: 'Big Addr', id64: 1, coords: { x: 0, y: 0, z: 0 }, bodies: [] },
       });
       component.searchControl.setValue(big);
@@ -280,7 +280,7 @@ describe('HomeComponent (extended coverage)', () => {
     });
 
     it('reports a not-found system address gracefully', async () => {
-      httpResponses.set('/biostats?id=111', { system: null });
+      httpResponses.set('/dump?id=111', { system: null });
       component.searchControl.setValue('111');
       component.search();
       await flushPromises();
@@ -289,7 +289,7 @@ describe('HomeComponent (extended coverage)', () => {
     });
 
     it('resolves a name via the EdAstro cache', async () => {
-      httpResponses.set('/biostats?id=555', {
+      httpResponses.set('/dump?id=555', {
         system: { name: 'Cached Sys', id64: 555, coords: { x: 0, y: 0, z: 0 }, bodies: [] },
       });
       // Seed the EdAstro cache before searching; search() reads the current snapshot.
@@ -302,7 +302,7 @@ describe('HomeComponent (extended coverage)', () => {
 
     it('resolves a name via the Canonn typeahead when not in the EdAstro cache', async () => {
       httpResponses.set('/typeahead', { min_max: [{ name: 'Found Sys', id64: 777 }] });
-      httpResponses.set('/biostats?id=777', {
+      httpResponses.set('/dump?id=777', {
         system: { name: 'Found Sys', id64: 777, coords: { x: 0, y: 0, z: 0 }, bodies: [] },
       });
       edastroSystems$.set([]); // not in cache -> falls through to the Canonn typeahead
@@ -322,7 +322,7 @@ describe('HomeComponent (extended coverage)', () => {
     });
 
     it('surfaces a 404 from the biostats API as a not-found error', async () => {
-      httpResponses.set('/biostats?id=404', Object.assign(new Error('nope'), { status: 404 }));
+      httpResponses.set('/dump?id=404', Object.assign(new Error('nope'), { status: 404 }));
       component.searchControl.setValue('404');
       component.search();
       await flushPromises();
@@ -394,7 +394,7 @@ describe('HomeComponent (extended coverage)', () => {
 
   describe('selection & navigation helpers', () => {
     it('routes a known system selection straight to its address', async () => {
-      httpResponses.set('/biostats?id=7', { system: { name: 'Mapped', id64: 7, coords: { x: 0, y: 0, z: 0 }, bodies: [] } });
+      httpResponses.set('/dump?id=7', { system: { name: 'Mapped', id64: 7, coords: { x: 0, y: 0, z: 0 }, bodies: [] } });
       edastroSystems$.set([{ name: 'Mapped Display', id64: 7 }]);
       component.onSystemSelected('Mapped Display');
       await flushPromises();


### PR DESCRIPTION
## Summary
- Switches the system-data fetch from `query/codex/biostats` to `query/codex/dump`.
- `codex/dump` returns the same system shape (plus system-level `factions`/`stations`) but gzip-compressed (`Content-Encoding: gzip`). `fetch()` decodes standard content-codings transparently in both the browser and Node, so no additional decompression code is needed — only the endpoint URL changed.
- Updated unit tests (`app.service.extra.spec.ts`, `home.component.extra.spec.ts`) and e2e fixture stubs (`e2e/support/system-fixture.ts`, `e2e/body-anchor-deeplink.spec.ts`) to route/mock the new `codex/dump` path.

Closes #140

## Test plan
- [x] `ng test --watch=false` — 1010/1010 passing
- [x] `ng build` — succeeds (pre-existing budget warnings only)
- [x] `playwright test e2e/body-anchor-deeplink.spec.ts e2e/merope.spec.ts` (stubbed fixtures) — passing, confirms the `codex/dump*` route stub is hit correctly
- [x] `playwright test e2e/alpha-centauri.spec.ts` (live network, no stub) — passing, confirms the real `codex/dump` endpoint is fetched and its gzip body decoded correctly end-to-end in Chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)