### PR TITLE
Filter malformed outpost coordinates

### DIFF
--- a/src/app/home/home.component.extra.spec.ts
+++ b/src/app/home/home.component.extra.spec.ts
@@ -217,6 +217,22 @@ describe('HomeComponent (extended coverage)', () => {
       expect(component.getNearestOutposts().length).toBe(1);
     });
 
+    it('excludes malformed outpost coordinates before choosing the nearest three', () => {
+      component.data.set({ system: { name: 'Sol', id64: 1, coords: { x: 0, y: 0, z: 0 } } } as any);
+      independentOutposts$.set([
+        { name: 'Missing', galMapSearch: 'Missing', coordinates: [], type: 'independentOutpost' },
+        { name: 'NaN', galMapSearch: 'NaN', coordinates: [NaN, 0, 0], type: 'independentOutpost' },
+        { name: 'Infinite', galMapSearch: 'Infinite', coordinates: [0, Infinity, 0], type: 'independentOutpost' },
+        { name: 'Fourth', galMapSearch: 'Fourth', coordinates: [4, 0, 0], type: 'independentOutpost' },
+        { name: 'Second', galMapSearch: 'Second', coordinates: [2, 0, 0], type: 'independentOutpost' },
+        { name: 'First', galMapSearch: 'First', coordinates: [1, 0, 0], type: 'independentOutpost' },
+        { name: 'Third', galMapSearch: 'Third', coordinates: [3, 0, 0], type: 'independentOutpost' },
+      ]);
+
+      expect(component.getNearestOutposts().map(outpost => outpost.name)).toEqual(['First', 'Second', 'Third']);
+      expect(component.getNearestOutposts().every(outpost => Number.isFinite(outpost.distance))).toBe(true);
+    });
+
     it('derives the display-name -> systemName/id64 map from the EdAstro feed', () => {
       edastroSystems$.set([{ name: 'Display Name', galMapSearch: 'Real Sys', id64: 42 }]);
       expect((component as any).systemMapping().get('Display Name')).toEqual({ systemName: 'Real Sys', id64: 42 });

--- a/src/app/home/home.component.extra.spec.ts
+++ b/src/app/home/home.component.extra.spec.ts
@@ -221,6 +221,8 @@ describe('HomeComponent (extended coverage)', () => {
       component.data.set({ system: { name: 'Sol', id64: 1, coords: { x: 0, y: 0, z: 0 } } } as any);
       independentOutposts$.set([
         { name: 'Missing', galMapSearch: 'Missing', coordinates: [], type: 'independentOutpost' },
+        { name: 'Non-array', galMapSearch: 'Non-array', coordinates: '1,2,3' as any, type: 'independentOutpost' },
+        { name: 'Sparse', galMapSearch: 'Sparse', coordinates: [1, , 3] as any, type: 'independentOutpost' },
         { name: 'NaN', galMapSearch: 'NaN', coordinates: [NaN, 0, 0], type: 'independentOutpost' },
         { name: 'Infinite', galMapSearch: 'Infinite', coordinates: [0, Infinity, 0], type: 'independentOutpost' },
         { name: 'Fourth', galMapSearch: 'Fourth', coordinates: [4, 0, 0], type: 'independentOutpost' },

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -368,7 +368,10 @@ export class HomeComponent implements OnInit, OnDestroy {
       return [];
     }
     return (this.independentOutposts() ?? [])
-      .filter(outpost => outpost.coordinates.length >= 3 && outpost.coordinates.slice(0, 3).every(Number.isFinite))
+      .filter(outpost => Array.isArray(outpost.coordinates)
+        && Number.isFinite(outpost.coordinates[0])
+        && Number.isFinite(outpost.coordinates[1])
+        && Number.isFinite(outpost.coordinates[2]))
       .map(outpost => {
         const [ox, oy, oz] = outpost.coordinates;
         return {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -368,6 +368,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       return [];
     }
     return (this.independentOutposts() ?? [])
+      .filter(outpost => outpost.coordinates.length >= 3 && outpost.coordinates.slice(0, 3).every(Number.isFinite))
       .map(outpost => {
         const [ox, oy, oz] = outpost.coordinates;
         return {


### PR DESCRIPTION
## Issue found
Nearest-outpost sorting calculated distances for rows with missing, `NaN`, or infinite coordinates. Those invalid distances could consume the three displayed slots and render an empty distance followed by `ly`, hiding valid nearby outposts.

## Summary
- require an actual coordinate array with finite values explicitly present at indices 0, 1, and 2
- reject non-array and sparse runtime payloads without throwing
- sort and slice only validated outposts
- cover mixed malformed and valid rows, including nearest-three ordering

## Verification
- `pnpm exec ng test --watch=false --include=src/app/home/home.component.extra.spec.ts` (50 passed)
- `pnpm exec playwright test --project=desktop-chromium --workers=4` (100 passed)