### PR TITLE
Render map markers without region metadata

### DIFF
--- a/src/app/region-map/region-map.component.spec.ts
+++ b/src/app/region-map/region-map.component.spec.ts
@@ -220,6 +220,20 @@ describe('RegionMapComponent', () => {
       expect([...svg.querySelectorAll('.known-system-marker text')].some(text => text.textContent === 'Remote Outpost')).toBe(true);
     });
 
+    it('removes the previous system marker when the next regionless system has no coordinates', () => {
+      fixture.componentRef.setInput('system', {
+        name: 'Marked', region: { name: 'Inner Orion Spur', region: 18 }, coords: { x: 0, y: 0, z: 0 },
+      });
+      const svg = mountSvg(buildSvg());
+      (component as any).highlightRegion();
+      expect(svg.querySelector('#system-marker')).not.toBeNull();
+
+      fixture.componentRef.setInput('system', { name: 'Unlocated' });
+      (component as any).highlightRegion();
+
+      expect(svg.querySelector('#system-marker')).toBeNull();
+    });
+
     it('binds each region zoom handler exactly once across re-highlights', () => {
       fixture.componentRef.setInput('system', {
         name: 'Sol', region: { name: 'x', region: 7 }, coords: { x: 0, y: 0, z: 0 },

--- a/src/app/region-map/region-map.component.spec.ts
+++ b/src/app/region-map/region-map.component.spec.ts
@@ -206,6 +206,20 @@ describe('RegionMapComponent', () => {
       expect(svg.querySelector('#system-marker')).not.toBeNull();
     });
 
+    it('renders coordinate-based markers when region metadata is absent', () => {
+      fixture.componentRef.setInput('system', { name: 'Regionless', coords: { x: 10, y: 20, z: 30 } });
+      fixture.componentRef.setInput('outposts', [
+        { name: 'Remote Outpost', galMapSearch: 'Remote System', coordinates: [40, 50, 60], type: 'independentOutpost' },
+      ]);
+      const svg = mountSvg(buildSvg());
+
+      (component as any).highlightRegion();
+
+      expect(svg.querySelector('#system-marker')).not.toBeNull();
+      expect(svg.querySelectorAll('.known-system-marker').length).toBeGreaterThan(6);
+      expect([...svg.querySelectorAll('.known-system-marker text')].some(text => text.textContent === 'Remote Outpost')).toBe(true);
+    });
+
     it('binds each region zoom handler exactly once across re-highlights', () => {
       fixture.componentRef.setInput('system', {
         name: 'Sol', region: { name: 'x', region: 7 }, coords: { x: 0, y: 0, z: 0 },

--- a/src/app/region-map/region-map.component.ts
+++ b/src/app/region-map/region-map.component.ts
@@ -169,7 +169,7 @@ export class RegionMapComponent implements OnChanges {
   private highlightRegion(): void {
     const regionMapContainer = this.regionMapContainer();
     const system = this.system();
-    if (!regionMapContainer || !system || !system.region) {
+    if (!regionMapContainer || !system) {
       return;
     }
 
@@ -215,17 +215,20 @@ export class RegionMapComponent implements OnChanges {
       }
     });
 
-    // Highlight the current region
-    const regionId = `Region_${String(system.region.region).padStart(2, '0')}`;
-    const regionElement = svgElement.querySelector(`#${regionId}`);
-    if (regionElement) {
-      (regionElement as HTMLElement).style.fill = '#ff9900';
-      (regionElement as HTMLElement).style.fillOpacity = '0.6';
-      (regionElement as HTMLElement).style.stroke = '#ff9900';
-      (regionElement as HTMLElement).style.strokeOpacity = '1';
-      (regionElement as HTMLElement).style.strokeWidth = '2';
-    } else {
-      logger.warn('Region element not found for ID:', regionId);
+    // Highlight the current region when the API supplied one. Coordinates are independently
+    // useful, so missing region metadata must not suppress the system and known-system markers.
+    if (system.region) {
+      const regionId = `Region_${String(system.region.region).padStart(2, '0')}`;
+      const regionElement = svgElement.querySelector(`#${regionId}`);
+      if (regionElement) {
+        (regionElement as HTMLElement).style.fill = '#ff9900';
+        (regionElement as HTMLElement).style.fillOpacity = '0.6';
+        (regionElement as HTMLElement).style.stroke = '#ff9900';
+        (regionElement as HTMLElement).style.strokeOpacity = '1';
+        (regionElement as HTMLElement).style.strokeWidth = '2';
+      } else {
+        logger.warn('Region element not found for ID:', regionId);
+      }
     }
 
     // Add red dot at system coordinates

--- a/src/app/region-map/region-map.component.ts
+++ b/src/app/region-map/region-map.component.ts
@@ -621,15 +621,15 @@ export class RegionMapComponent implements OnChanges {
   }
 
   private addSystemMarker(svgElement: SVGSVGElement): void {
-    const coords = this.system()?.coords;
-    if (!coords) {
-      return;
-    }
-
-    // Remove any existing system marker
+    // Always clear the previous search's marker, even when the new system has no coordinates.
     const existingMarker = svgElement.querySelector('#system-marker');
     if (existingMarker) {
       existingMarker.remove();
+    }
+
+    const coords = this.system()?.coords;
+    if (!coords) {
+      return;
     }
 
     // The region map uses X and Z galactic coordinates (X horizontal, Z vertical).


### PR DESCRIPTION
## Issue found
`highlightRegion()` returned immediately when a system lacked `region` metadata. Systems with valid coordinates therefore lost their current-system marker as well as all known-system and outpost markers, even though none of those overlays depends on a region ID.

## Summary
- make region highlighting conditional without aborting the rest of map decoration
- continue rendering current-system, known-system, and outpost markers for regionless systems
- clear the previous current-system marker when a new regionless system has no coordinates
- add regressions for regionless coordinates and sequential searches to an unlocated system

## Verification
- `pnpm exec ng test --watch=false --include=src/app/region-map/region-map.component.spec.ts` (21 passed)
- `pnpm exec playwright test --project=desktop-chromium --workers=4` (100 passed)