### PR TITLE
Support epoch-millisecond time overrides

### DIFF
--- a/src/app/home/home.component.extra.spec.ts
+++ b/src/app/home/home.component.extra.spec.ts
@@ -614,6 +614,33 @@ describe('HomeComponent (extended coverage)', () => {
   });
 
   describe('query-param navigation', () => {
+    function setTimeParam(value: string): ReturnType<typeof vi.fn> {
+      const route = TestBed.inject(ActivatedRoute);
+      (route.snapshot.queryParamMap as any).get = (key: string) => key === 't' ? value : null;
+      const setNowOverride = vi.fn();
+      (TestBed.inject(AppService) as any).setNowOverride = setNowOverride;
+      component.ngOnInit();
+      component.ngOnDestroy();
+      return setNowOverride;
+    }
+
+    it('accepts a 13-digit epoch-millisecond override', () => {
+      expect(setTimeParam('1785580800000')).toHaveBeenCalledWith(1785580800000);
+    });
+
+    it('accepts an ISO timestamp override', () => {
+      const iso = '2026-08-01T12:34:56Z';
+      expect(setTimeParam(iso)).toHaveBeenCalledWith(Date.parse(iso));
+    });
+
+    it('treats a short integer as milliseconds instead of a calendar year', () => {
+      expect(setTimeParam('2024')).toHaveBeenCalledWith(2024);
+    });
+
+    it.each(['not-a-time', '9'.repeat(400)])('rejects invalid or non-finite override %s', value => {
+      expect(setTimeParam(value)).not.toHaveBeenCalled();
+    });
+
     it('loads the system named in the initial route snapshot', () => {
       const route = TestBed.inject(ActivatedRoute);
       (route.snapshot.queryParamMap as any).get = () => 'Deep Link Sys';

--- a/src/app/home/home.component.extra.spec.ts
+++ b/src/app/home/home.component.extra.spec.ts
@@ -637,8 +637,31 @@ describe('HomeComponent (extended coverage)', () => {
       expect(setTimeParam('2024')).toHaveBeenCalledWith(2024);
     });
 
-    it.each(['not-a-time', '9'.repeat(400)])('rejects invalid or non-finite override %s', value => {
+    it.each([
+      [' -1 ', -1],
+      ['+2024', 2024],
+      ['8640000000000000', 8640000000000000],
+    ])('accepts signed, trimmed, and boundary epoch override %s', (value, expected) => {
+      expect(setTimeParam(value as string)).toHaveBeenCalledWith(expected);
+    });
+
+    it.each([
+      'not-a-time', '9'.repeat(400), '8640000000000001', '-8640000000000001',
+      '1.5', '+1.0', '1e3', '-2e2',
+      '01/02/2024', '2026-02-30', '2025-02-29',
+      '2026-08-01T24:00:00Z', '2026-08-01T12:60:00Z', '2026-08-01T12:34:60Z',
+      '2026-08-01T12:34:56+24:00', '2026-08-01T12:34:56+01:60',
+    ])('rejects invalid, out-of-range, or non-ISO override %s', value => {
       expect(setTimeParam(value)).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      '2026-08-01',
+      '2024-02-29T12:34Z',
+      '2026-08-01T12:34:56.123+01:30',
+      '2026-08-01T12:34:56.123456Z',
+    ])('accepts validated ISO override %s', value => {
+      expect(setTimeParam(value)).toHaveBeenCalledWith(Date.parse(value));
     });
 
     it('loads the system named in the initial route snapshot', () => {

--- a/src/app/home/home.component.extra.spec.ts
+++ b/src/app/home/home.component.extra.spec.ts
@@ -658,6 +658,8 @@ describe('HomeComponent (extended coverage)', () => {
     it.each([
       '2026-08-01',
       '2024-02-29T12:34Z',
+      '2026-08-01T12:30',
+      '2026-08-01T12:30:00',
       '2026-08-01T12:34:56.123+01:30',
       '2026-08-01T12:34:56.123456Z',
     ])('accepts validated ISO override %s', value => {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -52,7 +52,7 @@ interface MegashipRow {
  *  up there; `openMegashipRouteDialog` special-cases this value instead. */
 const GNOSIS_SIGNAL_NAME = 'The Gnosis';
 
-const ISO_TIME_OVERRIDE = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?(?:Z|[+-](\d{2}):(\d{2})))?$/;
+const ISO_TIME_OVERRIDE = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?(?:Z|[+-](\d{2}):(\d{2}))?)?$/;
 
 /** Parses the documented time-override forms without Date.parse's non-ISO coercions. */
 function parseTimeOverride(value: string): number | null {
@@ -998,7 +998,9 @@ export class HomeComponent implements OnInit, OnDestroy {
   });
 
   public ngOnInit(): void {
-    // Apply optional ?t= timestamp override (ISO-8601 or ms since epoch) for debugging.
+    // Apply optional ?t= override for debugging. Signed integer text is always milliseconds
+    // since the epoch (so `2024` means 2.024 seconds after it); ISO timestamps without a zone
+    // retain Date.parse's existing browser-local-time interpretation.
     const tParam = this.activatedRoute.snapshot.queryParamMap.get('t');
     if (tParam) {
       const ms = parseTimeOverride(tParam);

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -970,7 +970,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     // Apply optional ?t= timestamp override (ISO-8601 or ms since epoch) for debugging.
     const tParam = this.activatedRoute.snapshot.queryParamMap.get('t');
     if (tParam) {
-      const ms = Date.parse(tParam);
+      const value = tParam.trim();
+      const ms = /^[+-]?\d+$/.test(value) ? Number(value) : Date.parse(value);
       if (Number.isFinite(ms)) { this.appService.setNowOverride(ms); }
     }
     // Handle the initial deep-link (?system=…) from the route snapshot…

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -52,6 +52,37 @@ interface MegashipRow {
  *  up there; `openMegashipRouteDialog` special-cases this value instead. */
 const GNOSIS_SIGNAL_NAME = 'The Gnosis';
 
+const ISO_TIME_OVERRIDE = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?(?:Z|[+-](\d{2}):(\d{2})))?$/;
+
+/** Parses the documented time-override forms without Date.parse's non-ISO coercions. */
+function parseTimeOverride(value: string): number | null {
+  const trimmed = value.trim();
+  if (/^[+-]?\d+$/.test(trimmed)) {
+    const epochMs = Number(trimmed);
+    return Number.isFinite(epochMs) && Number.isFinite(new Date(epochMs).getTime()) ? epochMs : null;
+  }
+
+  const match = ISO_TIME_OVERRIDE.exec(trimmed);
+  if (!match) { return null; }
+
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, , offsetHourText, offsetMinuteText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (month < 1 || month > 12 || day < 1 || day > daysInMonth[month - 1]) { return null; }
+
+  if (hourText !== undefined && (
+    Number(hourText) > 23 || Number(minuteText) > 59 ||
+    (secondText !== undefined && Number(secondText) > 59) ||
+    (offsetHourText !== undefined && (Number(offsetHourText) > 23 || Number(offsetMinuteText) > 59))
+  )) { return null; }
+
+  const epochMs = Date.parse(trimmed);
+  return Number.isFinite(epochMs) && Number.isFinite(new Date(epochMs).getTime()) ? epochMs : null;
+}
+
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
@@ -970,9 +1001,8 @@ export class HomeComponent implements OnInit, OnDestroy {
     // Apply optional ?t= timestamp override (ISO-8601 or ms since epoch) for debugging.
     const tParam = this.activatedRoute.snapshot.queryParamMap.get('t');
     if (tParam) {
-      const value = tParam.trim();
-      const ms = /^[+-]?\d+$/.test(value) ? Number(value) : Date.parse(value);
-      if (Number.isFinite(ms)) { this.appService.setNowOverride(ms); }
+      const ms = parseTimeOverride(tParam);
+      if (ms !== null) { this.appService.setNowOverride(ms); }
     }
     // Handle the initial deep-link (?system=…) from the route snapshot…
     this.handleSystemParam(this.activatedRoute.snapshot.queryParamMap.get('system') ?? undefined);


### PR DESCRIPTION
## Issue found
The documented `?t=` form accepts milliseconds since the Unix epoch, but the implementation passed every value through `Date.parse()`. A 13-digit epoch was rejected, while short numeric strings could be misleadingly interpreted as calendar years instead of milliseconds.

During review, finite integer epochs outside JavaScript's valid Date range were also found to propagate invalid dates into calculations, and numeric decimals, exponent notation, non-ISO dates, and normalized-invalid calendar dates could fall through permissive `Date.parse()` behavior.

## Behavior note
Integer-looking input is deliberately interpreted as epoch milliseconds, so `?t=2024` now means 2.024 seconds after the Unix epoch rather than calendar year 2024. ISO timestamps with `Z` or an explicit offset use that zone; timezone-less forms such as `2026-08-01T12:30` retain the previous browser-local-time interpretation.

## Summary
- parse signed integer query values as epoch milliseconds, including short and whitespace-trimmed values
- reject integer epochs outside JavaScript's valid Date range
- accept structurally validated ISO dates and timestamps with optional timezones, including long fractional seconds
- reject decimal/exponent numeric forms, non-ISO dates, impossible calendar dates, and invalid time or timezone fields
- add boundary, sign, whitespace, leap-year, precision, timezone-less, and invalid-component regression coverage

## Verification
- `pnpm exec ng test --watch=false --include=src/app/home/home.component.extra.spec.ts` (77 passed)
- `pnpm test --watch=false` (1,038 passed)
- `pnpm run build` (passed with existing budget warnings)
- `pnpm exec playwright test --project=desktop-chromium --workers=4` (100 passed)
