### PR TITLE
Test generated Green Gas Giant source before deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - run: pnpm install
       - run: pnpm run prebuild
       - run: pnpm test --watch=false
-      - run: pnpm exec ng build #-- --base-href "/canonn-signals/"
+      - run: pnpm --config.enable-pre-post-scripts=false run build #-- --base-href "/canonn-signals/"
       - run: echo 'signals.canonn.tech' > dist/CNAME
       - name: Setup Pages
         uses: actions/configure-pages@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,9 @@ jobs:
         with:
           node-version: 22
       - run: pnpm install
+      - run: pnpm run prebuild
       - run: pnpm test --watch=false
-      - run: pnpm run build #-- --base-href "/canonn-signals/"
+      - run: pnpm exec ng build #-- --base-href "/canonn-signals/"
       - run: echo 'signals.canonn.tech' > dist/CNAME
       - name: Setup Pages
         uses: actions/configure-pages@v3


### PR DESCRIPTION
## Issue found
The deployment workflow ran tests before `prebuild` refreshed the live EDAstro-generated Green Gas Giant module. The subsequent build could therefore deploy generated TypeScript that had never been exercised by the test lane.

Review also identified a maintenance risk in invoking `ng build` directly: future flags or changes to the package `build` script would silently diverge from CI.

## Summary
- run the complete prebuild generation step before the CI test lane
- invoke the package `build` script after tests so it remains the single source of truth
- disable automatic pre/post lifecycle execution for that invocation so the already-tested generated sources are not regenerated between testing and deployment

## Verification
- `pnpm run prebuild` (65 Green Gas Giants generated)
- `pnpm test --watch=false` (1,010 passed)
- `pnpm --config.enable-pre-post-scripts=false run build` (passed with existing budget warnings; output begins directly with `ng build`)
- `pnpm exec playwright test --project=desktop-chromium --workers=4` (100 passed)
