### PR TITLE
Add runtime fallback for collision-worker failures

### DIFF
--- a/src/app/data/orbital-worker.service.spec.ts
+++ b/src/app/data/orbital-worker.service.spec.ts
@@ -1,6 +1,7 @@
 import { OrbitalWorkerService } from './orbital-worker.service';
 import { OrbitalRelationsCore } from './orbital-relations.core';
 import { SystemBody, CanonnBiostatsBody } from '../home/home.component';
+import * as Comlink from 'comlink';
 
 /**
  * The main-thread facade. Its `createProxy()` seam is stubbed per test so these cases never touch
@@ -226,6 +227,36 @@ describe('OrbitalWorkerService', () => {
       expect(worker.terminate).toHaveBeenCalledOnce();
     });
 
+    it('uses the captured failure signal when the worker is disabled as an RPC starts', async () => {
+      const proxy = fakeProxy();
+      const { svc } = serviceWith(proxy);
+      const worker = fakeWorker();
+      (svc as unknown as { registerWorker(worker: Worker): void }).registerWorker(worker as unknown as Worker);
+      proxy.detectCollisionStatus.mockImplementationOnce(() => {
+        (svc as unknown as { disableWorker(reason: unknown): void }).disableWorker(new Error('disabled during call'));
+        return new Promise(() => undefined);
+      });
+      const [a] = collidingPair();
+
+      await expect(svc.detectCollisionStatus(a, now)).resolves.toEqual(core.detectCollisionStatus(a, now));
+      expect(worker.terminate).toHaveBeenCalledOnce();
+    });
+
+    it('handles an asynchronous Comlink proxy-release rejection', async () => {
+      const proxy = fakeProxy() as ReturnType<typeof fakeProxy> & { [Comlink.releaseProxy]: ReturnType<typeof vi.fn> };
+      proxy[Comlink.releaseProxy] = vi.fn().mockRejectedValue(new Error('release failed'));
+      proxy.detectCollisionStatus.mockRejectedValueOnce(new Error('RPC rejected'));
+      const { svc } = serviceWith(proxy);
+      const worker = fakeWorker();
+      (svc as unknown as { registerWorker(worker: Worker): void }).registerWorker(worker as unknown as Worker);
+      const [a] = collidingPair();
+
+      await expect(svc.detectCollisionStatus(a, now)).resolves.toEqual(core.detectCollisionStatus(a, now));
+      await Promise.resolve();
+      expect(proxy[Comlink.releaseProxy]).toHaveBeenCalledOnce();
+      expect(worker.terminate).toHaveBeenCalledOnce();
+    });
+
     it('retries a pending Comlink RPC inline when the worker emits an error', async () => {
       const proxy = fakeProxy();
       proxy.detectCollisionStatus.mockReturnValueOnce(new Promise(() => undefined));
@@ -253,6 +284,31 @@ describe('OrbitalWorkerService', () => {
         await vi.advanceTimersByTimeAsync(30_000);
 
         await expect(result).resolves.toEqual(core.detectCollisionStatus(a, now));
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not permanently disable the worker after one timed-out RPC', async () => {
+      vi.useFakeTimers();
+      try {
+        const proxy = fakeProxy();
+        proxy.detectCollisionStatus
+          .mockReturnValueOnce(new Promise(() => undefined))
+          .mockResolvedValueOnce({
+            isCandidate: true, partnerName: 'Recovered Worker', synodicPeriodDays: 1,
+            nextCollision: null, upcomingCollisions: [], combinedRadiiKm: 1, simultaneousPartners: [],
+          });
+        const { svc, createSpy } = serviceWith(proxy);
+        const [a] = collidingPair();
+
+        const first = svc.detectCollisionStatus(a, now);
+        await vi.advanceTimersByTimeAsync(30_000);
+        await expect(first).resolves.toEqual(core.detectCollisionStatus(a, now));
+
+        await expect(svc.detectCollisionStatus(a, now)).resolves.toMatchObject({ partnerName: 'Recovered Worker' });
+        expect(proxy.detectCollisionStatus).toHaveBeenCalledTimes(2);
+        expect(createSpy).toHaveBeenCalledOnce();
       } finally {
         vi.useRealTimers();
       }

--- a/src/app/data/orbital-worker.service.spec.ts
+++ b/src/app/data/orbital-worker.service.spec.ts
@@ -127,6 +127,20 @@ describe('OrbitalWorkerService', () => {
       return { svc, createSpy };
     }
 
+    function fakeWorker() {
+      const listeners = new Map<string, (event: Event) => void>();
+      return {
+        addEventListener: vi.fn((type: string, listener: (event: Event) => void) => listeners.set(type, listener)),
+        terminate: vi.fn(),
+        fail(type: 'error' | 'messageerror' = 'error') {
+          const event = type === 'error'
+            ? Object.assign(new Event(type), { error: new Error('worker crashed') })
+            : new Event(type);
+          listeners.get(type)?.(event);
+        },
+      };
+    }
+
     it('routes every method through a single shared proxy instead of the inline core', async () => {
       const proxy = fakeProxy();
       const { svc, createSpy } = serviceWith(proxy);
@@ -173,6 +187,54 @@ describe('OrbitalWorkerService', () => {
       // A second call does not retry construction — the unavailable state is latched.
       await svc.upcomingContactsWithin(a, 365, now);
       expect(createSpy).toHaveBeenCalledOnce();
+    });
+
+    it('terminates the worker and retries inline when a Comlink RPC rejects', async () => {
+      const proxy = fakeProxy();
+      proxy.detectCollisionStatus.mockRejectedValueOnce(new Error('RPC rejected'));
+      const { svc, createSpy } = serviceWith(proxy);
+      const worker = fakeWorker();
+      (svc as unknown as { registerWorker(worker: Worker): void }).registerWorker(worker as unknown as Worker);
+      const [a] = collidingPair();
+
+      await expect(svc.detectCollisionStatus(a, now)).resolves.toEqual(core.detectCollisionStatus(a, now));
+      expect(worker.terminate).toHaveBeenCalledOnce();
+
+      await svc.upcomingContactsWithin(a, 365, now);
+      expect(createSpy).toHaveBeenCalledOnce();
+      expect(proxy.upcomingContactsWithin).not.toHaveBeenCalled();
+    });
+
+    it('retries a pending Comlink RPC inline when the worker emits an error', async () => {
+      const proxy = fakeProxy();
+      proxy.detectCollisionStatus.mockReturnValueOnce(new Promise(() => undefined));
+      const { svc } = serviceWith(proxy);
+      const worker = fakeWorker();
+      (svc as unknown as { registerWorker(worker: Worker): void }).registerWorker(worker as unknown as Worker);
+      const [a] = collidingPair();
+
+      const result = svc.detectCollisionStatus(a, now);
+      worker.fail();
+
+      await expect(result).resolves.toEqual(core.detectCollisionStatus(a, now));
+      expect(worker.terminate).toHaveBeenCalledOnce();
+    });
+
+    it('times out a silently pending RPC and retries inline', async () => {
+      vi.useFakeTimers();
+      try {
+        const proxy = fakeProxy();
+        proxy.detectCollisionStatus.mockReturnValueOnce(new Promise(() => undefined));
+        const { svc } = serviceWith(proxy);
+        const [a] = collidingPair();
+
+        const result = svc.detectCollisionStatus(a, now);
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        await expect(result).resolves.toEqual(core.detectCollisionStatus(a, now));
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/app/data/orbital-worker.service.spec.ts
+++ b/src/app/data/orbital-worker.service.spec.ts
@@ -205,6 +205,27 @@ describe('OrbitalWorkerService', () => {
       expect(proxy.upcomingContactsWithin).not.toHaveBeenCalled();
     });
 
+    it('wakes other pending RPCs immediately when one call rejects', async () => {
+      let rejectFirst!: (reason: unknown) => void;
+      const firstRpc = new Promise<never>((_, reject) => { rejectFirst = reject; });
+      const proxy = fakeProxy();
+      proxy.detectCollisionStatus
+        .mockReturnValueOnce(firstRpc)
+        .mockReturnValueOnce(new Promise(() => undefined));
+      const { svc } = serviceWith(proxy);
+      const worker = fakeWorker();
+      (svc as unknown as { registerWorker(worker: Worker): void }).registerWorker(worker as unknown as Worker);
+      const [a, b] = collidingPair();
+
+      const first = svc.detectCollisionStatus(a, now);
+      const second = svc.detectCollisionStatus(b, now);
+      rejectFirst(new Error('first RPC rejected'));
+
+      await expect(first).resolves.toEqual(core.detectCollisionStatus(a, now));
+      await expect(second).resolves.toEqual(core.detectCollisionStatus(b, now));
+      expect(worker.terminate).toHaveBeenCalledOnce();
+    });
+
     it('retries a pending Comlink RPC inline when the worker emits an error', async () => {
       const proxy = fakeProxy();
       proxy.detectCollisionStatus.mockReturnValueOnce(new Promise(() => undefined));

--- a/src/app/data/orbital-worker.service.ts
+++ b/src/app/data/orbital-worker.service.ts
@@ -6,13 +6,16 @@ import type { CollisionStatus, SimultaneousCollision, CollisionWindow, Separatio
 import { serializeCollisionFamily } from './collision-request';
 import type { CollisionWorkerApi } from './collision-worker-api';
 
+const WORKER_CALL_TIMEOUT_MS = 30_000;
+
 /**
  * Main-thread facade for the heavy collision engine, run off the UI thread in a single shared
  * {@link https://github.com/GoogleChromeLabs/comlink Comlink} worker so the 3D orbit search never
  * janks rendering. The worker is created lazily on first use and reused for the app's lifetime.
  *
- * When no `Worker` is available (jsdom unit tests, SSR) — or a body has no parent, so there is
- * nothing to serialize — each method falls back to running the framework-free
+ * When no `Worker` is available (jsdom unit tests, SSR), a worker fails/rejects/times out, or a
+ * body has no parent and there is nothing to serialize, each method falls back to running the
+ * framework-free
  * {@link OrbitalRelationsCore} inline against the live tree and resolving a Promise, so callers get
  * one uniform async API regardless of environment.
  *
@@ -27,6 +30,10 @@ import type { CollisionWorkerApi } from './collision-worker-api';
 export class OrbitalWorkerService {
   /** Comlink proxy to the shared worker; created on first heavy call, null until then. */
   private proxy: Comlink.Remote<CollisionWorkerApi> | null = null;
+  /** Worker backing {@link proxy}, retained so a failed runtime can be terminated. */
+  private worker: Worker | null = null;
+  /** Rejects active RPC races when the worker reports a module/runtime or message error. */
+  private workerFailure: Promise<never> | null = null;
   /** Latched once the worker can't be constructed, so we stop retrying and stay on the inline path. */
   private workerUnavailable = false;
   /** Engine instance for the inline (no-worker) fallback and for bodies with no parent. */
@@ -59,9 +66,69 @@ export class OrbitalWorkerService {
     if (typeof Worker === 'undefined') { return null; }
     try {
       const worker = new Worker(new URL('./collision.worker', import.meta.url), { type: 'module' });
+      this.registerWorker(worker);
       return Comlink.wrap<CollisionWorkerApi>(worker);
     } catch {
+      this.disableWorker();
       return null;
+    }
+  }
+
+  /** Registers runtime failure listeners before the first Comlink request can be made. */
+  private registerWorker(worker: Worker): void {
+    this.worker = worker;
+    let rejectFailure!: (reason: unknown) => void;
+    const failure = new Promise<never>((_, reject) => { rejectFailure = reject; });
+    // A failure can happen between calls. Mark the shared promise handled while retaining its
+    // rejected state so the next/current Promise.race still takes the inline fallback path.
+    void failure.catch(() => undefined);
+    this.workerFailure = failure;
+
+    const fail = (event: Event): void => {
+      const reason = 'error' in event && event.error
+        ? event.error
+        : new Error(event.type === 'messageerror' ? 'Collision worker message error' : 'Collision worker runtime error');
+      rejectFailure(reason);
+      this.disableWorker();
+    };
+    worker.addEventListener('error', fail);
+    worker.addEventListener('messageerror', fail);
+  }
+
+  /** Permanently switches this service instance to inline execution after a worker failure. */
+  private disableWorker(): void {
+    const proxy = this.proxy;
+    const worker = this.worker;
+    this.proxy = null;
+    this.worker = null;
+    this.workerFailure = null;
+    this.workerUnavailable = true;
+
+    try {
+      proxy?.[Comlink.releaseProxy]();
+    } catch {
+      // A broken transport may also reject release; worker termination below is authoritative.
+    }
+    worker?.terminate();
+  }
+
+  /** Runs one worker RPC, retrying inline after rejection, worker failure, or a silent hang. */
+  private async runWithFallback<T>(workerCall: () => Promise<T>, inlineCall: () => T): Promise<T> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const timedOut = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => reject(new Error('Collision worker call timed out')), WORKER_CALL_TIMEOUT_MS);
+    });
+
+    try {
+      const call = workerCall();
+      const races: Promise<T>[] = [call, timedOut];
+      if (this.workerFailure) { races.push(this.workerFailure); }
+      return await Promise.race(races);
+    } catch {
+      this.disableWorker();
+      return inlineCall();
+    } finally {
+      clearTimeout(timeout);
     }
   }
 
@@ -70,7 +137,10 @@ export class OrbitalWorkerService {
     const proxy = this.getProxy();
     const dto = proxy ? serializeCollisionFamily(body) : null;
     if (!proxy || !dto) { return this.inline.detectCollisionStatus(body, now); }
-    return proxy.detectCollisionStatus(dto, now);
+    return this.runWithFallback(
+      () => proxy.detectCollisionStatus(dto, now),
+      () => this.inline.detectCollisionStatus(body, now),
+    );
   }
 
   /** Off-thread {@link OrbitalRelationsCore.simultaneousCollisionsWithin}. */
@@ -78,7 +148,10 @@ export class OrbitalWorkerService {
     const proxy = this.getProxy();
     const dto = proxy ? serializeCollisionFamily(body) : null;
     if (!proxy || !dto) { return this.inline.simultaneousCollisionsWithin(body, horizonDays, now); }
-    return proxy.simultaneousCollisionsWithin(dto, horizonDays, now);
+    return this.runWithFallback(
+      () => proxy.simultaneousCollisionsWithin(dto, horizonDays, now),
+      () => this.inline.simultaneousCollisionsWithin(body, horizonDays, now),
+    );
   }
 
   /** Off-thread {@link OrbitalRelationsCore.upcomingContactsWithin}. */
@@ -86,13 +159,19 @@ export class OrbitalWorkerService {
     const proxy = this.getProxy();
     const dto = proxy ? serializeCollisionFamily(body) : null;
     if (!proxy || !dto) { return this.inline.upcomingContactsWithin(body, horizonDays, now); }
-    return proxy.upcomingContactsWithin(dto, horizonDays, now);
+    return this.runWithFallback(
+      () => proxy.upcomingContactsWithin(dto, horizonDays, now),
+      () => this.inline.upcomingContactsWithin(body, horizonDays, now),
+    );
   }
 
   /** Off-thread {@link OrbitalRelationsCore.separationSeries} (takes flat bodyData — no rehydrate). */
   async separationSeries(a: CanonnBiostatsBody, b: CanonnBiostatsBody, startMs: number, endMs: number, samples: number): Promise<SeparationSample[]> {
     const proxy = this.getProxy();
     if (!proxy) { return this.inline.separationSeries(a, b, startMs, endMs, samples); }
-    return proxy.separationSeries(a, b, startMs, endMs, samples);
+    return this.runWithFallback(
+      () => proxy.separationSeries(a, b, startMs, endMs, samples),
+      () => this.inline.separationSeries(a, b, startMs, endMs, samples),
+    );
   }
 }

--- a/src/app/data/orbital-worker.service.ts
+++ b/src/app/data/orbital-worker.service.ts
@@ -13,8 +13,8 @@ const WORKER_CALL_TIMEOUT_MS = 30_000;
  * {@link https://github.com/GoogleChromeLabs/comlink Comlink} worker so the 3D orbit search never
  * janks rendering. The worker is created lazily on first use and reused for the app's lifetime.
  *
- * When no `Worker` is available (jsdom unit tests, SSR), a worker fails/rejects/times out, or a
- * body has no parent and there is nothing to serialize, each method falls back to running the
+ * When no `Worker` is available (jsdom unit tests, SSR), a worker fails/rejects, a call times out,
+ * or a body has no parent and there is nothing to serialize, each method falls back to running the
  * framework-free
  * {@link OrbitalRelationsCore} inline against the live tree and resolving a Promise, so callers get
  * one uniform async API regardless of environment.
@@ -112,7 +112,8 @@ export class OrbitalWorkerService {
     rejectFailure?.(reason);
 
     try {
-      proxy?.[Comlink.releaseProxy]();
+      const release = proxy?.[Comlink.releaseProxy]();
+      void Promise.resolve(release).catch(() => undefined);
     } catch {
       // A broken transport may also reject release; worker termination below is authoritative.
     }
@@ -120,19 +121,27 @@ export class OrbitalWorkerService {
   }
 
   /** Runs one worker RPC, retrying inline after rejection, worker failure, or a silent hang. */
-  private async runWithFallback<T>(workerCall: () => Promise<T>, inlineCall: () => T): Promise<T> {
+  private async runWithFallback<T>(
+    workerCall: () => Promise<T>,
+    inlineCall: () => T,
+    workerFailure: Promise<never> | null,
+  ): Promise<T> {
     let timeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutError = new Error('Collision worker call timed out');
     const timedOut = new Promise<never>((_, reject) => {
-      timeout = setTimeout(() => reject(new Error('Collision worker call timed out')), WORKER_CALL_TIMEOUT_MS);
+      timeout = setTimeout(() => reject(timeoutError), WORKER_CALL_TIMEOUT_MS);
     });
 
     try {
       const call = workerCall();
       const races: Promise<T>[] = [call, timedOut];
-      if (this.workerFailure) { races.push(this.workerFailure); }
+      if (workerFailure) { races.push(workerFailure); }
       return await Promise.race(races);
     } catch (error) {
-      this.disableWorker(error);
+      // A timeout is scoped to this request: the worker may still answer later or serve subsequent
+      // calls, so do not permanently move CPU-heavy work onto the main thread. Transport/runtime
+      // errors still disable the broken worker and wake every RPC sharing its failure signal.
+      if (error !== timeoutError) { this.disableWorker(error); }
       return inlineCall();
     } finally {
       clearTimeout(timeout);
@@ -142,43 +151,51 @@ export class OrbitalWorkerService {
   /** Off-thread {@link OrbitalRelationsCore.detectCollisionStatus}. */
   async detectCollisionStatus(body: SystemBody, now: number): Promise<CollisionStatus> {
     const proxy = this.getProxy();
+    const workerFailure = this.workerFailure;
     const dto = proxy ? serializeCollisionFamily(body) : null;
-    if (!proxy || !dto) { return this.inline.detectCollisionStatus(body, now); }
+    if (!proxy || this.workerUnavailable || !dto) { return this.inline.detectCollisionStatus(body, now); }
     return this.runWithFallback(
       () => proxy.detectCollisionStatus(dto, now),
       () => this.inline.detectCollisionStatus(body, now),
+      workerFailure,
     );
   }
 
   /** Off-thread {@link OrbitalRelationsCore.simultaneousCollisionsWithin}. */
   async simultaneousCollisionsWithin(body: SystemBody, horizonDays: number, now: number): Promise<SimultaneousCollision[]> {
     const proxy = this.getProxy();
+    const workerFailure = this.workerFailure;
     const dto = proxy ? serializeCollisionFamily(body) : null;
-    if (!proxy || !dto) { return this.inline.simultaneousCollisionsWithin(body, horizonDays, now); }
+    if (!proxy || this.workerUnavailable || !dto) { return this.inline.simultaneousCollisionsWithin(body, horizonDays, now); }
     return this.runWithFallback(
       () => proxy.simultaneousCollisionsWithin(dto, horizonDays, now),
       () => this.inline.simultaneousCollisionsWithin(body, horizonDays, now),
+      workerFailure,
     );
   }
 
   /** Off-thread {@link OrbitalRelationsCore.upcomingContactsWithin}. */
   async upcomingContactsWithin(body: SystemBody, horizonDays: number, now: number): Promise<CollisionWindow[]> {
     const proxy = this.getProxy();
+    const workerFailure = this.workerFailure;
     const dto = proxy ? serializeCollisionFamily(body) : null;
-    if (!proxy || !dto) { return this.inline.upcomingContactsWithin(body, horizonDays, now); }
+    if (!proxy || this.workerUnavailable || !dto) { return this.inline.upcomingContactsWithin(body, horizonDays, now); }
     return this.runWithFallback(
       () => proxy.upcomingContactsWithin(dto, horizonDays, now),
       () => this.inline.upcomingContactsWithin(body, horizonDays, now),
+      workerFailure,
     );
   }
 
   /** Off-thread {@link OrbitalRelationsCore.separationSeries} (takes flat bodyData — no rehydrate). */
   async separationSeries(a: CanonnBiostatsBody, b: CanonnBiostatsBody, startMs: number, endMs: number, samples: number): Promise<SeparationSample[]> {
     const proxy = this.getProxy();
-    if (!proxy) { return this.inline.separationSeries(a, b, startMs, endMs, samples); }
+    const workerFailure = this.workerFailure;
+    if (!proxy || this.workerUnavailable) { return this.inline.separationSeries(a, b, startMs, endMs, samples); }
     return this.runWithFallback(
       () => proxy.separationSeries(a, b, startMs, endMs, samples),
       () => this.inline.separationSeries(a, b, startMs, endMs, samples),
+      workerFailure,
     );
   }
 }

--- a/src/app/data/orbital-worker.service.ts
+++ b/src/app/data/orbital-worker.service.ts
@@ -34,6 +34,8 @@ export class OrbitalWorkerService {
   private worker: Worker | null = null;
   /** Rejects active RPC races when the worker reports a module/runtime or message error. */
   private workerFailure: Promise<never> | null = null;
+  /** Rejector paired with {@link workerFailure}, retained so any disable path wakes all RPCs. */
+  private rejectWorkerFailure: ((reason: unknown) => void) | null = null;
   /** Latched once the worker can't be constructed, so we stop retrying and stay on the inline path. */
   private workerUnavailable = false;
   /** Engine instance for the inline (no-worker) fallback and for bodies with no parent. */
@@ -68,8 +70,8 @@ export class OrbitalWorkerService {
       const worker = new Worker(new URL('./collision.worker', import.meta.url), { type: 'module' });
       this.registerWorker(worker);
       return Comlink.wrap<CollisionWorkerApi>(worker);
-    } catch {
-      this.disableWorker();
+    } catch (error) {
+      this.disableWorker(error);
       return null;
     }
   }
@@ -83,26 +85,31 @@ export class OrbitalWorkerService {
     // rejected state so the next/current Promise.race still takes the inline fallback path.
     void failure.catch(() => undefined);
     this.workerFailure = failure;
+    this.rejectWorkerFailure = rejectFailure;
 
     const fail = (event: Event): void => {
       const reason = 'error' in event && event.error
         ? event.error
         : new Error(event.type === 'messageerror' ? 'Collision worker message error' : 'Collision worker runtime error');
-      rejectFailure(reason);
-      this.disableWorker();
+      this.disableWorker(reason);
     };
     worker.addEventListener('error', fail);
     worker.addEventListener('messageerror', fail);
   }
 
   /** Permanently switches this service instance to inline execution after a worker failure. */
-  private disableWorker(): void {
+  private disableWorker(reason: unknown = new Error('Collision worker disabled')): void {
     const proxy = this.proxy;
     const worker = this.worker;
+    const rejectFailure = this.rejectWorkerFailure;
     this.proxy = null;
     this.worker = null;
     this.workerFailure = null;
+    this.rejectWorkerFailure = null;
     this.workerUnavailable = true;
+    // Wake every RPC racing this shared signal before terminating the transport. Without this,
+    // calls other than the one that observed a rejection/timeout wait for their own watchdogs.
+    rejectFailure?.(reason);
 
     try {
       proxy?.[Comlink.releaseProxy]();
@@ -124,8 +131,8 @@ export class OrbitalWorkerService {
       const races: Promise<T>[] = [call, timedOut];
       if (this.workerFailure) { races.push(this.workerFailure); }
       return await Promise.race(races);
-    } catch {
-      this.disableWorker();
+    } catch (error) {
+      this.disableWorker(error);
       return inlineCall();
     } finally {
       clearTimeout(timeout);


### PR DESCRIPTION
## Issue found
A collision worker could construct successfully and then fail while loading or servicing a Comlink request. Rejected calls did not retry inline, and transport failures could leave the RPC unresolved, keeping collision skeletons visible indefinitely.

Review also found that a single timed-out request permanently latched all future heavy work onto the main thread, asynchronous `releaseProxy()` rejection was not handled, and a call racing a concurrent worker disable could miss the shared failure signal and wait for its full watchdog.

## Summary
- race worker RPCs against runtime/message errors and a 30-second per-call watchdog
- terminate and release a worker on transport/runtime rejection, latch that broken worker to inline execution, and wake all concurrent calls through a captured shared failure signal
- handle both synchronous and asynchronous Comlink proxy-release failures
- fall back inline only for the individual timed-out call, allowing the worker to recover for later calls rather than permanently moving heavy work to the main thread
- cover rejected RPCs, concurrent pending and startup-disable races, worker error events, silent hangs, timeout recovery, release rejection, and worker reuse/latching

## Known tradeoff
A worker that is permanently stuck without emitting an error will make each call wait for its own 30-second watchdog before falling back. A consecutive-timeout policy that disables the worker after two or three timeouts would balance transient recovery against persistent hangs, but is deferred from this PR.

## Verification
- `pnpm exec ng test --watch=false --include=src/app/data/orbital-worker.service.spec.ts` (16 passed)
- `pnpm test --watch=false` (1,017 passed)
- `pnpm run build` (passed with existing budget warnings)
- `pnpm exec playwright test --project=desktop-chromium --workers=4` (100 passed)
