### PR TITLE
Make region-map SVG controls keyboard accessible

### DIFF
--- a/src/app/region-map/region-map.component.scss
+++ b/src/app/region-map/region-map.component.scss
@@ -12,7 +12,33 @@
 }
 
 .region-map-slot {
+    position: relative;
     width: 100%;
+}
+
+.region-map-skip-link {
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    left: 0;
+    padding: 0.4rem 0.6rem;
+    border: 2px solid var(--color-accent);
+    border-radius: 4px;
+    background: var(--color-surface-3);
+    color: var(--color-white);
+    font: inherit;
+    cursor: pointer;
+    transform: translateY(-150%);
+}
+
+.region-map-skip-link:focus-visible {
+    transform: translateY(0);
+    outline: 3px solid var(--color-white);
+    outline-offset: 2px;
+}
+
+.region-map-skip-target {
+    position: absolute;
 }
 
 // Square placeholder matching the loaded map's footprint (square viewBox, rendered at 100% width

--- a/src/app/region-map/region-map.component.spec.ts
+++ b/src/app/region-map/region-map.component.spec.ts
@@ -158,6 +158,36 @@ describe('RegionMapComponent', () => {
       (outpostCircles[outpostCircles.length - 1] as Element).dispatchEvent(new MouseEvent('click'));
       expect(emitted).toContain('PG Sys 1');
     });
+
+    it('makes known and outpost markers keyboard accessible and shows descriptions on focus', () => {
+      const emitted: string[] = [];
+      component.systemSelected.subscribe(n => emitted.push(n));
+      fixture.componentRef.setInput('outposts', [
+        { name: 'Outpost &amp; One', galMapSearch: 'PG Sys 1', coordinates: [10, 0, 20], type: 'independentOutpost' },
+      ]);
+      const svg = buildSvg();
+      (component as any).addKnownSystemMarkers(svg);
+
+      const groups = svg.querySelectorAll('.known-system-marker');
+      const knownCircle = groups[0].querySelector('circle')!;
+      const knownText = groups[0].querySelector('text')!;
+      (knownText as any).getBBox = () => ({ x: 1, y: 2, width: 30, height: 10 });
+      expect(knownCircle.getAttribute('role')).toBe('button');
+      expect(knownCircle.getAttribute('tabindex')).toBe('0');
+      expect(knownCircle.getAttribute('aria-label')).toContain('Varati');
+
+      knownCircle.dispatchEvent(new FocusEvent('focus'));
+      expect(knownText.style.display).toBe('block');
+      knownCircle.dispatchEvent(new FocusEvent('blur'));
+      expect(knownText.style.display).toBe('none');
+      knownCircle.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', cancelable: true }));
+      expect(emitted).toContain('Varati');
+
+      const outpostCircle = groups[groups.length - 1].querySelector('circle')!;
+      expect(outpostCircle.getAttribute('aria-label')).toContain('Outpost & One');
+      outpostCircle.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }));
+      expect(emitted).toContain('PG Sys 1');
+    });
   });
 
   describe('updateMarkerScales', () => {
@@ -245,6 +275,28 @@ describe('RegionMapComponent', () => {
         expect(p.getAttribute('data-zoom-bound')).toBe('true');
       });
     });
+
+    it('makes regions named keyboard controls with Enter and Space zoom activation', () => {
+      fixture.componentRef.setInput('system', {
+        name: 'Sol', region: { name: 'Inner Orion Spur', region: 18 }, coords: { x: 0, y: 0, z: 0 },
+      });
+      const svg = mountSvg(buildSvg());
+      (component as any).highlightRegion();
+
+      const current = svg.querySelector('#Region_18')!;
+      const other = svg.querySelector('#Region_07')!;
+      expect(current.getAttribute('role')).toBe('button');
+      expect(current.getAttribute('tabindex')).toBe('0');
+      expect(current.getAttribute('aria-label')).toBe('Zoom to Inner Orion Spur');
+      expect(other.getAttribute('aria-label')).toBe('Zoom to galaxy region 7');
+
+      other.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', cancelable: true }));
+      expect(svg.getAttribute('viewBox')).not.toBe('0 0 2048 2048');
+
+      svg.setAttribute('viewBox', '0 0 2048 2048');
+      current.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }));
+      expect(svg.getAttribute('viewBox')).not.toBe('0 0 2048 2048');
+    });
   });
 
   describe('zoomToRegion + Gnosis', () => {
@@ -292,7 +344,17 @@ describe('RegionMapComponent', () => {
 
       const marker = svg.querySelector('#gnosis-marker');
       expect(marker).not.toBeNull();
-      marker!.querySelector('circle')!.dispatchEvent(new MouseEvent('click'));
+      const circle = marker!.querySelector('circle')!;
+      const text = marker!.querySelector('text')!;
+      (text as any).getBBox = () => ({ x: 1, y: 2, width: 30, height: 10 });
+      expect(circle.getAttribute('role')).toBe('button');
+      expect(circle.getAttribute('tabindex')).toBe('0');
+      expect(circle.getAttribute('aria-label')).toBe('Open The Gnosis at Varati');
+      circle.dispatchEvent(new FocusEvent('focus'));
+      expect(text.style.display).toBe('block');
+      circle.dispatchEvent(new FocusEvent('blur'));
+      expect(text.style.display).toBe('none');
+      circle.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', cancelable: true }));
       expect(emitted).toEqual(['Varati']);
     });
 

--- a/src/app/region-map/region-map.component.spec.ts
+++ b/src/app/region-map/region-map.component.spec.ts
@@ -71,6 +71,16 @@ describe('RegionMapComponent', () => {
     expect(emitted).toEqual(['Sol']);
   });
 
+  it('provides a keyboard control that skips every interactive map element', () => {
+    fixture.detectChanges();
+    const skip = fixture.nativeElement.querySelector('.region-map-skip-link') as HTMLButtonElement;
+    const target = fixture.nativeElement.querySelector('.region-map-skip-target') as HTMLSpanElement;
+
+    skip.click();
+
+    expect(document.activeElement).toBe(target);
+  });
+
   it('maps galactic X/Z coordinates into the SVG viewBox space', () => {
     // Sol is at the galactic origin; check the documented transform constants.
     const tx = (component as any).mapX(0);
@@ -303,8 +313,13 @@ describe('RegionMapComponent', () => {
       const other = svg.querySelector('#Region_07')!;
       expect(current.getAttribute('role')).toBe('button');
       expect(current.getAttribute('tabindex')).toBe('0');
-      expect(current.getAttribute('aria-label')).toBe('Zoom to Inner Orion Spur');
+      expect(current.getAttribute('aria-label')).toBe('Zoom to galaxy region 18, Inner Orion Spur');
       expect(other.getAttribute('aria-label')).toBe('Zoom to galaxy region 7');
+
+      const interactiveStyles = svg.querySelector('style#custom-region-styles')?.textContent ?? '';
+      expect(interactiveStyles).toContain('[role="button"]:focus-visible');
+      expect(interactiveStyles).toContain('outline: 4px solid var(--color-white)');
+      expect(interactiveStyles).toContain('drop-shadow(0 0 5px var(--color-accent))');
 
       other.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', cancelable: true }));
       expect(svg.getAttribute('viewBox')).not.toBe('0 0 2048 2048');

--- a/src/app/region-map/region-map.component.spec.ts
+++ b/src/app/region-map/region-map.component.spec.ts
@@ -220,6 +220,20 @@ describe('RegionMapComponent', () => {
       expect([...svg.querySelectorAll('.known-system-marker text')].some(text => text.textContent === 'Remote Outpost')).toBe(true);
     });
 
+    it('removes the previous system marker when the next regionless system has no coordinates', () => {
+      fixture.componentRef.setInput('system', {
+        name: 'Marked', region: { name: 'Inner Orion Spur', region: 18 }, coords: { x: 0, y: 0, z: 0 },
+      });
+      const svg = mountSvg(buildSvg());
+      (component as any).highlightRegion();
+      expect(svg.querySelector('#system-marker')).not.toBeNull();
+
+      fixture.componentRef.setInput('system', { name: 'Unlocated' });
+      (component as any).highlightRegion();
+
+      expect(svg.querySelector('#system-marker')).toBeNull();
+    });
+
     it('binds each region zoom handler exactly once across re-highlights', () => {
       fixture.componentRef.setInput('system', {
         name: 'Sol', region: { name: 'x', region: 7 }, coords: { x: 0, y: 0, z: 0 },

--- a/src/app/region-map/region-map.component.spec.ts
+++ b/src/app/region-map/region-map.component.spec.ts
@@ -178,13 +178,23 @@ describe('RegionMapComponent', () => {
 
       knownCircle.dispatchEvent(new FocusEvent('focus'));
       expect(knownText.style.display).toBe('block');
+      knownCircle.dispatchEvent(new MouseEvent('mouseenter'));
+      knownCircle.dispatchEvent(new MouseEvent('mouseleave'));
+      expect(knownText.style.display).toBe('block'); // focus still owns the description
       knownCircle.dispatchEvent(new FocusEvent('blur'));
       expect(knownText.style.display).toBe('none');
+
+      (component as any).bindSvgReset(svg);
+      svg.setAttribute('viewBox', '100 200 300 300');
       knownCircle.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', cancelable: true }));
       expect(emitted).toContain('Varati');
+      expect(svg.getAttribute('viewBox')).toBe('0 0 2048 2048');
 
       const outpostCircle = groups[groups.length - 1].querySelector('circle')!;
       expect(outpostCircle.getAttribute('aria-label')).toContain('Outpost & One');
+      expect(outpostCircle.getAttribute('tabindex')).toBe('-1');
+      (component as any).updateMarkerScales(svg, 4);
+      expect(outpostCircle.getAttribute('tabindex')).toBe('0');
       outpostCircle.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }));
       expect(emitted).toContain('PG Sys 1');
     });
@@ -198,6 +208,7 @@ describe('RegionMapComponent', () => {
       always.setAttribute('class', 'known-system-marker');
       const ac = document.createElementNS(SVG_NS, 'circle');
       ac.setAttribute('cx', '100'); ac.setAttribute('cy', '200');
+      ac.setAttribute('role', 'button');
       always.appendChild(ac);
       svg.appendChild(always);
 
@@ -206,15 +217,18 @@ describe('RegionMapComponent', () => {
       zoomed.setAttribute('data-zoom-level', 'zoomed');
       const zc = document.createElementNS(SVG_NS, 'circle');
       zc.setAttribute('cx', '50'); zc.setAttribute('cy', '60');
+      zc.setAttribute('role', 'button');
       zoomed.appendChild(zc);
       svg.appendChild(zoomed);
 
       (component as any).updateMarkerScales(svg, 4);
       expect(always.getAttribute('transform')).toContain('scale(0.25)');
       expect(zoomed.style.display).toBe('block'); // visible when zoomed in
+      expect(zc.getAttribute('tabindex')).toBe('0');
 
       (component as any).updateMarkerScales(svg, 1);
       expect(zoomed.style.display).toBe('none'); // hidden at full view
+      expect(zc.getAttribute('tabindex')).toBe('-1');
     });
   });
 
@@ -224,6 +238,7 @@ describe('RegionMapComponent', () => {
         name: 'Sol', region: { name: 'Inner Orion Spur', region: 18 }, coords: { x: 0, y: 0, z: 0 },
       });
       const svg = mountSvg(buildSvg());
+      (component as any).bindSvgReset(svg);
       (component as any).highlightRegion();
 
       const active = svg.querySelector('#Region_18') as HTMLElement;
@@ -281,6 +296,7 @@ describe('RegionMapComponent', () => {
         name: 'Sol', region: { name: 'Inner Orion Spur', region: 18 }, coords: { x: 0, y: 0, z: 0 },
       });
       const svg = mountSvg(buildSvg());
+      (component as any).bindSvgReset(svg);
       (component as any).highlightRegion();
 
       const current = svg.querySelector('#Region_18')!;
@@ -292,8 +308,14 @@ describe('RegionMapComponent', () => {
 
       other.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', cancelable: true }));
       expect(svg.getAttribute('viewBox')).not.toBe('0 0 2048 2048');
+      expect(other.getAttribute('tabindex')).toBe('0');
+      expect(current.getAttribute('tabindex')).toBe('-1');
 
-      svg.setAttribute('viewBox', '0 0 2048 2048');
+      other.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }));
+      expect(svg.getAttribute('viewBox')).toBe('0 0 2048 2048');
+      expect(other.getAttribute('tabindex')).toBe('0');
+      expect(current.getAttribute('tabindex')).toBe('0');
+
       current.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }));
       expect(svg.getAttribute('viewBox')).not.toBe('0 0 2048 2048');
     });

--- a/src/app/region-map/region-map.component.spec.ts
+++ b/src/app/region-map/region-map.component.spec.ts
@@ -206,6 +206,20 @@ describe('RegionMapComponent', () => {
       expect(svg.querySelector('#system-marker')).not.toBeNull();
     });
 
+    it('renders coordinate-based markers when region metadata is absent', () => {
+      fixture.componentRef.setInput('system', { name: 'Regionless', coords: { x: 10, y: 20, z: 30 } });
+      fixture.componentRef.setInput('outposts', [
+        { name: 'Remote Outpost', galMapSearch: 'Remote System', coordinates: [40, 50, 60], type: 'independentOutpost' },
+      ]);
+      const svg = mountSvg(buildSvg());
+
+      (component as any).highlightRegion();
+
+      expect(svg.querySelector('#system-marker')).not.toBeNull();
+      expect(svg.querySelectorAll('.known-system-marker').length).toBeGreaterThan(6);
+      expect([...svg.querySelectorAll('.known-system-marker text')].some(text => text.textContent === 'Remote Outpost')).toBe(true);
+    });
+
     it('binds each region zoom handler exactly once across re-highlights', () => {
       fixture.componentRef.setInput('system', {
         name: 'Sol', region: { name: 'x', region: 7 }, coords: { x: 0, y: 0, z: 0 },

--- a/src/app/region-map/region-map.component.ts
+++ b/src/app/region-map/region-map.component.ts
@@ -169,7 +169,7 @@ export class RegionMapComponent implements OnChanges {
   private highlightRegion(): void {
     const regionMapContainer = this.regionMapContainer();
     const system = this.system();
-    if (!regionMapContainer || !system || !system.region) {
+    if (!regionMapContainer || !system) {
       return;
     }
 
@@ -215,17 +215,20 @@ export class RegionMapComponent implements OnChanges {
       }
     });
 
-    // Highlight the current region
-    const regionId = `Region_${String(system.region.region).padStart(2, '0')}`;
-    const regionElement = svgElement.querySelector(`#${regionId}`);
-    if (regionElement) {
-      (regionElement as HTMLElement).style.fill = '#ff9900';
-      (regionElement as HTMLElement).style.fillOpacity = '0.6';
-      (regionElement as HTMLElement).style.stroke = '#ff9900';
-      (regionElement as HTMLElement).style.strokeOpacity = '1';
-      (regionElement as HTMLElement).style.strokeWidth = '2';
-    } else {
-      logger.warn('Region element not found for ID:', regionId);
+    // Highlight the current region when the API supplied one. Coordinates are independently
+    // useful, so missing region metadata must not suppress the system and known-system markers.
+    if (system.region) {
+      const regionId = `Region_${String(system.region.region).padStart(2, '0')}`;
+      const regionElement = svgElement.querySelector(`#${regionId}`);
+      if (regionElement) {
+        (regionElement as HTMLElement).style.fill = '#ff9900';
+        (regionElement as HTMLElement).style.fillOpacity = '0.6';
+        (regionElement as HTMLElement).style.stroke = '#ff9900';
+        (regionElement as HTMLElement).style.strokeOpacity = '1';
+        (regionElement as HTMLElement).style.strokeWidth = '2';
+      } else {
+        logger.warn('Region element not found for ID:', regionId);
+      }
     }
 
     // Add red dot at system coordinates

--- a/src/app/region-map/region-map.component.ts
+++ b/src/app/region-map/region-map.component.ts
@@ -84,6 +84,30 @@ export class RegionMapComponent implements OnChanges {
     this.systemSelected.emit(systemName);
   }
 
+  /** Applies the shared mouse, keyboard and focus behaviour for selectable SVG markers. */
+  private bindMarkerInteractions(
+    circle: SVGCircleElement,
+    accessibleName: string,
+    systemName: string,
+    showDescription: () => void,
+    hideDescription: () => void,
+  ): void {
+    circle.setAttribute('role', 'button');
+    circle.setAttribute('tabindex', '0');
+    circle.setAttribute('aria-label', accessibleName);
+    circle.addEventListener('click', () => this.selectSystem(systemName));
+    circle.addEventListener('keydown', event => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        this.selectSystem(systemName);
+      }
+    });
+    circle.addEventListener('mouseenter', showDescription);
+    circle.addEventListener('focus', showDescription);
+    circle.addEventListener('mouseleave', hideDescription);
+    circle.addEventListener('blur', hideDescription);
+  }
+
   private async loadRegionMap(): Promise<void> {
     const regionMapContainer = this.regionMapContainer();
     if (!regionMapContainer || !this.system()) {
@@ -172,7 +196,6 @@ export class RegionMapComponent implements OnChanges {
     if (!regionMapContainer || !system) {
       return;
     }
-
     const svgElement = regionMapContainer.nativeElement.querySelector('svg');
     if (!svgElement) {
       return;
@@ -190,7 +213,7 @@ export class RegionMapComponent implements OnChanges {
       svgElement.insertBefore(styleElement, svgElement.firstChild);
     }
 
-    // Reset all regions to default style and add click handlers
+    // Reset all regions to default style and add mouse/keyboard zoom handlers.
     const allRegions = svgElement.querySelectorAll('path[id^="Region_"]');
     allRegions.forEach(region => {
       (region as HTMLElement).style.fill = 'darkorange';
@@ -198,18 +221,30 @@ export class RegionMapComponent implements OnChanges {
       (region as HTMLElement).style.stroke = 'orange';
       (region as HTMLElement).style.strokeOpacity = '1';
       (region as HTMLElement).style.strokeWidth = '';
+      const regionNumber = Number.parseInt(region.id.replace('Region_', ''), 10);
+      region.setAttribute('role', 'button');
+      region.setAttribute('tabindex', '0');
+      region.setAttribute('aria-label', `Zoom to galaxy region ${regionNumber}`);
 
       // Add click handler for zooming exactly once per region. The SVG is loaded
       // once and reused across searches, so without this guard each search would
       // stack another duplicate listener on every region path.
       if (!region.hasAttribute('data-zoom-bound')) {
         region.setAttribute('data-zoom-bound', 'true');
-        region.addEventListener('click', (event) => {
+        const zoom = (event: Event): void => {
           const currentViewBox = svgElement.getAttribute('viewBox');
           // Only zoom in if we're not already zoomed
           if (currentViewBox === FULL_VIEWBOX) {
             event.stopPropagation();
             this.zoomToRegion(region as SVGPathElement, svgElement);
+          }
+        };
+        region.addEventListener('click', zoom);
+        region.addEventListener('keydown', event => {
+          const key = (event as KeyboardEvent).key;
+          if (key === 'Enter' || key === ' ') {
+            event.preventDefault();
+            zoom(event);
           }
         });
       }
@@ -218,16 +253,18 @@ export class RegionMapComponent implements OnChanges {
     // Highlight the current region when the API supplied one. Coordinates are independently
     // useful, so missing region metadata must not suppress the system and known-system markers.
     if (system.region) {
-      const regionId = `Region_${String(system.region.region).padStart(2, '0')}`;
-      const regionElement = svgElement.querySelector(`#${regionId}`);
+      const currentRegionId = `Region_${String(system.region.region).padStart(2, '0')}`;
+      const regionElement = svgElement.querySelector(`#${currentRegionId}`);
       if (regionElement) {
+        const namedSuffix = system.region.name ? `, ${system.region.name}` : '';
+        regionElement.setAttribute('aria-label', `Zoom to galaxy region ${system.region.region}${namedSuffix}`);
         (regionElement as HTMLElement).style.fill = '#ff9900';
         (regionElement as HTMLElement).style.fillOpacity = '0.6';
         (regionElement as HTMLElement).style.stroke = '#ff9900';
         (regionElement as HTMLElement).style.strokeOpacity = '1';
         (regionElement as HTMLElement).style.strokeWidth = '2';
       } else {
-        logger.warn('Region element not found for ID:', regionId);
+        logger.warn('Region element not found for ID:', currentRegionId);
       }
     }
 
@@ -352,9 +389,6 @@ export class RegionMapComponent implements OnChanges {
       circle.setAttribute('opacity', '0.9');
       circle.style.cursor = 'pointer';
 
-      // Add click handler to navigate to system
-      circle.addEventListener('click', () => this.selectSystem(system.systemName));
-
       // Check viewBox to determine if we should position tooltip on left
       // When zoomed, use viewBox bounds instead of full map coordinates
       const viewBoxCenterX = viewBoxValues[0] + (viewBoxValues[2] / 2);
@@ -380,8 +414,7 @@ export class RegionMapComponent implements OnChanges {
       rect.setAttribute('pointer-events', 'none');
       rect.style.display = 'none';
 
-      // Add hover events
-      circle.addEventListener('mouseenter', () => {
+      const showDescription = (): void => {
         // Show the text first: getBBox() returns a zero rect (Chromium) or throws
         // (Firefox) for a display:none element, so it must be measured while visible.
         text.style.display = 'block';
@@ -392,12 +425,13 @@ export class RegionMapComponent implements OnChanges {
         rect.setAttribute('y', (bbox.y - 2).toString());
         rect.setAttribute('width', (bbox.width + 8).toString());
         rect.setAttribute('height', (bbox.height + 4).toString());
-      });
+      };
 
-      circle.addEventListener('mouseleave', () => {
+      const hideDescription = (): void => {
         rect.style.display = 'none';
         text.style.display = 'none';
-      });
+      };
+      this.bindMarkerInteractions(circle, `Open ${system.name}`, system.systemName, showDescription, hideDescription);
 
       // Add elements to group
       group.appendChild(circle);
@@ -430,6 +464,7 @@ export class RegionMapComponent implements OnChanges {
       const [x, , z] = outpost.coordinates;
       const tx = this.mapX(x);
       const finalY = this.mapY(z);
+      const outpostName = decodeHtmlEntities(outpost.name);
 
       // Create a group for the marker and label
       const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
@@ -445,9 +480,6 @@ export class RegionMapComponent implements OnChanges {
       circle.setAttribute('stroke-width', '1.5');
       circle.setAttribute('opacity', '0.9');
       circle.style.cursor = 'pointer';
-
-      // Add click handler to navigate to system
-      circle.addEventListener('click', () => this.selectSystem(outpost.galMapSearch));
 
       // Check viewBox to determine tooltip position based on distance from edges
       const viewBoxLeft = viewBoxValues[0];
@@ -467,7 +499,7 @@ export class RegionMapComponent implements OnChanges {
       text.setAttribute('pointer-events', 'none');
       text.setAttribute('text-anchor', isRightSide ? 'end' : 'start');
       text.style.display = 'none';
-      text.textContent = decodeHtmlEntities(outpost.name);
+      text.textContent = outpostName;
 
       // Create background rect for text
       const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
@@ -476,8 +508,7 @@ export class RegionMapComponent implements OnChanges {
       rect.setAttribute('pointer-events', 'none');
       rect.style.display = 'none';
 
-      // Add hover events
-      circle.addEventListener('mouseenter', () => {
+      const showDescription = (): void => {
         // Show the text first: getBBox() returns a zero rect (Chromium) or throws
         // (Firefox) for a display:none element, so it must be measured while visible.
         text.style.display = 'block';
@@ -487,12 +518,13 @@ export class RegionMapComponent implements OnChanges {
         rect.setAttribute('y', (bbox.y - 1).toString());
         rect.setAttribute('width', (bbox.width + 6).toString());
         rect.setAttribute('height', (bbox.height + 2).toString());
-      });
+      };
 
-      circle.addEventListener('mouseleave', () => {
+      const hideDescription = (): void => {
         rect.style.display = 'none';
         text.style.display = 'none';
-      });
+      };
+      this.bindMarkerInteractions(circle, `Open ${outpostName}`, outpost.galMapSearch, showDescription, hideDescription);
 
       // Add elements to group
       group.appendChild(circle);
@@ -561,9 +593,6 @@ export class RegionMapComponent implements OnChanges {
     circle.setAttribute('opacity', '0.9');
     circle.style.cursor = 'pointer';
 
-    // Add click handler to navigate to system
-    circle.addEventListener('click', () => this.selectSystem(gnosisData.system));
-
     // Position tooltip - use more conservative positioning for long text
     // Check if we're in the right 60% of the map (not just right half)
     const isRightSide = tx > 819; // 2048 * 0.4 = 819
@@ -588,8 +617,7 @@ export class RegionMapComponent implements OnChanges {
     rect.setAttribute('pointer-events', 'none');
     rect.style.display = 'none';
 
-    // Add hover events
-    circle.addEventListener('mouseenter', () => {
+    const showDescription = (): void => {
       // Show the text first: getBBox() returns a zero rect (Chromium) or throws
       // (Firefox) for a display:none element, so it must be measured while visible.
       text.style.display = 'block';
@@ -599,12 +627,19 @@ export class RegionMapComponent implements OnChanges {
       rect.setAttribute('y', (bbox.y - 2).toString());
       rect.setAttribute('width', (bbox.width + 8).toString());
       rect.setAttribute('height', (bbox.height + 4).toString());
-    });
+    };
 
-    circle.addEventListener('mouseleave', () => {
+    const hideDescription = (): void => {
       rect.style.display = 'none';
       text.style.display = 'none';
-    });
+    };
+    this.bindMarkerInteractions(
+      circle,
+      `Open The Gnosis at ${gnosisData.system}`,
+      gnosisData.system,
+      showDescription,
+      hideDescription,
+    );
 
     // Add elements to group
     group.appendChild(circle);

--- a/src/app/region-map/region-map.component.ts
+++ b/src/app/region-map/region-map.component.ts
@@ -621,15 +621,15 @@ export class RegionMapComponent implements OnChanges {
   }
 
   private addSystemMarker(svgElement: SVGSVGElement): void {
-    const coords = this.system()?.coords;
-    if (!coords) {
-      return;
-    }
-
-    // Remove any existing system marker
+    // Always clear the previous search's marker, even when the new system has no coordinates.
     const existingMarker = svgElement.querySelector('#system-marker');
     if (existingMarker) {
       existingMarker.remove();
+    }
+
+    const coords = this.system()?.coords;
+    if (!coords) {
+      return;
     }
 
     // The region map uses X and Z galactic coordinates (X horizontal, Z vertical).

--- a/src/app/region-map/region-map.component.ts
+++ b/src/app/region-map/region-map.component.ts
@@ -43,10 +43,12 @@ const FULL_VIEWBOX = `0 0 ${MAP_SIZE} ${MAP_SIZE}`;
   // @if) so `regionMapContainer` resolves before `loadRegionMap` runs.
   template: `
     <div class="region-map-slot">
+      <button type="button" class="region-map-skip-link" (click)="skipMap()">Skip interactive galaxy map</button>
       @if (!mapLoaded()) {
         <div class="region-map-skeleton skeleton" aria-hidden="true"></div>
       }
       <div #regionMapContainer class="region-map"></div>
+      <span #mapEnd class="region-map-skip-target" tabindex="-1"></span>
     </div>
   `,
   styleUrl: './region-map.component.scss',
@@ -61,6 +63,7 @@ export class RegionMapComponent implements OnChanges {
   readonly systemSelected = output<string>();
 
   readonly regionMapContainer = viewChild.required<ElementRef<HTMLDivElement>>('regionMapContainer');
+  readonly mapEnd = viewChild.required<ElementRef<HTMLSpanElement>>('mapEnd');
 
   /** Guards against issuing a second SVG fetch while the first is still in flight. */
   private svgLoading = false;
@@ -82,6 +85,10 @@ export class RegionMapComponent implements OnChanges {
 
   private selectSystem(systemName: string): void {
     this.systemSelected.emit(systemName);
+  }
+
+  public skipMap(): void {
+    this.mapEnd().nativeElement.focus();
   }
 
   /** Applies the shared mouse, keyboard and focus behaviour for selectable SVG markers. */
@@ -231,6 +238,11 @@ export class RegionMapComponent implements OnChanges {
       styleElement.textContent = `
         .regionText { display: none !important; }
         .region { pointer-events: auto !important; cursor: pointer !important; }
+        [role="button"]:focus-visible {
+          outline: 4px solid var(--color-white);
+          outline-offset: 4px;
+          filter: drop-shadow(0 0 5px var(--color-accent));
+        }
       `;
       svgElement.insertBefore(styleElement, svgElement.firstChild);
     }

--- a/src/app/region-map/region-map.component.ts
+++ b/src/app/region-map/region-map.component.ts
@@ -99,13 +99,44 @@ export class RegionMapComponent implements OnChanges {
     circle.addEventListener('keydown', event => {
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
-        this.selectSystem(systemName);
+        circle.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
       }
     });
-    circle.addEventListener('mouseenter', showDescription);
-    circle.addEventListener('focus', showDescription);
-    circle.addEventListener('mouseleave', hideDescription);
-    circle.addEventListener('blur', hideDescription);
+    let hovered = false;
+    let focused = false;
+    let descriptionVisible = false;
+    const updateDescription = (): void => {
+      const shouldShow = hovered || focused;
+      if (shouldShow === descriptionVisible) { return; }
+      descriptionVisible = shouldShow;
+      if (shouldShow) { showDescription(); } else { hideDescription(); }
+    };
+    circle.addEventListener('mouseenter', () => { hovered = true; updateDescription(); });
+    circle.addEventListener('focus', () => { focused = true; updateDescription(); });
+    circle.addEventListener('mouseleave', () => { hovered = false; updateDescription(); });
+    circle.addEventListener('blur', () => { focused = false; updateDescription(); });
+  }
+
+  /** Binds the full-map reset once; keyboard controls dispatch the same bubbling click path. */
+  private bindSvgReset(svgElement: SVGSVGElement): void {
+    if (svgElement.hasAttribute('data-reset-bound')) { return; }
+    svgElement.setAttribute('data-reset-bound', 'true');
+    svgElement.addEventListener('click', event => {
+      if (svgElement.getAttribute('viewBox') !== FULL_VIEWBOX) {
+        event.stopPropagation();
+        svgElement.setAttribute('viewBox', FULL_VIEWBOX);
+        delete svgElement.dataset['zoomedRegionId'];
+        this.updateRegionTabStops(svgElement, null);
+        this.updateMarkerScales(svgElement, 1);
+      }
+    });
+  }
+
+  /** Keeps clipped region paths out of the tab order while one region is zoomed. */
+  private updateRegionTabStops(svgElement: SVGSVGElement, activeRegion: SVGPathElement | null): void {
+    svgElement.querySelectorAll('path[id^="Region_"]').forEach(region => {
+      region.setAttribute('tabindex', !activeRegion || region === activeRegion ? '0' : '-1');
+    });
   }
 
   private async loadRegionMap(): Promise<void> {
@@ -170,16 +201,7 @@ export class RegionMapComponent implements OnChanges {
         svgElement.style.height = 'auto';
         svgElement.style.borderRadius = '8px';
 
-        // Add click handler to reset zoom
-        svgElement.addEventListener('click', (event) => {
-          const currentViewBox = svgElement.getAttribute('viewBox');
-          // If we're zoomed in, any click resets to full view
-          if (currentViewBox !== FULL_VIEWBOX) {
-            event.stopPropagation();
-            svgElement.setAttribute('viewBox', FULL_VIEWBOX);
-            this.updateMarkerScales(svgElement, 1);
-          }
-        });
+        this.bindSvgReset(svgElement);
       }
 
       this.highlightRegion();
@@ -244,11 +266,16 @@ export class RegionMapComponent implements OnChanges {
           const key = (event as KeyboardEvent).key;
           if (key === 'Enter' || key === ' ') {
             event.preventDefault();
-            zoom(event);
+            region.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
           }
         });
       }
     });
+    const zoomedRegionId = svgElement.dataset['zoomedRegionId'];
+    const zoomedRegion = zoomedRegionId
+      ? svgElement.querySelector<SVGPathElement>(`#${zoomedRegionId}`)
+      : null;
+    this.updateRegionTabStops(svgElement, zoomedRegion);
 
     // Highlight the current region when the API supplied one. Coordinates are independently
     // useful, so missing region metadata must not suppress the system and known-system markers.
@@ -296,6 +323,8 @@ export class RegionMapComponent implements OnChanges {
 
     // Set the viewBox to a square zoom
     svgElement.setAttribute('viewBox', `${x} ${y} ${size} ${size}`);
+    svgElement.dataset['zoomedRegionId'] = regionPath.id;
+    this.updateRegionTabStops(svgElement, regionPath);
 
     // Get region ID from the path element
     const regionId = regionPath.id; // e.g., "Region_01"
@@ -345,6 +374,9 @@ export class RegionMapComponent implements OnChanges {
       if (zoomLevel === 'zoomed') {
         // Show zoom-only markers when zoomed in (scaleFactor > 1)
         (marker as HTMLElement).style.display = scaleFactor > 1 ? 'block' : 'none';
+      }
+      if (circle?.getAttribute('role') === 'button') {
+        circle.setAttribute('tabindex', zoomLevel !== 'zoomed' || scaleFactor > 1 ? '0' : '-1');
       }
     });
   }
@@ -442,6 +474,7 @@ export class RegionMapComponent implements OnChanges {
       if (system.zoomLevel === 'zoomed') {
         group.style.display = currentScaleFactor > 1 ? 'block' : 'none';
         group.setAttribute('data-zoom-level', 'zoomed');
+        circle.setAttribute('tabindex', currentScaleFactor > 1 ? '0' : '-1');
       } else {
         group.setAttribute('data-zoom-level', 'always');
       }
@@ -534,6 +567,7 @@ export class RegionMapComponent implements OnChanges {
       // Set visibility - only show when zoomed in
       group.style.display = currentScaleFactor > 1 ? 'block' : 'none';
       group.setAttribute('data-zoom-level', 'zoomed');
+      circle.setAttribute('tabindex', currentScaleFactor > 1 ? '0' : '-1');
 
       // Apply current scale immediately
       if (currentScaleFactor !== 1) {


### PR DESCRIPTION
## Issue found
Interactive SVG regions and known-system, outpost, and Gnosis markers only responded to pointer input. They were absent from keyboard navigation, had no programmatic role or accessible name, and marker descriptions appeared only on hover.

Review also found that the branch conflicted with #145 and could reintroduce its regionless-marker regression during conflict resolution, that SVG controls lacked a reliable visible focus indicator, that region labels used inconsistent naming, and that keyboard users had no way to skip the map's many controls.

## Dependency
This branch is rebased onto #145 (`fix/regionless-map-markers`) so #145 must merge first. Its regionless-system behavior and stale-marker regression coverage are preserved in this branch.

## Summary
- expose zoomable regions and selectable markers as named button controls
- route Enter and Space through the same bubbling activation path as pointer clicks
- keep clipped regions and hidden zoom-only markers out of the tab order, restoring them on reset
- compose hover and focus ownership of marker descriptions
- add a high-contrast `:focus-visible` treatment inside the injected SVG
- use consistent `Zoom to galaxy region …` accessible names, appending the known region name when available
- provide a keyboard-visible control that skips all interactive map elements
- retain coordinate-based markers when region metadata is absent

## Verification
- `ng test --watch=false --include=src/app/region-map/region-map.component.spec.ts` (24 passed)
- `ng test --watch=false` (1,015 passed)
- `ng build` (passed with existing budget warnings)
- `playwright test --project=desktop-chromium --workers=4` (100 passed)
