### PR TITLE
Render zero-valued SIMBAD coordinates

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -34,6 +34,8 @@
 @let edastro = edastroData();
 @let edGalaxy = edGalaxyData();
 @let simbad = edGalaxy?.Simbad;
+@let simbadRA = simbad?.RAJ2000 !== null && simbad?.RAJ2000 !== undefined ? formatRAJ2000(simbad.RAJ2000) : '';
+@let simbadDE = simbad?.DEJ2000 !== null && simbad?.DEJ2000 !== undefined ? formatDEJ2000(simbad.DEJ2000) : '';
 <div class="system-container">
   <div class="system-container-data">
     <div class="system-info-box">
@@ -201,9 +203,7 @@
             }
           </div>
           }
-          @if (simbad && (simbad.Name ||
-            (simbad.RAJ2000 !== null && simbad.RAJ2000 !== undefined) ||
-            (simbad.DEJ2000 !== null && simbad.DEJ2000 !== undefined))) {
+          @if (simbad && (simbad.Name || simbadRA || simbadDE)) {
           <div class="system-data-section">
             <div class="system-data-section-header">Simbad</div>
             @if (simbad.Name) {
@@ -223,16 +223,16 @@
               </div>
             </div>
             }
-            @if (simbad.RAJ2000 !== null && simbad.RAJ2000 !== undefined) {
+            @if (simbadRA) {
             <div class="system-data-entry">
               <div>Right Ascension</div>
-              <div>{{ formatRAJ2000(simbad.RAJ2000) }}</div>
+              <div>{{ simbadRA }}</div>
             </div>
             }
-            @if (simbad.DEJ2000 !== null && simbad.DEJ2000 !== undefined) {
+            @if (simbadDE) {
             <div class="system-data-entry">
               <div>Declination</div>
-              <div>{{ formatDEJ2000(simbad.DEJ2000) }}</div>
+              <div>{{ simbadDE }}</div>
             </div>
             }
           </div>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -33,6 +33,7 @@
 @if (data(); as data) {
 @let edastro = edastroData();
 @let edGalaxy = edGalaxyData();
+@let simbad = edGalaxy?.Simbad;
 <div class="system-container">
   <div class="system-container-data">
     <div class="system-info-box">
@@ -200,36 +201,38 @@
             }
           </div>
           }
-          @if (edGalaxy?.Simbad?.Name || edGalaxy?.Simbad?.RAJ2000 || edGalaxy?.Simbad?.DEJ2000) {
+          @if (simbad && (simbad.Name ||
+            (simbad.RAJ2000 !== null && simbad.RAJ2000 !== undefined) ||
+            (simbad.DEJ2000 !== null && simbad.DEJ2000 !== undefined))) {
           <div class="system-data-section">
             <div class="system-data-section-header">Simbad</div>
-            @if (edGalaxy.Simbad.Name) {
+            @if (simbad.Name) {
             <div class="system-data-entry">
               <div>Name</div>
               <div>
-                @if (edGalaxy.Simbad.Ident) {
-                <span class="pgname-link" role="button" tabindex="0" (click)="openSimbadPageRaw(edGalaxy.Simbad.Ident)"
-                  (keydown.enter)="openSimbadPageRaw(edGalaxy.Simbad.Ident)"
-                  (keydown.space)="$event.preventDefault(); openSimbadPageRaw(edGalaxy.Simbad.Ident)"
+                @if (simbad.Ident) {
+                <span class="pgname-link" role="button" tabindex="0" (click)="openSimbadPageRaw(simbad.Ident)"
+                  (keydown.enter)="openSimbadPageRaw(simbad.Ident)"
+                  (keydown.space)="$event.preventDefault(); openSimbadPageRaw(simbad.Ident)"
                   title="Open in SIMBAD" style="cursor:pointer;text-decoration:underline dotted;">
-                  {{ edGalaxy.Simbad.Name }}
+                  {{ simbad.Name }}
                 </span>
                 } @else {
-                {{ edGalaxy.Simbad.Name }}
+                {{ simbad.Name }}
                 }
               </div>
             </div>
             }
-            @if (edGalaxy.Simbad.RAJ2000) {
+            @if (simbad.RAJ2000 !== null && simbad.RAJ2000 !== undefined) {
             <div class="system-data-entry">
               <div>Right Ascension</div>
-              <div>{{ formatRAJ2000(edGalaxy.Simbad.RAJ2000) }}</div>
+              <div>{{ formatRAJ2000(simbad.RAJ2000) }}</div>
             </div>
             }
-            @if (edGalaxy.Simbad.DEJ2000) {
+            @if (simbad.DEJ2000 !== null && simbad.DEJ2000 !== undefined) {
             <div class="system-data-entry">
               <div>Declination</div>
-              <div>{{ formatDEJ2000(edGalaxy.Simbad.DEJ2000) }}</div>
+              <div>{{ formatDEJ2000(simbad.DEJ2000) }}</div>
             </div>
             }
           </div>
@@ -607,4 +610,3 @@
   </div>
 </div>
 }
-

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -100,6 +100,38 @@ describe('HomeComponent', () => {
     expect(component.formatDEJ2000(-1).startsWith('-')).toBe(true);
   });
 
+  it('renders zero-valued SIMBAD right ascension and declination', () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      ok: true,
+      text: () => Promise.resolve('<svg viewBox="0 0 2048 2048"></svg>'),
+    })));
+    try {
+      component.data.set({
+        system: {
+          name: 'Zero Coordinates', id64: 1n, coords: { x: 0, y: 0, z: 0 },
+          population: 0, bodies: [], signals: {},
+        },
+      } as any);
+      component.edGalaxyData.set({
+        PGName: '', SystemAddress: 1n, Name: 'Zero Coordinates',
+        Simbad: { RAJ2000: 0, DEJ2000: 0 },
+      });
+
+      fixture.detectChanges();
+
+      const sections = [...(fixture.nativeElement as HTMLElement).querySelectorAll('.system-data-section')];
+      const simbadSection = sections.find(section =>
+        section.querySelector('.system-data-section-header')?.textContent?.trim() === 'Simbad');
+      expect(simbadSection).toBeDefined();
+      expect(simbadSection!.textContent).toContain('Right Ascension');
+      expect(simbadSection!.textContent).toContain('0h 00m 00.0s');
+      expect(simbadSection!.textContent).toContain('Declination');
+      expect(simbadSection!.textContent).toContain('+0° 00′ 00.0″');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('publishes the PGName synchronously so its row never blanks while Simbad loads', async () => {
     // Merope is a hand-named system, so it routes through the async Simbad lookup rather than the
     // synchronous PG-system fallback. Hold the Simbad promise open to observe the pre-resolve state.

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -132,6 +132,37 @@ describe('HomeComponent', () => {
     }
   });
 
+  it('does not render SIMBAD rows for malformed coordinate values', () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      ok: true,
+      text: () => Promise.resolve('<svg viewBox="0 0 2048 2048"></svg>'),
+    })));
+    try {
+      component.data.set({
+        system: {
+          name: 'Invalid Coordinates', id64: 1n, coords: { x: 0, y: 0, z: 0 },
+          population: 0, bodies: [], signals: {},
+        },
+      } as any);
+
+      for (const Simbad of [
+        { RAJ2000: NaN, DEJ2000: 'bad' },
+        { RAJ2000: null, DEJ2000: Infinity },
+      ]) {
+        component.edGalaxyData.set({
+          PGName: '', SystemAddress: 1n, Name: 'Invalid Coordinates', Simbad,
+        } as any);
+        fixture.detectChanges();
+
+        const headers = [...(fixture.nativeElement as HTMLElement).querySelectorAll('.system-data-section-header')]
+          .map(header => header.textContent?.trim());
+        expect(headers).not.toContain('Simbad');
+      }
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('publishes the PGName synchronously so its row never blanks while Simbad loads', async () => {
     // Merope is a hand-named system, so it routes through the async Simbad lookup rather than the
     // synchronous PG-system fallback. Hold the Simbad promise open to observe the pre-resolve state.

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -86,7 +86,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   // Format RAJ2000 (degrees) to '19h 21m 45.0s' (rounded to 0.1s, padded)
   formatRAJ2000(ra: number): string {
-    if (typeof ra !== 'number' || isNaN(ra)) return '';
+    if (!Number.isFinite(ra)) return '';
     const totalSeconds = ra * 240; // 360deg = 24h, so 1deg = 240s
     let hours = Math.floor(totalSeconds / 3600);
     let minutes = Math.floor((totalSeconds % 3600) / 60);
@@ -103,7 +103,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   // Format DEJ2000 (degrees) to '+21° 53′ 02.3″' (rounded to 0.1″, padded)
   formatDEJ2000(de: number): string {
-    if (typeof de !== 'number' || isNaN(de)) return '';
+    if (!Number.isFinite(de)) return '';
     const sign = de >= 0 ? '+' : '-';
     const abs = Math.abs(de);
     let degrees = Math.floor(abs);


### PR DESCRIPTION
## Issue found
The SIMBAD section and individual coordinate rows used truthiness checks. Valid right ascension or declination values of exactly 0 degrees were treated as absent, potentially hiding both rows and the entire section.

During review, the replacement presence checks were also found to admit malformed runtime values such as strings and non-finite numbers, which could render nonsensical coordinates.

## Summary
- preserve valid zero-degree right ascension and declination values
- derive the display values once and render only coordinates that format successfully
- require finite numeric coordinates so malformed API payloads do not create empty or nonsensical SIMBAD rows
- cover zero values plus malformed string, NaN, and Infinity payloads

## Verification
- `pnpm exec ng test --watch=false --include=src/app/home/home.component.spec.ts` (46 passed)
- `pnpm exec playwright test --project=desktop-chromium --workers=4` (100 passed)
