### PR TITLE
Make broken GEC GIF retry one-shot

### DIFF
--- a/src/app/home/home.component.extra.spec.ts
+++ b/src/app/home/home.component.extra.spec.ts
@@ -414,11 +414,16 @@ describe('HomeComponent (extended coverage)', () => {
       expect(loadSpy).toHaveBeenCalledWith('Colonia');
     });
 
-    it('reloads a broken GIF after a delay', () => {
-      const img = { src: 'assets/Orbit2.gif' } as HTMLImageElement;
+    it('reloads a broken GIF only once after repeated error events', () => {
+      const img = document.createElement('img');
+      img.src = 'assets/Orbit2.gif';
       component.onGecImageError({ target: img } as unknown as Event);
       vi.runOnlyPendingTimers();
       expect(img.src).toContain('?t=');
+
+      component.onGecImageError({ target: img } as unknown as Event);
+      vi.runOnlyPendingTimers();
+      expect(img.src.match(/[?&]t=/g)).toHaveLength(1);
     });
 
     it('delegates the display name to AppService and tracks bodies by id', () => {

--- a/src/app/home/home.component.extra.spec.ts
+++ b/src/app/home/home.component.extra.spec.ts
@@ -426,6 +426,33 @@ describe('HomeComponent (extended coverage)', () => {
       expect(img.src.match(/[?&]t=/g)).toHaveLength(1);
     });
 
+    it('does not retry a replacement source but lets that source handle its own error', () => {
+      const img = document.createElement('img');
+      img.src = 'assets/first.gif';
+      component.onGecImageError({ target: img } as unknown as Event);
+
+      img.src = 'assets/second.gif';
+      vi.runOnlyPendingTimers();
+      expect(img.src).toContain('/assets/second.gif');
+      expect(img.src).not.toContain('?t=');
+
+      component.onGecImageError({ target: img } as unknown as Event);
+      vi.runOnlyPendingTimers();
+      expect(img.src).toContain('/assets/second.gif?t=');
+    });
+
+    it('places the cache-buster before a URL fragment and preserves existing parameters', () => {
+      const img = document.createElement('img');
+      img.src = 'https://example.com/image.gif?size=large#preview';
+      component.onGecImageError({ target: img } as unknown as Event);
+      vi.runOnlyPendingTimers();
+
+      const retried = new URL(img.src);
+      expect(retried.searchParams.get('size')).toBe('large');
+      expect(retried.searchParams.get('t')).not.toBeNull();
+      expect(retried.hash).toBe('#preview');
+    });
+
     it('delegates the display name to AppService and tracks bodies by id', () => {
       expect(component.getBodyDisplayName('Foo')).toBe('Foo*');
       expect(component.trackByBody(0, { bodyData: { bodyId: 8 } } as any)).toBe(8);

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1615,9 +1615,12 @@ export class HomeComponent implements OnInit, OnDestroy {
     // Some GEC GIFs intermittently fail to decode on first load; force a one-shot
     // reload with a cache-busting query param so a transient failure self-heals.
     const img = event.target as HTMLImageElement;
-    if (img.src.toLowerCase().includes('.gif')) {
+    if (img.src.toLowerCase().includes('.gif') && img.dataset['gecRetryAttempted'] !== 'true') {
+      // Mark it before scheduling the retry so repeated error events cannot queue more reloads.
+      img.dataset['gecRetryAttempted'] = 'true';
       setTimeout(() => {
-        img.src = img.src + '?t=' + Date.now();
+        const separator = img.src.includes('?') ? '&' : '?';
+        img.src = `${img.src}${separator}t=${Date.now()}`;
       }, 100);
     }
   }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1615,14 +1615,24 @@ export class HomeComponent implements OnInit, OnDestroy {
     // Some GEC GIFs intermittently fail to decode on first load; force a one-shot
     // reload with a cache-busting query param so a transient failure self-heals.
     const img = event.target as HTMLImageElement;
-    if (img.src.toLowerCase().includes('.gif') && img.dataset['gecRetryAttempted'] !== 'true') {
-      // Mark it before scheduling the retry so repeated error events cannot queue more reloads.
-      img.dataset['gecRetryAttempted'] = 'true';
-      setTimeout(() => {
-        const separator = img.src.includes('?') ? '&' : '?';
-        img.src = `${img.src}${separator}t=${Date.now()}`;
-      }, 100);
+    const failedUrl = new URL(img.src, document.baseURI);
+    if (!failedUrl.pathname.toLowerCase().endsWith('.gif')) { return; }
+
+    const failedHref = failedUrl.href;
+    if (img.dataset['gecRetrySource'] === failedHref || img.dataset['gecRetryUrl'] === failedHref) {
+      return;
     }
+
+    // Record the specific failed source before scheduling so duplicate error events cannot queue
+    // retries, while a subsequently assigned image URL remains eligible for its own one-shot retry.
+    img.dataset['gecRetrySource'] = failedHref;
+    setTimeout(() => {
+      if (img.src !== failedHref) { return; }
+      const retryUrl = new URL(failedHref);
+      retryUrl.searchParams.set('t', Date.now().toString());
+      img.dataset['gecRetryUrl'] = retryUrl.href;
+      img.src = retryUrl.href;
+    }, 100);
   }
 
   public getBodyDisplayName(bodyName: string): string {


### PR DESCRIPTION
## Issue found
Every error event from a broken GEC GIF scheduled another cache-busted reload. A persistently unavailable or undecodable image could therefore loop forever, continually mutating its URL and issuing requests.

## Summary
- track one retry per failed source URL and ignore duplicate error events
- avoid mutating a replacement image source from a stale delayed callback
- use URL search parameters so existing queries and fragments remain valid
- intentionally limit retry detection to URLs whose pathname ends in `.gif`; this covers `edastro.mainImage` while excluding extensionless or query-only image endpoints that the previous broad substring check could classify as GIFs
- verify repeated errors, source replacement, per-source retries, and query/fragment handling

## Verification
- `pnpm exec ng test --watch=false --include=src/app/home/home.component.extra.spec.ts` (51 passed)
- `pnpm exec playwright test --project=desktop-chromium --workers=4` (100 passed)
