### PR TITLE
Fix spherical angular-diameter geometry

### DIFF
--- a/src/app/data/body-physics.service.spec.ts
+++ b/src/app/data/body-physics.service.spec.ts
@@ -332,11 +332,11 @@ describe('BodyPhysicsService', () => {
   });
 
   describe('angularDiameterDegrees', () => {
-    it('returns 90° when the parent radius equals the orbital distance', () => {
-      // atan(1) = 45°; the full angular diameter is twice the half-angle.
+    it('returns 180° when the parent radius equals the orbital distance', () => {
+      // asin(1) = 90°; the full angular diameter is twice the half-angle.
       const parent = body({ radius: KM_PER_AU, type: 'Planet' });
       const b = body({ semiMajorAxis: 1 }, parent);
-      expect(service.angularDiameterDegrees(b)).toBeCloseTo(90, 6);
+      expect(service.angularDiameterDegrees(b)).toBeCloseTo(180, 6);
     });
 
     it('returns null without a parent, orbit distance, or parent radius', () => {
@@ -379,6 +379,14 @@ describe('BodyPhysicsService', () => {
       expect(service.highAngularDiameterAssessment(distantMoon)).toBeNull();
     });
 
+    it('uses spherical geometry near the planet threshold', () => {
+      const gasGiant = body({ type: 'Planet', subType: 'Sudarsky class I gas giant', radius: 0.4 * KM_PER_AU });
+      const moon = body({ type: 'Planet', isLandable: true, semiMajorAxis: 1 }, gasGiant);
+      const result = service.highAngularDiameterAssessment(moon);
+      expect(result).not.toBeNull();
+      expect(result!.angularDiameterDegrees).toBeCloseTo(47.16, 2);
+    });
+
     it('does not flag a body that is not landable', () => {
       const star = body({ type: 'Star', solarRadius: 1 });
       const nonLandable = body({ type: 'Planet', isLandable: false, semiMajorAxis: 0.02 }, star);
@@ -401,7 +409,7 @@ describe('BodyPhysicsService', () => {
       const result = service.highAngularDiameterAssessment(moon);
       expect(result).not.toBeNull();
       expect(result!.parentType).toBe('Planet');
-      expect(result!.angularDiameterDegrees).toBeCloseTo(51.25, 1);
+      expect(result!.angularDiameterDegrees).toBeCloseTo(57.33, 1);
     });
   });
 });

--- a/src/app/data/body-physics.service.spec.ts
+++ b/src/app/data/body-physics.service.spec.ts
@@ -339,6 +339,12 @@ describe('BodyPhysicsService', () => {
       expect(service.angularDiameterDegrees(b)).toBeCloseTo(180, 6);
     });
 
+    it('clamps an overlapping parent radius to a finite 180°', () => {
+      const parent = body({ radius: 2 * KM_PER_AU, type: 'Planet' });
+      const b = body({ semiMajorAxis: 1 }, parent);
+      expect(service.angularDiameterDegrees(b)).toBeCloseTo(180, 6);
+    });
+
     it('returns null without a parent, orbit distance, or parent radius', () => {
       expect(service.angularDiameterDegrees(body({ semiMajorAxis: 1 }))).toBeNull();
       const parent = body({ radius: 70000, type: 'Planet' });

--- a/src/app/data/body-physics.service.ts
+++ b/src/app/data/body-physics.service.ts
@@ -439,7 +439,7 @@ export class BodyPhysicsService {
   /**
    * Angular diameter (degrees) the parent body subtends in `body`'s sky, i.e. how large the
    * parent appears from `body` at its orbital distance (centre-to-centre). Computed exactly as
-   * `2 * atan(parentRadius / distance)` — CCFE's original Lua script instead uses the
+   * `2 * asin(parentRadius / distance)` — CCFE's original Lua script instead uses the
    * small-angle approximation `57.3 * (2 * radius / distance)`, which diverges by a few
    * percent at the angles this badge cares about (see AGENTS.md's "physical accuracy" rule).
    * `distance` is `body`'s own orbital semi-major axis (its average distance from the parent
@@ -451,7 +451,7 @@ export class BodyPhysicsService {
     if (parentRadiusKm === null) { return null; }
     const distanceKm = body.bodyData.semiMajorAxis * KM_PER_AU;
     if (distanceKm <= 0) { return null; }
-    return 2 * Math.atan(parentRadiusKm / distanceKm) * (180 / Math.PI);
+    return 2 * Math.asin(Math.min(parentRadiusKm / distanceKm, 1)) * (180 / Math.PI);
   }
 
   /**


### PR DESCRIPTION
## Issue found
The apparent angular diameter used `2 * atan(R / d)` even though the stored orbital distance is centre-to-centre. That understates large apparent sizes, changes the 45-degree badge threshold result, and produced an incorrect value for the pinned real system.

## Summary
- calculate apparent angular diameter with the spherical `2 * asin(R / d)` formula
- clamp the radius/distance ratio for contact or overlapping cases
- add threshold, overlap-clamp, and real-system regression coverage

## Verification
- `pnpm exec ng test --watch=false --include=src/app/data/body-physics.service.spec.ts` (49 passed)
- `pnpm exec playwright test --project=desktop-chromium --workers=4` (100 passed)